### PR TITLE
Improve UX with creating new shape by shortkey

### DIFF
--- a/cvat/apps/engine/static/engine/js/shapeCreator.js
+++ b/cvat/apps/engine/static/engine/js/shapeCreator.js
@@ -409,7 +409,7 @@ class ShapeCreatorView {
         }.bind(this));
     }
 
-    _create(usingShortkey) {
+    _create() {
         let sizeUI = null;
         switch(this._type) {
         case 'box':
@@ -445,7 +445,7 @@ class ShapeCreatorView {
                     this._controller.finish(box, this._type);
                 }
 
-                this._controller.switchCreateMode(true, usingShortkey);
+                this._controller.switchCreateMode(true);
             }.bind(this)).on('drawupdate', (e) => {
                 sizeUI = drawBoxSize.call(sizeUI, this._frameContent, this._frameText, e.target.getBBox());
             }).on('drawcancel', () => {
@@ -548,7 +548,7 @@ class ShapeCreatorView {
 
             this._createButton.text("Stop Creation");
             document.oncontextmenu = () => false;
-            this._create(model.usingShortkey);
+            this._create();
         }
         else {
             this._removeAim();

--- a/cvat/apps/engine/static/engine/js/shapeCreator.js
+++ b/cvat/apps/engine/static/engine/js/shapeCreator.js
@@ -114,6 +114,10 @@ class ShapeCreatorModel extends Listener {
         return this._createMode;
     }
 
+    get usingShortkey() {
+        return this._usingShortkey;
+    }
+
     get defaultType() {
         return this._defaultType;
     }
@@ -154,7 +158,7 @@ class ShapeCreatorController {
         }
     }
 
-    switchCreateMode(force, usingShortkey) {
+    switchCreateMode(force, usingShortkey = false) {
         this._model.switchCreateMode(force, usingShortkey);
     }
 
@@ -533,7 +537,7 @@ class ShapeCreatorView {
             this._mode = model.defaultMode;
 
             if (!['polygon', 'polyline', 'points'].includes(this._type)) {
-                if (!model._usingShortkey) {
+                if (!model.usingShortkey) {
                     this._aimCoord = {
                         x: 0,
                         y: 0
@@ -544,13 +548,7 @@ class ShapeCreatorView {
 
             this._createButton.text("Stop Creation");
             document.oncontextmenu = () => false;
-            this._create(model._usingShortkey);
-            if (!model._usingShortkey) {
-                this._aimCoord = {
-                    x: 0,
-                    y: 0
-                };
-            }
+            this._create(model.usingShortkey);
         }
         else {
             this._removeAim();


### PR DESCRIPTION
This PR contains improvement for creating shape with shortkey.

Current behavior:
You click **N** key for new shape creation, but you got two red helper lines only if **mousemove** will trigger, which is is a little confusing.

As workaround:
I'm listening **mousemove** event and draw this lines when creation of new shape is triggered by shortkey