### PR TITLE
[Datumaro] Coco format updates

### DIFF
--- a/datumaro/datumaro/components/config_model.py
+++ b/datumaro/datumaro/components/config_model.py
@@ -11,7 +11,7 @@ from datumaro.components.config import Config, \
 SOURCE_SCHEMA = _SchemaBuilder() \
     .add('url', str) \
     .add('format', str) \
-    .add('options', str) \
+    .add('options', dict) \
     .build()
 
 class Source(Config):

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -271,6 +271,14 @@ class PolygonObject(ShapeObject):
     def get_polygon(self):
         return self.get_points()
 
+    def area(self):
+        import pycocotools.mask as mask_utils
+
+        _, _, w, h = self.get_bbox()
+        rle = mask_utils.frPyObjects([self.get_points()], h, w)
+        area = mask_utils.area(rle)
+        return area
+
 class BboxObject(ShapeObject):
     # pylint: disable=redefined-builtin
     def __init__(self, x=0, y=0, w=0, h=0,

--- a/datumaro/datumaro/components/importers/ms_coco.py
+++ b/datumaro/datumaro/components/importers/ms_coco.py
@@ -22,7 +22,7 @@ class CocoImporter:
     def __init__(self, task_filter=None):
         self._task_filter = task_filter
 
-    def __call__(self, path):
+    def __call__(self, path, **extra_params):
         from datumaro.components.project import Project # cyclic import
         project = Project()
 
@@ -37,6 +37,7 @@ class CocoImporter:
                 project.add_source(source_name, {
                     'url': ann_file,
                     'format': self._COCO_EXTRACTORS[ann_type],
+                    'options': extra_params,
                 })
 
         return project


### PR DESCRIPTION
Added:
- Auto inference and matching for instance annotation parts - masks, bboxes, polygons
    Now, these elements are taken from the annotation group, and are inferred otherwise
- Project `source` options became a `dict`
- implemented `area()` method for polygons
- object polygon(-s) to mask conversion in `COCO` extractor option