### PR TITLE
The tfrecord file starts at id 0, which is incompatible with tensorflow.

### DIFF
--- a/cvat/apps/annotation/tfrecord.py
+++ b/cvat/apps/annotation/tfrecord.py
@@ -98,7 +98,7 @@ def dump(file_object, annotations):
         with codecs.open(os.path.join(out_dir, labelmap_file), 'w', encoding='utf8') as f:
             for label, idx in label_ids.items():
                 f.write(u'item {\n')
-                f.write(u'\tid: {}\n'.format(idx))
+                f.write(u'\tid: {}\n'.format(idx+1))
                 f.write(u"\tname: '{}'\n".format(label))
                 f.write(u'}\n\n')
 


### PR DESCRIPTION
It has to start at 1, 0 is reserved in Tensorflow.

Ref: https://github.com/opencv/cvat/issues/866