### PR TITLE
[WIP] Switch from ubuntu base docker image to debian

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION}
 # It is not available on official repositories (https://wiki.debian.org/ffmpeg)
 RUN echo "deb http://www.deb-multimedia.org jessie main non-free" > /etc/apt/sources.list.d/deb-multimedia.list && \
   apt-get update && \
-  apt-get install -yq --force-yes && \
+  apt-get install -yq --force-yes \
       deb-multimedia-keyring && \
   apt-get update && \
   apt-get install -yq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,10 +23,14 @@ ENV DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION}
 # It is not available on official repositories (https://wiki.debian.org/ffmpeg)
 RUN echo "deb http://www.deb-multimedia.org jessie main non-free" > /etc/apt/sources.list.d/deb-multimedia.list \
   && apt-get update \
-  && apt-get install -y --force-yes deb-multimedia-keyring \
+  && apt-get install -yq --force-yes \
+      deb-multimedia-keyring \
   && apt-get update \
-  && apt-get install -y ffmpeg \
-  && apt-get install -y gstreamer0.10-ffmpeg
+  && apt-get install -yq \
+      ffmpeg \
+      gstreamer0.10-ffmpeg \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Install necessary apt packages
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION}
 # It is not available on official repositories (https://wiki.debian.org/ffmpeg)
 RUN echo "deb http://www.deb-multimedia.org jessie main non-free" > /etc/apt/sources.list.d/deb-multimedia.list && \
   apt-get update && \
-  apt-get install -yq \
+  apt-get install -yq --force-yes \
       deb-multimedia-keyring && \
   apt-get update && \
   apt-get install -yq \

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,16 +21,16 @@ ENV DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION}
 
 # Install ffmpeg on debian jessie (https://www.deb-multimedia.org/)
 # It is not available on official repositories (https://wiki.debian.org/ffmpeg)
-RUN echo "deb http://www.deb-multimedia.org jessie main non-free" > /etc/apt/sources.list.d/deb-multimedia.list \
-  && apt-get update \
-  && apt-get install -yq --force-yes \
-      deb-multimedia-keyring \
-  && apt-get update \
-  && apt-get install -yq \
+RUN echo "deb http://www.deb-multimedia.org jessie main non-free" > /etc/apt/sources.list.d/deb-multimedia.list && \
+  apt-get update && \
+  apt-get install -yq --force-yes && \
+      deb-multimedia-keyring && \
+  apt-get update && \
+  apt-get install -yq \
       ffmpeg \
-      gstreamer0.10-ffmpeg \
-  && apt-get clean \
-  && rm -rf /var/lib/apt/lists/*
+      gstreamer0.10-ffmpeg && \
+  apt-get clean && \
+  rm -rf /var/lib/apt/lists/*
 
 # Install necessary apt packages
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM debian:jessie-slim
+FROM python:3.6.9-slim-jessie
 
 ARG http_proxy
 ARG https_proxy
@@ -40,8 +40,6 @@ RUN apt-get update && \
         supervisor \
         libldap2-dev \
         libsasl2-dev \
-        python3-dev \
-        python3-pip \
         tzdata \
         unzip \
         unrar-free \
@@ -116,7 +114,7 @@ RUN if [ "$WITH_TESTS" = "yes" ]; then \
 # Install and initialize CVAT, copy all necessary files
 COPY cvat/requirements/ /tmp/requirements/
 COPY supervisord.conf mod_wsgi.conf wait-for-it.sh manage.py ${HOME}/
-RUN pip3 install --no-cache-dir -r /tmp/requirements/${DJANGO_CONFIGURATION}.txt
+RUN pip3 install -r /tmp/requirements/${DJANGO_CONFIGURATION}.txt
 # pycocotools package is impossible to install with its dependencies by one pip install command
 RUN pip3 install --no-cache-dir pycocotools==2.0.0
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.9-slim-jessie
+FROM python:3.6.9-jessie
 
 ARG http_proxy
 ARG https_proxy
@@ -37,7 +37,6 @@ RUN apt-get update && \
         apache2 \
         apache2-dev \
         libapache2-mod-xsendfile \
-        supervisor \
         libldap2-dev \
         libsasl2-dev \
         tzdata \
@@ -153,13 +152,14 @@ COPY utils ${HOME}/utils
 COPY cvat/ ${HOME}/cvat
 COPY cvat-core/ ${HOME}/cvat-core
 COPY tests ${HOME}/tests
+COPY datumaro/ ${HOME}/datumaro
+
+RUN sed -r "s/^(.*)#.*$/\1/g" ${HOME}/datumaro/requirements.txt | xargs -n 1 -L 1 pip3 install --no-cache-dir
 
 # Binary option is necessary to correctly apply the patch on Windows platform.
 # https://unix.stackexchange.com/questions/239364/how-to-fix-hunk-1-failed-at-1-different-line-endings-message
 RUN patch --binary -p1 < ${HOME}/cvat/apps/engine/static/engine/js/3rdparty.patch
-RUN chown -R ${USER}:${USER} ${HOME}
-RUN chown -R ${USER}:${USER} /var/log/
-RUN chown -R ${USER}:${USER} /tmp/
+RUN chown -R ${USER}:${USER} .
 
 # RUN all commands below as 'django' user
 USER ${USER}
@@ -168,4 +168,4 @@ RUN mkdir data share media keys logs /tmp/supervisord
 RUN python3 manage.py collectstatic || python3 manage.py collectstatic
 
 EXPOSE 8080 8443
-ENTRYPOINT ["/usr/bin/supervisord"]
+ENTRYPOINT ["supervisord"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION}
 # It is not available on official repositories (https://wiki.debian.org/ffmpeg)
 RUN echo "deb http://www.deb-multimedia.org jessie main non-free" > /etc/apt/sources.list.d/deb-multimedia.list && \
   apt-get update && \
-  apt-get install -yq --force-yes \
+  apt-get install -yq \
       deb-multimedia-keyring && \
   apt-get update && \
   apt-get install -yq \

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04 AS cvat-ui
+FROM node:10.16.3-buster-slim AS cvat-ui
 
 ARG http_proxy
 ARG https_proxy
@@ -13,10 +13,6 @@ ENV TERM=xterm \
 
 ENV LANG='C.UTF-8'  \
     LC_ALL='C.UTF-8'
-
-# Install necessary apt packages
-RUN apt update && apt install -yq nodejs npm curl && \
-    npm install -g n && n 10.16.3
 
 # Create output directories
 RUN mkdir /tmp/cvat-ui /tmp/cvat-core

--- a/cvat/requirements/base.txt
+++ b/cvat/requirements/base.txt
@@ -47,3 +47,4 @@ h5py==2.9.0
 imgaug==0.2.9
 django-cors-headers==3.0.2
 furl==2.0.0
+supervisor==4.1.0

--- a/cvat/requirements/production.txt
+++ b/cvat/requirements/production.txt
@@ -1,4 +1,3 @@
 -r base.txt
 psycopg2-binary==2.7.4
 mod-wsgi==4.6.2
-supervisor==4.1.0

--- a/cvat/requirements/production.txt
+++ b/cvat/requirements/production.txt
@@ -1,3 +1,4 @@
 -r base.txt
 psycopg2-binary==2.7.4
 mod-wsgi==4.6.2
+supervisor==4.1.0

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -24,26 +24,26 @@ autorestart=true
 
 [program:rqworker_default]
 command=%(ENV_HOME)s/wait-for-it.sh redis:6379 -t 0 -- bash -ic \
-    "exec /usr/bin/python3 %(ENV_HOME)s/manage.py rqworker -v 3 default"
+    "exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 default"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=2
 process_name=rqworker_default_%(process_num)s
 
 [program:rqworker_low]
 command=%(ENV_HOME)s/wait-for-it.sh redis:6379 -t 0 -- bash -ic \
-    "exec /usr/bin/python3 %(ENV_HOME)s/manage.py rqworker -v 3 low"
+    "exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 low"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=1
 
 [program:git_status_updater]
 command=%(ENV_HOME)s/wait-for-it.sh redis:6379 -t 0 -- bash -ic \
-    "/usr/bin/python3 ~/manage.py update_git_states"
+    "python3 ~/manage.py update_git_states"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=1
 
 [program:rqscheduler]
 command=%(ENV_HOME)s/wait-for-it.sh redis:6379 -t 0 -- bash -ic \
-    "/usr/bin/python3 /usr/local/bin/rqscheduler --host redis -i 30"
+    "python3 /usr/local/bin/rqscheduler --host redis -i 30"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=1
 
@@ -54,9 +54,9 @@ numprocs=1
 ; with docker cache. Thus it is necessary to run collectstatic here for such
 ; apps.
 command=%(ENV_HOME)s/wait-for-it.sh db:5432 -t 0 -- bash -ic \
-    "/usr/bin/python3 ~/manage.py migrate && \
-    /usr/bin/python3 ~/manage.py collectstatic --no-input && \
-    exec /usr/bin/python3 $HOME/manage.py runmodwsgi --log-to-terminal --port 8080 \
+    "python3 ~/manage.py migrate && \
+    python3 ~/manage.py collectstatic --no-input && \
+    exec python3 $HOME/manage.py runmodwsgi --log-to-terminal --port 8080 \
     --limit-request-body 1073741824 --log-level INFO --include-file ~/mod_wsgi.conf \
     %(ENV_DJANGO_MODWSGI_EXTRA_ARGS)s --locale %(ENV_LC_ALL)s"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"


### PR DESCRIPTION
This pull request switched the docker images from being ubuntu based to debian.
More about the reasons in #7 

**Why did i choose python:3.6.9-jessie for cvat-backend?**
Sadly only jessie has pre compiled ffmpeg and gstreamer libraries, therefore we can not use stretch or jessie. Furthermore to reduce the compile time, i decided to go with python 3.6.9 base image that includes pip3, python3, ... 

**Why did i choose node:10.16.3-buster-slim for cvat-ui?**
Mostly, since buster is the newest stable debian release and the node container has node 10.16.3 preinstalled (previously used node version).

I did not test all of the features, such as CUDA, Autosegmentation, ... and would appreciate help with testing it. There are probably further adjustments needed. Feel free contribute or share bugs :)