### PR TITLE
Fix image id type to int in coco converter

### DIFF
--- a/utils/coco/converter.py
+++ b/utils/coco/converter.py
@@ -397,6 +397,7 @@ def main():
             z_order_off_counter += 1
 
         # Create new image
+        image['id'] = int(image['id'])
         insert_image_data(image, args.image_dir, result_annotation)
         height = result_annotation['images'][-1]['height']
         width = result_annotation['images'][-1]['width']


### PR DESCRIPTION
@nmanovic This is a fix for [Issue#298](https://github.com/opencv/cvat/issues/298) with a corrected image id type. Please take a look.