### PR TITLE
Fix security issues

### DIFF
--- a/cvat/requirements/base.txt
+++ b/cvat/requirements/base.txt
@@ -1,5 +1,5 @@
 click==6.7
-Django==2.1.7
+Django==2.1.9
 django-appconf==1.0.2
 django-auth-ldap==1.4.0
 django-cacheops==4.0.6
@@ -29,7 +29,7 @@ GitPython==2.1.11
 coreapi==2.3.3
 django-filter==2.0.0
 Markdown==3.0.1
-djangorestframework==3.9.0
+djangorestframework==3.9.1
 Pygments==2.3.1
 drf-yasg==1.15.0
 Shapely==1.6.4.post2


### PR DESCRIPTION
CVE-2019-12308 More information

moderate severity
Vulnerable versions: >= 2.1.0, < 2.1.9
Patched version: 2.1.9
An issue was discovered in Django 1.11 before 1.11.21, 2.1 before 2.1.9, and 2.2 before 2.2.2. The clickable Current URL value displayed by the AdminURLFieldWidget displays the provided value without validating it as a safe URL. Thus, an unvalidated value stored in the database, or a value provided as a URL query parameter payload, could result in an clickable JavaScript link.

WS-2019-0037 More information

moderate severity
Vulnerable versions: < 3.9.1
Patched version: 3.9.1
Django-Rest-Framework, before 3.9.1, has a XSS vulnerability caused by disabled autoescaping in the default DRF Browsable API view templates.