### PR TITLE
Fix an issue with permissions (observer can change annotations)

### DIFF
--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -1653,6 +1653,29 @@ class JobAnnotationAPITestCase(APITestCase):
         self._run_api_v1_jobs_id_annotations(self.user, self.assignee,
             self.assignee)
 
+    def test_api_v1_jobs_id_annotations_observer(self):
+        task, jobs = self._create_task(self.user, self.assignee)
+        job = jobs[0]
+        data = {
+            "version": 0,
+            "tags": [],
+            "shapes": [],
+            "tracks": []
+        }
+
+        response = self._get_api_v1_jobs_id_data(job["id"], self.observer)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        response = self._put_api_v1_jobs_id_data(job["id"], self.observer, data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self._patch_api_v1_jobs_id_data(job["id"], self.observer, "create", data)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        response = self._delete_api_v1_jobs_id_data(job["id"], self.observer)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
     def test_api_v1_jobs_id_annotations_no_auth(self):
         self._run_api_v1_jobs_id_annotations(self.user, self.assignee, None)
 

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -1654,7 +1654,7 @@ class JobAnnotationAPITestCase(APITestCase):
             self.assignee)
 
     def test_api_v1_jobs_id_annotations_observer(self):
-        task, jobs = self._create_task(self.user, self.assignee)
+        _, jobs = self._create_task(self.user, self.assignee)
         job = jobs[0]
         data = {
             "version": 0,


### PR DESCRIPTION
Fix #712 

Note: If a task doesn't have an assignee an observer can still change annotations.