### PR TITLE
Fix failed python install of testing environment

### DIFF
--- a/cvat/requirements/testing.txt
+++ b/cvat/requirements/testing.txt
@@ -1,2 +1,2 @@
--f development.txt
+-r development.txt
 fakeredis==1.0.3


### PR DESCRIPTION
# Steps of Reproduce
1. edit docker-compose.yml
    1. `DJANGO_CONFIGURATION: "production"` to `"testing"`
2. docker-compose build
3. Got a failed message.

# Cause
The problem is typo of python install command in requirements/testing.txt, I think.