### PR TITLE
Typo: Greed -> Grid.

### DIFF
--- a/cvat/apps/engine/templates/engine/annotation.html
+++ b/cvat/apps/engine/templates/engine/annotation.html
@@ -248,15 +248,15 @@
                         <td> <input type="checkbox"  id="resetZoomBox" class="settingsBox"/> </td>
                     </tr>
                     <tr>
-                        <td> <label> Greed Size </label> </td>
+                        <td> <label> Grid Size </label> </td>
                         <td> <input type="number" min="5" max="1000" value="100" id="playerGridSizeInput" class="regular h2"/> </td>
                     </tr>
                     <tr>
-                        <td> <label> Greed Opacity </label> </td>
+                        <td> <label> Grid Opacity </label> </td>
                         <td> <input type="range" min="0" max="5" value="0" id="playerGridOpacityInput" class="regular h2"/> </td>
                     </tr>
                     <tr>
-                        <td> <label> Greed Stroke </label> </td>
+                        <td> <label> Grid Stroke </label> </td>
                         <td>
                             <select id="playerGridStrokeInput" class="regular h2">
                                 <option value="black"> Black </option>


### PR DESCRIPTION
UI Label fix: "Grid" (system of reference lines), instead of "Greed" (avarice).