### PR TITLE
sort shapes in track before interpolating

### DIFF
--- a/cvat/apps/engine/annotation.py
+++ b/cvat/apps/engine/annotation.py
@@ -1104,6 +1104,7 @@ class TrackManager(ObjectManager):
 
         # TODO: should be return an iterator?
         shapes = []
+        track["shapes"] = sorted(track["shapes"], key=lambda k: k['frame'])
         curr_frame = track["shapes"][0]["frame"]
         prev_shape = {}
         for shape in track["shapes"]:


### PR DESCRIPTION
My group is doing keypoint interpolation and we ran into a problem where half our tasks were failing to "Dump annotation" when the button on the cvat dashboard was used.

This was the error:
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.5/dist-packages/rq/worker.py", line 812, in perform_job
    rv = job.perform()
  File "/usr/local/lib/python3.5/dist-packages/rq/job.py", line 588, in perform
    self._result = self._execute()
  File "/usr/local/lib/python3.5/dist-packages/rq/job.py", line 594, in _execute
    return self.func(*self.args, **self.kwargs)
  File "/home/django/cvat/apps/engine/annotation.py", line 121, in dump_task_data
    annotation.dump(file_path, scheme, host, query_params)
  File "/home/django/cvat/apps/engine/annotation.py", line 1412, in dump
    track, 0, db_task.size):
  File "/home/django/cvat/apps/engine/annotation.py", line 1118, in get_interpolated_shapes
    assert shape["frame"] > curr_frame
AssertionError
```

That is an assert in `TrackManager.get_interpolated_shapes`. The assert is in a loop where shapes of a track are being iterated through. 

Somehow the shapes were arriving at that part of the code out of order. I know this was the issue because I made a 1-line change to sort `track["shapes"]` before the loop and our dumps started succeeding.

I'm sorry I dont have a repro. I suspect specific user activity causes the shapes to be stored out of order and they are not sorted upon retrieval? In any case, this code change is innocuous enough and should save future users some headache