### PR TITLE
Update documentation to point to OpenVino component documentation

### DIFF
--- a/components/openvino/README.md
+++ b/components/openvino/README.md
@@ -7,8 +7,8 @@
 ### Preparation
 
 * Download [OpenVINO toolkit 2018R5](https://software.intel.com/en-us/openvino-toolkit) .tgz installer (offline or online) for Ubuntu platforms.
-* Put downloaded file into ```components/openvino```.
-* Accept EULA in the eula.cfg file.
+* Put downloaded file into ```cvat/components/openvino```.
+* Accept EULA in the `cvat/components/eula.cfg` file.
 
 ### Build docker image
 ```bash
@@ -21,3 +21,22 @@ docker-compose -f docker-compose.yml -f components/openvino/docker-compose.openv
 # From project root directory
 docker-compose -f docker-compose.yml -f components/openvino/docker-compose.openvino.yml up -d
 ```
+
+You should be able to login and see the web interface for CVAT know, complete with the new "Model Manager" button.
+
+### OpenVINO Models
+
+Clone the [Open Model Zoo](https://github.com/opencv/open_model_zoo). `$ git clone https://github.com/opencv/open_model_zoo.git`
+
+Install the appropriate libraries. Currently that command would be `$ pip install -r open_model_zoo/tools/downloader/requirements.in`
+
+Download the models using `downloader.py` file in `open_model_zoo/tools/downloader/`. 
+The `--name` command can be used to specify specific models. 
+The `--print_all` command can print all the available models. 
+Specific models that are already integrated into Cvat can be found [here](https://github.com/opencv/cvat/tree/develop/utils/open_model_zoo).
+
+From the web user interface in CVAT, upload the models using the model manager.
+You'll need to include the xml and bin file from the model downloader.
+You'll need to include the python and JSON files from scratch or by using the ones in the CVAT libary. 
+See [here](https://github.com/opencv/cvat/tree/develop/cvat/apps/auto_annotation) for instructions for creating custom 
+python and JSON files.

--- a/components/openvino/README.md
+++ b/components/openvino/README.md
@@ -22,7 +22,7 @@ docker-compose -f docker-compose.yml -f components/openvino/docker-compose.openv
 docker-compose -f docker-compose.yml -f components/openvino/docker-compose.openvino.yml up -d
 ```
 
-You should be able to login and see the web interface for CVAT know, complete with the new "Model Manager" button.
+You should be able to login and see the web interface for CVAT now, complete with the new "Model Manager" button.
 
 ### OpenVINO Models
 

--- a/cvat/apps/auto_annotation/README.md
+++ b/cvat/apps/auto_annotation/README.md
@@ -9,6 +9,10 @@ OpenVINO&trade; toolkit format are supported. If you would like to annotate a
 task with a custom model please convert it to the intermediate representation
 (IR) format via the model optimizer tool. See [OpenVINO documentation](https://software.intel.com/en-us/articles/OpenVINO-InferEngine) for details.
 
+### Installation
+
+See the installation instructions for [the OpenVINO component](../../../components/openvino)
+
 ### Usage
 
 To annotate a task with a custom model you need to prepare 4 files:

--- a/cvat/apps/documentation/installation.md
+++ b/cvat/apps/documentation/installation.md
@@ -236,7 +236,6 @@ server. Proxy is an advanced topic and it is not covered by the guide.
 ### Additional components
 
 - [Auto annotation using DL models in OpenVINO toolkit format](/cvat/apps/auto_annotation/README.md)
-  - [See auto annotation installation instructions here](/components/openvino/README.md)
 - [Analytics: management and monitoring of data annotation team](/components/analytics/README.md)
 - [TF Object Detection API: auto annotation](/components/tf_annotation/README.md)
 - [Support for NVIDIA GPUs](/components/cuda/README.md)

--- a/cvat/apps/documentation/installation.md
+++ b/cvat/apps/documentation/installation.md
@@ -236,6 +236,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
 ### Additional components
 
 - [Auto annotation using DL models in OpenVINO toolkit format](/cvat/apps/auto_annotation/README.md)
+  - [See auto annotation installation instructions here](/components/openvino/README.md)
 - [Analytics: management and monitoring of data annotation team](/components/analytics/README.md)
 - [TF Object Detection API: auto annotation](/components/tf_annotation/README.md)
 - [Support for NVIDIA GPUs](/components/cuda/README.md)


### PR DESCRIPTION
Currently the documentation points to the application documentation rather than the component documentation. The app docs have usage instructions but not installation instructions.