### PR TITLE
#35 CVAT - AWS-Deployment guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ CVAT is completely re-designed and re-implemented version of [Video Annotation T
 
 - [User's guide](cvat/apps/documentation/user_guide.md)
 - [XML annotation format](cvat/apps/documentation/xml_format.md)
+- [AWS Deployment Guide](cvat/apps/documentation/AWS-Deployment-Guide.md)
 
 ## Screencasts
 

--- a/cvat/apps/documentation/AWS-Deployment-Guide.md
+++ b/cvat/apps/documentation/AWS-Deployment-Guide.md
@@ -1,0 +1,9 @@
+### AWS-Deployment Guide
+
+There are two ways of deploying the CVAT.
+1. **On Nvidia GPU Machine:** Tensorflow annotation feature is dependent on GPU hardware. One of the easy ways to launch CVAT with the tf-annotation app is to use AWS P3 instances, which provides the NVIDIA GPU. Read more about [P3 instances here.](https://aws.amazon.com/about-aws/whats-new/2017/10/introducing-amazon-ec2-p3-instances/)
+Overall setup instruction is explained in [main readme file](https://github.com/opencv/cvat/), except Installing Nvidia drivers.  So we need to download the drivers and install it. For Amazon P3 instances, download the Nvidia Drivers from Nvidia website. For more check [Installing the NVIDIA Driver on Linux Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/install-nvidia-driver.html) link.
+
+2. **On Any other AWS Machine:** We can follow the same instruction guide mentioned in the [Readme file](https://github.com/opencv/cvat/). The additional step is to add a [security group and rule  to allow  incoming connections](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-network-security.html).
+
+For any of above, don't forget to add exposed AWS public IP address to `docker-compose.override.com`.


### PR DESCRIPTION
I have added links and short setup guide on how to launch CVAT on AWS p3 instances for TF annotation app feature.