### PR TITLE
Added restart tag to docker-compose for `cvat_ui`

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,6 +64,7 @@ services:
   cvat_ui:
     container_name: cvat_ui
     image: nginx
+    restart: always
     build:
       context: cvat-ui
       args:


### PR DESCRIPTION
Without the `restart` flag for the `cvat_ui` container, the app does not successfully load on the HOST machine rebooting