### PR TITLE
COCO Annotation IDs should begin with 1

### DIFF
--- a/cvat/apps/annotation/coco.py
+++ b/cvat/apps/annotation/coco.py
@@ -264,7 +264,7 @@ def dump(file_object, annotations):
     insert_info_data(annotations, result_annotation)
     category_map = insert_categories_data(annotations, result_annotation)
 
-    segm_id = 0
+    segm_id = 1
     for img in annotations.group_by_frame():
         polygons = []
 


### PR DESCRIPTION
Currently the annotation ID begins with 0 which is interpreted by cocoapi as a false detection. The array dtm saves the matches via the ground truth annotation ID. The variable dtm is initialized as an array of zeros. https://github.com/cocodataset/cocoapi/blob/636becdc73d54283b3aac6d4ec363cffbb6f9b20/PythonAPI/pycocotools/cocoeval.py#L269
https://github.com/cocodataset/cocoapi/blob/636becdc73d54283b3aac6d4ec363cffbb6f9b20/PythonAPI/pycocotools/cocoeval.py#L295
https://github.com/cocodataset/cocoapi/blob/636becdc73d54283b3aac6d4ec363cffbb6f9b20/PythonAPI/pycocotools/cocoeval.py#L375