### PR TITLE
OpenVino2019 handeling

### DIFF
--- a/cvat/apps/auto_annotation/model_loader.py
+++ b/cvat/apps/auto_annotation/model_loader.py
@@ -7,6 +7,7 @@ import json
 import cv2
 import os
 import subprocess
+import numpy as np
 
 from cvat.apps.auto_annotation.inference_engine import make_plugin, make_network
 
@@ -28,8 +29,17 @@ class ModelLoader():
             raise Exception("Following layers are not supported by the plugin for specified device {}:\n {}".
                       format(plugin.device, ", ".join(not_supported_layers)))
 
-        self._input_blob_name = next(iter(network.inputs))
+        iter_inputs = iter(network.inputs)
+        self._input_blob_name = next(iter_inputs)
         self._output_blob_name = next(iter(network.outputs))
+
+        self._require_image_info = False
+
+        # NOTE: handeling for the inclusion of `image_info` in OpenVino2019
+        if 'image_info' in network.inputs:
+            self._require_image_info = True
+        if self._input_blob_name == 'image_info':
+            self._input_blob_name = next(iter_inputs)
 
         self._net = plugin.load(network=network, num_requests=2)
         input_type = network.inputs[self._input_blob_name]
@@ -39,7 +49,16 @@ class ModelLoader():
         _, _, h, w = self._input_layout
         in_frame = image if image.shape[:-1] == (h, w) else cv2.resize(image, (w, h))
         in_frame = in_frame.transpose((2, 0, 1))  # Change data layout from HWC to CHW
-        results = self._net.infer(inputs={self._input_blob_name: in_frame})
+        inputs = {self._input_blob_name: in_frame}
+        if self._require_image_info:
+            info = np.zeros([1, 3])
+            info[0, 0] = h
+            info[0, 1] = w
+            # frame number
+            info[0, 2] = 1
+            inputs['image_info'] = info
+
+        results = self._net.infer(inputs)
         if len(results) == 1:
             return results[self._output_blob_name].copy()
         else:


### PR DESCRIPTION
This pull request is for conversation only, it's not meant to be merged in its current state.

In OpenVino 2019R1 the tensorflow API changed to have two inputs instead of a single input.

MO 2018R5 generates model IRs with these inputs:

```
network.inputs = ['image_tensor']
```

MO 2019R1 IRs:

```
network.inputs = ['image_tensor', 'image_info']
```

This breaks the auto annotation apps way of handling inputs.

The attached code is a brute force way of handling the change. Likely we'd want to all the user to drop in some custom code, similar to how the interpret code is currently handled that allows them to make the appropriate changes to the model.