### PR TITLE
page_size parameter for all REST API methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ https://github.com/opencv/cvat/issues/750).
 - Text Detection Auto Annoation Script in OpenVINO format for version 4
 
 ### Changed
--
+- page_size parameter for all REST API methods
 
 ### Deprecated
 -

--- a/cvat/apps/engine/pagination.py
+++ b/cvat/apps/engine/pagination.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2019 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import sys
+from rest_framework.pagination import PageNumberPagination
+
+class CustomPagination(PageNumberPagination):
+    page_size_query_param = "page_size"
+
+    def get_page_size(self, request):
+        page_size = 0
+        try:
+            value = request.query_params[self.page_size_query_param]
+            if value == "all":
+                page_size = sys.maxsize
+            else:
+                page_size = int(value)
+        except (KeyError, ValueError):
+            pass
+
+        return page_size if page_size > 0 else self.page_size

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -137,7 +137,7 @@ REST_FRAMEWORK = {
     # Need to add 'api-docs' here as a workaround for include_docs_urls.
     'ALLOWED_VERSIONS': ('v1', 'api-docs'),
     'DEFAULT_PAGINATION_CLASS':
-        'rest_framework.pagination.PageNumberPagination',
+        'cvat.apps.engine.pagination.CustomPagination',
     'PAGE_SIZE': 10,
     'DEFAULT_FILTER_BACKENDS': (
         'rest_framework.filters.SearchFilter',


### PR DESCRIPTION
You can specify page_size=<number> or page_size=all to return all elements. It allows to avoid default limitation to get only 10 objects per a list.

Fix #868, #853