### PR TITLE
Disable fix_segments_intersections for now

### DIFF
--- a/cvat/apps/annotation/coco.py
+++ b/cvat/apps/annotation/coco.py
@@ -290,16 +290,11 @@ def dump(file_object, annotations):
 
         # Create new image
         insert_image_data(img, result_annotation)
-        # polygons = fix_segments_intersections(polygons, img.height, img.width, img.name)
-        empty_polygon = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
-        for i, _ in enumerate(polygons):
-            polygons[i]['points'] = [polygons[i]['points']]
-        output_polygons = []
-        for polygon in polygons:
-            poly_len = len(polygon['points'])
-            if poly_len != 0 and polygon['points'] != [empty_polygon]:
-                output_polygons.append(polygon)
-        polygons = output_polygons
+        if annotations.meta['task']['z_order'] == 'True':
+            polygons = fix_segments_intersections(polygons, img.height, img.width, img.name)
+        else:
+            for polygon in polygons:
+                polygon['points'] = [polygon['points']]
 
         # combine grouped polygons with the same label
         grouped_poligons = OrderedDict()

--- a/cvat/apps/annotation/coco.py
+++ b/cvat/apps/annotation/coco.py
@@ -290,7 +290,16 @@ def dump(file_object, annotations):
 
         # Create new image
         insert_image_data(img, result_annotation)
-        polygons = fix_segments_intersections(polygons, img.height, img.width, img.name)
+        # polygons = fix_segments_intersections(polygons, img.height, img.width, img.name)
+        empty_polygon = [0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+        for i, _ in enumerate(polygons):
+            polygons[i]['points'] = [polygons[i]['points']]
+        output_polygons = []
+        for polygon in polygons:
+            poly_len = len(polygon['points'])
+            if poly_len != 0 and polygon['points'] != [empty_polygon]:
+                output_polygons.append(polygon)
+        polygons = output_polygons
 
         # combine grouped polygons with the same label
         grouped_poligons = OrderedDict()


### PR DESCRIPTION
When the bounding boxes had intersections and were exported with the COCO JSON format they were often cut off. I commented out the line with the function fix_segments_intersections and replaced it with lines of that function. This helped with the bounding boxes and keeps the masks as they are created with CVAT. It is probably inconvenient for the user to get something fixed in the export without an active agreement. Secondly letting a function automatically fix segments could result in a bad fix.