### PR TITLE
Cuda installation has been fixed

### DIFF
--- a/cvat/apps/tf_annotation/docker_setup_tf_annotation.sh
+++ b/cvat/apps/tf_annotation/docker_setup_tf_annotation.sh
@@ -21,7 +21,7 @@ CUDA_PKG_VERSION="9-0=${CUDA_VERSION}-1"
 echo "export PATH=/usr/local/nvidia/bin:/usr/local/cuda/bin:${PATH}" >> ${HOME}/.bashrc
 echo "export LD_LIBRARY_PATH=/usr/local/nvidia/lib:/usr/local/nvidia/lib64:${LD_LIBRARY_PATH}" >> ${HOME}/.bashrc
 
-apt-get update && apt-get install -y --no-install-recommends \
+apt-get update && apt-get install -y --no-install-recommends --allow-unauthenticated \
     libprotobuf-dev \
     libprotoc-dev \
     protobuf-compiler \
@@ -31,7 +31,7 @@ apt-get update && apt-get install -y --no-install-recommends \
     libcudnn7=$CUDNN_VERSION-1+cuda9.0 && \
     ln -s cuda-9.0 /usr/local/cuda && \
 rm -rf /var/lib/apt/lists/* \
-    /etc/apt/sources.list.d/nvidia-ml.list
+    /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list
 
 pip3 install --no-cache-dir -r "$(cd `dirname $0` && pwd)/requirements.txt"
 


### PR DESCRIPTION
Currently CUDA installation process is aborted with message:
```bash
E: There were unauthenticated packages and -y was used without --allow-unauthenticated
```
I think it problems with keys, but original CUDA docker files haven't been changed, i.e. they have the same problem. 