### PR TITLE
[Datumaro] Disable lazy image caching by default

### DIFF
--- a/datumaro/datumaro/util/image.py
+++ b/datumaro/datumaro/util/image.py
@@ -19,12 +19,17 @@ def load_image(path):
     return image
 
 class lazy_image:
-    def __init__(self, path, loader=load_image):
+    def __init__(self, path, loader=load_image, cache=None):
         self.path = path
         self.loader = loader
         self.image = None
+        self.cache = bool(cache)
 
     def __call__(self):
         if self.image is None:
-            self.image = self.loader(self.path)
-        return self.image
+            image = self.loader(self.path)
+            if self.cache:
+                self.image = image
+        else:
+            image = self.image
+        return image

--- a/datumaro/datumaro/util/image_cache.py
+++ b/datumaro/datumaro/util/image_cache.py
@@ -1,0 +1,38 @@
+from collections import OrderedDict
+
+
+_instance = None
+
+DEFAULT_CAPACITY = 1000
+
+class ImageCache:
+    @staticmethod
+    def get_instance():
+        global _instance
+        if _instance is None:
+            _instance = ImageCache()
+        return _instance
+
+    def __init__(self, capacity=DEFAULT_CAPACITY):
+        self.capacity = int(capacity)
+        self.items = OrderedDict()
+
+    def push(self, item_id, image):
+        if self.capacity <= len(self.items):
+            self.items.popitem(last=True)
+        self.items[item_id] = image
+
+    def get(self, item_id):
+        default = object()
+        item = self.items.get(item_id, default)
+        if item is default:
+            return None
+
+        self.items.move_to_end(item_id, last=False) # naive splay tree
+        return item
+
+    def size(self):
+        return len(self.items)
+
+    def clear(self):
+        self.items.clear()

--- a/datumaro/tests/test_images.py
+++ b/datumaro/tests/test_images.py
@@ -1,0 +1,33 @@
+import numpy as np
+import os.path as osp
+from PIL import Image
+import timeit
+
+from unittest import TestCase
+
+from datumaro.util.test_utils import TestDir
+from datumaro.util.image import lazy_image
+
+
+class LazyImageTest(TestCase):
+    def test_cache_works(self):
+        test_code = 'image()'
+        iterations = 1000
+
+        with TestDir() as test_dir:
+            image = np.ones((100, 100, 3), dtype=np.uint8)
+            image = Image.fromarray(image).convert('RGB')
+
+            image_path = osp.join(test_dir.path, 'image.jpg')
+            image.save(image_path)
+
+
+            caching_time = timeit.timeit(test_code,
+                globals={ 'image': lazy_image(image_path, cache=True) },
+                number=iterations)
+
+            non_caching_time = timeit.timeit(test_code,
+                globals={ 'image': lazy_image(image_path, cache=False) },
+                number=iterations)
+
+            self.assertLessEqual(caching_time, non_caching_time)

--- a/datumaro/tests/test_images.py
+++ b/datumaro/tests/test_images.py
@@ -1,7 +1,6 @@
 import numpy as np
 import os.path as osp
 from PIL import Image
-import timeit
 
 from unittest import TestCase
 
@@ -11,9 +10,6 @@ from datumaro.util.image import lazy_image
 
 class LazyImageTest(TestCase):
     def test_cache_works(self):
-        test_code = 'image()'
-        iterations = 1000
-
         with TestDir() as test_dir:
             image = np.ones((100, 100, 3), dtype=np.uint8)
             image = Image.fromarray(image).convert('RGB')
@@ -21,13 +17,8 @@ class LazyImageTest(TestCase):
             image_path = osp.join(test_dir.path, 'image.jpg')
             image.save(image_path)
 
+            caching_loader = lazy_image(image_path, cache=True)
+            self.assertTrue(caching_loader() is caching_loader())
 
-            caching_time = timeit.timeit(test_code,
-                globals={ 'image': lazy_image(image_path, cache=True) },
-                number=iterations)
-
-            non_caching_time = timeit.timeit(test_code,
-                globals={ 'image': lazy_image(image_path, cache=False) },
-                number=iterations)
-
-            self.assertLessEqual(caching_time, non_caching_time)
+            non_caching_loader = lazy_image(image_path, cache=False)
+            self.assertFalse(non_caching_loader() is non_caching_loader())

--- a/datumaro/tests/test_images.py
+++ b/datumaro/tests/test_images.py
@@ -6,6 +6,7 @@ from unittest import TestCase
 
 from datumaro.util.test_utils import TestDir
 from datumaro.util.image import lazy_image
+from datumaro.util.image_cache import ImageCache
 
 
 class LazyImageTest(TestCase):
@@ -17,8 +18,32 @@ class LazyImageTest(TestCase):
             image_path = osp.join(test_dir.path, 'image.jpg')
             image.save(image_path)
 
-            caching_loader = lazy_image(image_path, cache=True)
+            caching_loader = lazy_image(image_path, cache=None)
             self.assertTrue(caching_loader() is caching_loader())
 
             non_caching_loader = lazy_image(image_path, cache=False)
             self.assertFalse(non_caching_loader() is non_caching_loader())
+
+class ImageCacheTest(TestCase):
+    def test_cache_fifo_displacement(self):
+        capacity = 2
+        cache = ImageCache(capacity)
+
+        loaders = [lazy_image(None, loader=lambda p: object(), cache=cache)
+            for _ in range(capacity + 1)]
+
+        first_request = [loader() for loader in loaders[1 : ]]
+        loaders[0]() # pop something from the cache
+
+        second_request = [loader() for loader in loaders[2 : ]]
+        second_request.insert(0, loaders[1]())
+
+        matches = sum([a is b for a, b in zip(first_request, second_request)])
+        self.assertEqual(matches, len(first_request) - 1)
+
+    def test_global_cache_is_accessible(self):
+        loader = lazy_image(None, loader=lambda p: object())
+
+        ImageCache.get_instance().clear()
+        self.assertTrue(loader() is loader())
+        self.assertEqual(ImageCache.get_instance().size(), 1)


### PR DESCRIPTION
Temporarily fixes server OOM/swap DOS for large dataset export.