### PR TITLE
Allow multiple outputs for model

### DIFF
--- a/cvat/apps/auto_annotation/model_loader.py
+++ b/cvat/apps/auto_annotation/model_loader.py
@@ -39,7 +39,11 @@ class ModelLoader():
         _, _, h, w = self._input_layout
         in_frame = image if image.shape[:-1] == (h, w) else cv2.resize(image, (w, h))
         in_frame = in_frame.transpose((2, 0, 1))  # Change data layout from HWC to CHW
-        return self._net.infer(inputs={self._input_blob_name: in_frame})[self._output_blob_name].copy()
+        results = self._net.infer(inputs={self._input_blob_name: in_frame})
+        if len(results) == 1:
+            return results[self._output_blob_name].copy()
+        else:
+            return results.copy()
 
 
 def load_label_map(labels_path):


### PR DESCRIPTION
Some of the openvino models require a significant amount of post processing. Specifically the [text detection model](https://github.com/opencv/open_model_zoo/blob/master/intel_models/text-detection-0002/description/text-detection-0002.md) outputs a [1x2x192x320] matrix and a [1x16x192x320] matrix that need to be combined together to create the bounding boxes.

Previously, there wasn't capability to get multiple outputs.