### PR TITLE
enable the import of picture with alpha channel

### DIFF
--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -387,6 +387,7 @@ def _create_thread(tid, params):
             for name in filenames:
                 compressed_name = os.path.splitext(name)[0] + '.jpg'
                 image = Image.open(name)
+                image = image.convert('RGB')
                 image.save(compressed_name, quality=compress_quality, optimize=True)
                 compressed_names.append(compressed_name)
                 if compressed_name != name:


### PR DESCRIPTION
 - jpg doesnt support alpha channels
 - when importing pictures with alpha channel error shows up
 -- "Could not create the task. OSError: cannot write mode RGBA as JPEG"
 - fix error by converting "RGBA" to "RGB" before saving image