### PR TITLE
fixed build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,7 @@ RUN apt-get update && \
         unrar \
         p7zip-full \
         vim && \
+    pip3 install -U setuptools && \
     add-apt-repository --remove ppa:mc3man/gstffmpeg-keep -y && \
     add-apt-repository --remove ppa:mc3man/xerus-media -y && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
```
Collecting ruamel.yaml>=0.15.34 (from drf-yasg==1.15.0->-r /tmp/requirements/base.txt (line 34))
  Downloading https://files.pythonhosted.org/packages/fd/f4/0a9044336f9ae455749a9e1ce6a7c8d6a47551f7eeddb8e9ea574d25b75c/ruamel.yaml-0.16.1.tar.gz (144kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-9rjnol9x/ruamel.yaml/setup.py", line 23, in <module>
        from setuptools.namespaces import Installer as NameSpaceInstaller # NOQA
    ImportError: No module named 'setuptools.namespaces'
```
Some of dependencies require newer version of python setuptools than Ubuntu16.04 repo contains.

ruamel.yaml>=0.16.1 installation guide(https://yaml.readthedocs.io/en/latest/install.html) requires setuptools>=20.6.8 but it's wrong, because namespace functionality moved to separate module in v28.7.0 (PR - https://github.com/pypa/setuptools/pull/832/files)
