### PR TITLE
keep the file order provided in the task data api

### DIFF
--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -39,7 +39,7 @@ class ImageListExtractor(MediaExtractor):
         if not source_path:
             raise Exception('No image found')
         super().__init__(
-            source_path=sorted(source_path),
+            source_path=source_path,
             dest_path=dest_path,
             image_quality=image_quality,
             step=1,


### PR DESCRIPTION
There are some cases that the file order is significant in the annocation process. 

The previous implementation uses `dict` to store intermediate data, and `dict.keys()` to get the list back.  So that the file order is lost as Python prior to 3.6 does not guarantee the return order from `dict.keys()`.

As of Python 3.6, for the CPython implementation of Python, dictionaries [maintain insertion order](https://docs.python.org/3.6/whatsnew/3.6.html#new-dict-implementation) by default. But for compatibility, this pull request uses `OrderedDict` to keep the insertion order for both Python 3.6+ and prior.