### PR TITLE
Fixed: no such table: allauth_socialaccount

### DIFF
--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -108,6 +108,7 @@ INSTALLED_APPS = [
     'django.contrib.sites',
     'allauth',
     'allauth.account',
+    'allauth.socialaccount',
     'rest_auth.registration'
 ]
 


### PR DESCRIPTION
Partial solution of #664

Common django issue. 