### PR TITLE
Static methods don't have a `self` variable

### DIFF
--- a/cvat/apps/auto_annotation/model_manager.py
+++ b/cvat/apps/auto_annotation/model_manager.py
@@ -247,7 +247,7 @@ class Results():
         return self._results["tracks"]
 
     @staticmethod
-    def _create_polyshape(self, points, label, frame_number, attributes=None):
+    def _create_polyshape(points, label, frame_number, attributes=None):
         return {
             "label": label,
             "frame": frame_number,


### PR DESCRIPTION
This causes an error when using the `add_polygon` method