### PR TITLE
LabeledDataSerializer requires list, not string

### DIFF
--- a/cvat/apps/auto_annotation/model_manager.py
+++ b/cvat/apps/auto_annotation/model_manager.py
@@ -9,6 +9,7 @@ import os
 import rq
 import shutil
 import tempfile
+import itertools
 
 from django.db import transaction
 from django.utils import timezone
@@ -251,7 +252,7 @@ class Results():
         return {
             "label": label,
             "frame": frame_number,
-            "points": " ".join("{},{}".format(pair[0], pair[1]) for pair in points),
+            "points": list(itertools.chain.from_iterable(points)),
             "attributes": attributes or {},
         }
 


### PR DESCRIPTION
Resolves error: `ErrorDetail(string='Expected a list of items but got type "str".', code='not_a_list')` when running auto annotations.