### PR TITLE
Typo fix

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -23,7 +23,7 @@ priority=1
 autorestart=true
 
 [program:rqworker_default]
-command=%(ENV_HOME)s/wait-for-it.sh cvat_redis:6379 -t 0 -- bash -ic \
+command=%(ENV_HOME)s/wait-for-it.sh redis:6379 -t 0 -- bash -ic \
     "exec /usr/bin/python3 %(ENV_HOME)s/manage.py rqworker -v 3 default"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=2


### PR DESCRIPTION
Hi,

Should not this be cvat_redis -> redis ?

Sorry, if I missed something...
