### PR TITLE
[Datumaro] VOC labelmap support

### DIFF
--- a/datumaro/datumaro/cli/project/__init__.py
+++ b/datumaro/datumaro/cli/project/__init__.py
@@ -68,6 +68,8 @@ def build_import_parser(parser):
         help="Overwrite existing files in the save directory")
     parser.add_argument('--copy', action='store_true',
         help="Copy the dataset instead of saving source links")
+    parser.add_argument('--skip-check', action='store_true',
+        help="Skip source checking")
     # parser.add_argument('extra_args', nargs=argparse.REMAINDER,
     #     help="Additional arguments for importer (pass '-- -h' for help)")
     return parser
@@ -99,7 +101,9 @@ def import_command(args):
     project.config.project_name = project_name
     project.config.project_dir = project_dir
 
-    dataset = project.make_dataset()
+    if not args.skip_check or args.copy:
+        log.info("Checking the dataset...")
+        dataset = project.make_dataset()
     if args.copy:
         log.info("Cloning data...")
         dataset.save(merge=True, save_images=True)

--- a/datumaro/datumaro/cli/project/__init__.py
+++ b/datumaro/datumaro/cli/project/__init__.py
@@ -131,6 +131,8 @@ def build_export_parser(parser):
         help="Output format")
     parser.add_argument('-p', '--project', dest='project_dir', default='.',
         help="Directory of the project to operate on (default: current dir)")
+    parser.add_argument('--overwrite', action='store_true',
+        help="Overwrite existing files in the save directory")
     parser.add_argument('extra_args', nargs=argparse.REMAINDER, default=None,
         help="Additional arguments for converter (pass '-- -h' for help)")
     return parser
@@ -139,7 +141,11 @@ def export_command(args):
     project = load_project(args.project_dir)
 
     dst_dir = osp.abspath(args.dst_dir)
-    os.makedirs(dst_dir, exist_ok=False)
+    if not args.overwrite and osp.isdir(dst_dir) and os.listdir(dst_dir):
+        log.error("Directory '%s' already exists "
+            "(pass --overwrite to force creation)" % dst_dir)
+        return 1
+    os.makedirs(dst_dir, exist_ok=args.overwrite)
 
     project.make_dataset().export(
         save_dir=dst_dir,

--- a/datumaro/datumaro/cli/source/__init__.py
+++ b/datumaro/datumaro/cli/source/__init__.py
@@ -194,6 +194,8 @@ def build_export_parser(parser):
         help="Output format")
     parser.add_argument('-p', '--project', dest='project_dir', default='.',
         help="Directory of the project to operate on (default: current dir)")
+    parser.add_argument('--overwrite', action='store_true',
+        help="Overwrite existing files in the save directory")
     parser.add_argument('extra_args', nargs=argparse.REMAINDER, default=None,
         help="Additional arguments for converter (pass '-- -h' for help)")
     return parser
@@ -202,7 +204,11 @@ def export_command(args):
     project = load_project(args.project_dir)
 
     dst_dir = osp.abspath(args.dst_dir)
-    os.makedirs(dst_dir, exist_ok=False)
+    if not args.overwrite and osp.isdir(dst_dir) and os.listdir(dst_dir):
+        log.error("Directory '%s' already exists "
+            "(pass --overwrite to force creation)" % dst_dir)
+        return 1
+    os.makedirs(dst_dir, exist_ok=args.overwrite)
 
     source_project = project.make_source_project(args.name)
     source_project.make_dataset().export(

--- a/datumaro/datumaro/cli/source/__init__.py
+++ b/datumaro/datumaro/cli/source/__init__.py
@@ -62,14 +62,16 @@ def build_import_parser(parser):
     dir_parser.add_argument('url',
         help="Path to the source directory")
     dir_parser.add_argument('--copy', action='store_true',
-        help="Copy data to the project")
+        help="Copy the dataset instead of saving source links")
 
+    parser.add_argument('-n', '--name', default=None,
+        help="Name of the new source")
     parser.add_argument('-f', '--format', default=None,
         help="Name of the source dataset format (default: 'project')")
-    parser.add_argument('-n', '--name', default=None,
-        help="Name of the source to be imported")
     parser.add_argument('-p', '--project', dest='project_dir', default='.',
         help="Directory of the project to operate on (default: current dir)")
+    parser.add_argument('--skip-check', action='store_true',
+        help="Skip source checking")
     return parser
 
 def import_command(args):
@@ -99,6 +101,10 @@ def import_command(args):
         if args.format:
             source['format'] = args.format
         project.add_source(name, source)
+
+        if not args.skip_check:
+            log.info("Checking the source...")
+            project.make_source_project(name)
         project.save()
 
         log.info("Source '%s' has been added to the project, location: '%s'" \
@@ -131,6 +137,10 @@ def import_command(args):
         if args.format:
             source['format'] = args.format
         project.add_source(name, source)
+
+        if not args.skip_check:
+            log.info("Checking the source...")
+            project.make_source_project(name)
         project.save()
 
         log.info("Source '%s' has been added to the project, location: '%s'" \

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -53,6 +53,11 @@ class Categories:
     def __init__(self, attributes=None):
         if attributes is None:
             attributes = set()
+        else:
+            if not isinstance(attributes, set):
+                attributes = set(attributes)
+            for attr in attributes:
+                assert isinstance(attr, str)
         self.attributes = attributes
 
     def __eq__(self, other):
@@ -62,7 +67,7 @@ class Categories:
             (self.attributes == other.attributes)
 
 class LabelCategories(Categories):
-    Category = namedtuple('Category', ['name', 'parent'])
+    Category = namedtuple('Category', ['name', 'parent', 'attributes'])
 
     def __init__(self, items=None, attributes=None):
         super().__init__(attributes=attributes)
@@ -81,11 +86,18 @@ class LabelCategories(Categories):
             indices[item.name] = index
         self._indices = indices
 
-    def add(self, name, parent=None):
+    def add(self, name, parent=None, attributes=None):
         assert name not in self._indices
+        if attributes is None:
+            attributes = set()
+        else:
+            if not isinstance(attributes, set):
+                attributes = set(attributes)
+            for attr in attributes:
+                assert isinstance(attr, str)
 
         index = len(self.items)
-        self.items.append(self.Category(name, parent))
+        self.items.append(self.Category(name, parent, attributes))
         self._indices[name] = index
 
     def find(self, name):

--- a/datumaro/datumaro/components/extractors/voc.py
+++ b/datumaro/datumaro/components/extractors/voc.py
@@ -30,8 +30,8 @@ class VocExtractor(Extractor):
             self.items = []
 
         def __iter__(self):
-            for item in self.items:
-                yield self._parent._get(item, self._name)
+            for item_id in self.items:
+                yield self._parent._get(item_id, self._name)
 
         def __len__(self):
             return len(self.items)
@@ -122,17 +122,17 @@ class VocExtractor(Extractor):
             for item in subset:
                 yield item
 
-    def _get(self, item, subset_name):
+    def _get(self, item_id, subset_name):
         image = None
         image_path = osp.join(self._path, VocPath.IMAGES_DIR,
-            item + VocPath.IMAGE_EXT)
+            item_id + VocPath.IMAGE_EXT)
         if osp.isfile(image_path):
             image = lazy_image(image_path)
 
-        annotations = self._get_annotations(item)
+        annotations = self._get_annotations(item_id)
 
         return DatasetItem(annotations=annotations,
-            id=item, subset=subset_name, image=image)
+            id=item_id, subset=subset_name, image=image)
 
     def _get_label_id(self, label):
         label_id, _ = self._categories[AnnotationType.label].find(label)
@@ -258,58 +258,48 @@ class VocExtractor(Extractor):
             return None
 
 class VocClassificationExtractor(VocExtractor):
-    _ANNO_DIR = 'Main'
-
     def __init__(self, path):
         super().__init__(path, task=VocTask.classification)
 
-        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, self._ANNO_DIR)
+        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, 'Main')
         subsets = self._load_subsets(subsets_dir)
         self._subsets = subsets
 
         self._load_cls_annotations(subsets_dir, subsets)
 
 class VocDetectionExtractor(VocExtractor):
-    _ANNO_DIR = 'Main'
-
     def __init__(self, path):
         super().__init__(path, task=VocTask.detection)
 
-        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, self._ANNO_DIR)
+        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, 'Main')
         subsets = self._load_subsets(subsets_dir)
         self._subsets = subsets
 
         self._load_det_annotations()
 
 class VocSegmentationExtractor(VocExtractor):
-    _ANNO_DIR = 'Segmentation'
-
     def __init__(self, path):
         super().__init__(path, task=VocTask.segmentation)
 
-        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, self._ANNO_DIR)
+        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, 'Segmentation')
         subsets = self._load_subsets(subsets_dir)
         self._subsets = subsets
 
 class VocLayoutExtractor(VocExtractor):
-    _ANNO_DIR = 'Layout'
-
     def __init__(self, path):
         super().__init__(path, task=VocTask.person_layout)
 
-        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, self._ANNO_DIR)
+        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, 'Layout')
         subsets = self._load_subsets(subsets_dir)
         self._subsets = subsets
 
         self._load_det_annotations()
 
 class VocActionExtractor(VocExtractor):
-    _ANNO_DIR = 'Action'
-
     def __init__(self, path):
         super().__init__(path, task=VocTask.action_classification)
 
-        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, self._ANNO_DIR)
+        subsets_dir = osp.join(path, VocPath.SUBSETS_DIR, 'Action')
         subsets = self._load_subsets(subsets_dir)
         self._subsets = subsets
 

--- a/datumaro/datumaro/components/extractors/voc.py
+++ b/datumaro/datumaro/components/extractors/voc.py
@@ -4,18 +4,15 @@
 # SPDX-License-Identifier: MIT
 
 from collections import defaultdict
-from itertools import chain
 import os
 import os.path as osp
 from xml.etree import ElementTree as ET
 
 from datumaro.components.extractor import (Extractor, DatasetItem,
     AnnotationType, LabelObject, MaskObject, BboxObject,
-    LabelCategories, MaskCategories
 )
-from datumaro.components.formats.voc import (VocLabel, VocAction,
-    VocBodyPart, VocTask, VocPath, VocColormap, VocInstColormap,
-    VocIgnoredLabel
+from datumaro.components.formats.voc import (
+    VocTask, VocPath, VocInstColormap, parse_label_map, make_voc_categories
 )
 from datumaro.util import dir_items
 from datumaro.util.image import lazy_image
@@ -23,31 +20,6 @@ from datumaro.util.mask_tools import lazy_mask, invert_colormap
 
 
 _inverse_inst_colormap = invert_colormap(VocInstColormap)
-
-# pylint: disable=pointless-statement
-def _make_voc_categories():
-    categories = {}
-
-    label_categories = LabelCategories()
-    for label in chain(VocLabel, VocAction, VocBodyPart):
-        label_categories.add(label.name)
-    categories[AnnotationType.label] = label_categories
-
-    def label_id(class_index):
-        if class_index in [0, VocIgnoredLabel]:
-            return class_index
-
-        class_label = VocLabel(class_index).name
-        label_id, _ = label_categories.find(class_label)
-        return label_id + 1
-    colormap = { label_id(idx): tuple(color) \
-        for idx, color in VocColormap.items() }
-    mask_categories = MaskCategories(colormap)
-    mask_categories.inverse_colormap # force init
-    categories[AnnotationType.mask] = mask_categories
-
-    return categories
-# pylint: enable=pointless-statement
 
 class VocExtractor(Extractor):
     class Subset(Extractor):
@@ -87,10 +59,10 @@ class VocExtractor(Extractor):
         label_annotations = defaultdict(list)
         label_anno_files = [s for s in dir_files \
             if '_' in s and s[s.rfind('_') + 1:] in subset_names]
-        for ann_file in label_anno_files:
-            with open(osp.join(subsets_dir, ann_file + '.txt'), 'r') as f:
-                label = ann_file[:ann_file.rfind('_')]
-                label_id = VocLabel[label].value
+        for ann_filename in label_anno_files:
+            with open(osp.join(subsets_dir, ann_filename + '.txt'), 'r') as f:
+                label = ann_filename[:ann_filename.rfind('_')]
+                label_id = self._get_label_id(label)
                 for line in f:
                     item, present = line.split()
                     if present == '1':
@@ -113,7 +85,11 @@ class VocExtractor(Extractor):
         self._annotations[VocTask.detection] = det_annotations
 
     def _load_categories(self):
-        self._categories = _make_voc_categories()
+        label_map = None
+        label_map_path = osp.join(self._path, VocPath.LABELMAP_FILE)
+        if osp.isfile(label_map_path):
+            label_map = parse_label_map(label_map_path)
+        self._categories = make_voc_categories(label_map)
 
     def __init__(self, path, task):
         super().__init__()
@@ -187,11 +163,10 @@ class VocExtractor(Extractor):
 
         cls_annotations = self._annotations.get(VocTask.classification)
         if cls_annotations is not None and \
-           self._task is VocTask.classification:
+                self._task is VocTask.classification:
             item_labels = cls_annotations.get(item)
             if item_labels is not None:
-                for label in item_labels:
-                    label_id = self._get_label_id(VocLabel(label).name)
+                for label_id in item_labels:
                     item_annotations.append(LabelObject(label_id))
 
         det_annotations = self._annotations.get(VocTask.detection)
@@ -215,16 +190,16 @@ class VocExtractor(Extractor):
                     continue
 
                 difficult_elem = object_elem.find('difficult')
-                if difficult_elem is not None:
-                    attributes['difficult'] = (difficult_elem.text == '1')
+                attributes['difficult'] = difficult_elem is not None and \
+                    difficult_elem.text == '1'
 
                 truncated_elem = object_elem.find('truncated')
-                if truncated_elem is not None:
-                    attributes['truncated'] = (truncated_elem.text == '1')
+                attributes['truncated'] = truncated_elem is not None and \
+                    truncated_elem.text == '1'
 
                 occluded_elem = object_elem.find('occluded')
-                if occluded_elem is not None:
-                    attributes['occluded'] = (occluded_elem.text == '1')
+                attributes['occluded'] = occluded_elem is not None and \
+                    occluded_elem.text == '1'
 
                 pose_elem = object_elem.find('pose')
                 if pose_elem is not None:
@@ -238,34 +213,34 @@ class VocExtractor(Extractor):
                     attributes['point'] = point
 
                 actions_elem = object_elem.find('actions')
-                if actions_elem is not None and \
-                   self._task is VocTask.action_classification:
-                    for action in VocAction:
-                        action_elem = actions_elem.find(action.name)
-                        if action_elem is None or action_elem.text != '1':
-                            continue
+                actions = {a: False
+                    for a in self._categories[AnnotationType.label] \
+                        .items[obj_label_id].attributes}
+                if actions_elem is not None:
+                    for action_elem in actions_elem:
+                        actions[action_elem.tag] = (action_elem.text == '1')
+                for action, present in actions.items():
+                    attributes[action] = present
 
-                        act_label_id = self._get_label_id(action.name)
-                        assert group in [None, obj_id]
-                        group = obj_id
-                        item_annotations.append(LabelObject(act_label_id,
-                            group=obj_id))
+                for part_elem in object_elem.findall('part'):
+                    part = part_elem.find('name').text
+                    part_label_id = self._get_label_id(part)
+                    bbox = self._parse_bbox(part_elem)
+                    group = obj_id
 
-                if self._task is VocTask.person_layout:
-                    for part_elem in object_elem.findall('part'):
-                        part = part_elem.find('name').text
-                        part_label_id = self._get_label_id(part)
-                        bbox = self._parse_bbox(part_elem)
-                        group = obj_id
-                        item_annotations.append(BboxObject(
-                            *bbox, label=part_label_id,
-                            group=obj_id))
+                    if self._task is not VocTask.person_layout:
+                        break
+                    item_annotations.append(BboxObject(
+                        *bbox, label=part_label_id,
+                        group=obj_id))
 
-                if self._task in [VocTask.action_classification, VocTask.person_layout]:
-                    if group is None:
-                        continue
+                if self._task is VocTask.person_layout and group is None:
+                    continue
+                if self._task is VocTask.action_classification and not actions:
+                    continue
 
-                item_annotations.append(BboxObject(*obj_bbox, label=obj_label_id,
+                item_annotations.append(BboxObject(
+                    *obj_bbox, label=obj_label_id,
                     attributes=attributes, id=obj_id, group=group))
 
         return item_annotations
@@ -414,7 +389,7 @@ class VocResultsExtractor(Extractor):
             if mark != task_desc['mark']:
                 continue
 
-            label_id = VocLabel[label].value
+            label_id = self._get_label_id(label)
             anns = defaultdict(list)
             with open(osp.join(task_dir, ann_file + ann_ext), 'r') as f:
                 for line in f:
@@ -441,7 +416,11 @@ class VocResultsExtractor(Extractor):
             VocTask.action_classification)
 
     def _load_categories(self):
-        self._categories = _make_voc_categories()
+        label_map = None
+        label_map_path = osp.join(self._path, VocPath.LABELMAP_FILE)
+        if osp.isfile(label_map_path):
+            label_map = parse_label_map(label_map_path)
+        self._categories = make_voc_categories(label_map)
 
     def _get_label_id(self, label):
         label_id = self._categories[AnnotationType.label].find(label)
@@ -511,9 +490,8 @@ class VocComp_1_2_Extractor(VocResultsExtractor):
         if cls_ann is not None:
             for desc in cls_ann:
                 label_id, conf = desc
-                label_id = self._get_label_id(VocLabel(int(label_id)).name)
                 annotations.append(LabelObject(
-                    label_id,
+                    int(label_id),
                     attributes={ 'score': float(conf) }
                 ))
 
@@ -538,11 +516,10 @@ class VocComp_3_4_Extractor(VocResultsExtractor):
         if det_ann is not None:
             for desc in det_ann:
                 label_id, conf, left, top, right, bottom = desc
-                label_id = self._get_label_id(VocLabel(int(label_id)).name)
                 annotations.append(BboxObject(
                     x=float(left), y=float(top),
                     w=float(right) - float(left), h=float(bottom) - float(top),
-                    label=label_id,
+                    label=int(label_id),
                     attributes={ 'score': float(conf) }
                 ))
 
@@ -639,7 +616,7 @@ class VocComp_7_8_Extractor(VocResultsExtractor):
                 conf = float(layout_elem.find('confidence').text)
                 parts = []
                 for part_elem in layout_elem.findall('part'):
-                    label_id = VocBodyPart[part_elem.find('class').text].value
+                    label_id = self._get_label_id(part_elem.find('class').text)
                     bbox_elem = part_elem.find('bndbox')
                     xmin = float(bbox_elem.find('xmin').text)
                     xmax = float(bbox_elem.find('xmax').text)
@@ -671,8 +648,7 @@ class VocComp_7_8_Extractor(VocResultsExtractor):
                 }
 
                 for part in parts:
-                    part_id, bbox = part
-                    label_id = self._get_label_id(VocBodyPart(part_id).name)
+                    label_id, bbox = part
                     annotations.append(BboxObject(
                         *bbox, label=label_id,
                         attributes=attributes))
@@ -691,6 +667,12 @@ class VocComp_9_10_Extractor(VocResultsExtractor):
         self._subsets = subsets
         self._annotations = dict(annotations)
 
+    def _load_categories(self):
+        from collections import OrderedDict
+        from datumaro.components.formats.voc import VocAction
+        label_map = OrderedDict((a.name, [[], [], []]) for a in VocAction)
+        self._categories = make_voc_categories(label_map)
+
     def _get_annotations(self, item, subset_name):
         annotations = []
 
@@ -698,9 +680,8 @@ class VocComp_9_10_Extractor(VocResultsExtractor):
         if action_ann is not None:
             for desc in action_ann:
                 action_id, obj_id, conf = desc
-                label_id = self._get_label_id(VocAction(int(action_id)).name)
                 annotations.append(LabelObject(
-                    label_id,
+                    action_id,
                     attributes={
                         'score': conf,
                         'object_id': int(obj_id),

--- a/datumaro/datumaro/components/formats/voc.py
+++ b/datumaro/datumaro/components/formats/voc.py
@@ -161,6 +161,7 @@ def parse_label_map(path):
 
 def write_label_map(path, label_map):
     with open(path, 'w') as f:
+        f.write('# label:color_rgb:parts:actions\n')
         for label_name, label_desc in label_map.items():
             if label_desc[0]:
                 color_rgb = ','.join(str(c) for c in label_desc[0][::-1])
@@ -180,11 +181,12 @@ def make_voc_categories(label_map=None):
     categories = {}
 
     label_categories = LabelCategories()
-    label_categories.attributes.update('difficult', 'truncated', 'occluded')
+    label_categories.attributes.update(['difficult', 'truncated', 'occluded'])
 
     for label, desc in label_map.items():
         label_categories.add(label, attributes=desc[2])
-    for part in set(chain(*(desc[1] for desc in label_map.values()))):
+    for part in OrderedDict((k, None) for k in chain(
+            *(desc[1] for desc in label_map.values()))):
         label_categories.add(part)
     categories[AnnotationType.label] = label_categories
 

--- a/datumaro/datumaro/components/formats/voc.py
+++ b/datumaro/datumaro/components/formats/voc.py
@@ -5,7 +5,12 @@
 
 from collections import OrderedDict
 from enum import Enum
+from itertools import chain
 import numpy as np
+
+from datumaro.components.extractor import (AnnotationType,
+    LabelCategories, MaskCategories
+)
 
 
 VocTask = Enum('VocTask', [
@@ -17,6 +22,7 @@ VocTask = Enum('VocTask', [
 ])
 
 VocLabel = Enum('VocLabel', [
+    ('background', 0),
     ('aeroplane', 1),
     ('bicycle', 2),
     ('bird', 3),
@@ -37,9 +43,8 @@ VocLabel = Enum('VocLabel', [
     ('sofa', 18),
     ('train', 19),
     ('tvmonitor', 20),
+    ('ignored', 255),
 ])
-
-VocIgnoredLabel = 255
 
 VocPose = Enum('VocPose', [
     'Unspecified',
@@ -86,7 +91,7 @@ def generate_colormap(length=256):
     )
 
 VocColormap = {id: color for id, color in generate_colormap(256).items()
-    if id in [l.value for l in VocLabel] + [0, VocIgnoredLabel]}
+    if id in [l.value for l in VocLabel]}
 VocInstColormap = generate_colormap(256)
 
 class VocPath:
@@ -97,6 +102,7 @@ class VocPath:
     SUBSETS_DIR = 'ImageSets'
     IMAGE_EXT = '.jpg'
     SEGM_EXT = '.png'
+    LABELMAP_FILE = 'labelmap.txt'
 
     TASK_DIR = {
         VocTask.classification: 'Main',
@@ -105,3 +111,93 @@ class VocPath:
         VocTask.action_classification: 'Action',
         VocTask.person_layout: 'Layout',
     }
+
+
+def make_voc_label_map():
+    labels = sorted(VocLabel, key=lambda l: l.value)
+    label_map = OrderedDict(
+        (label.name, [VocColormap[label.value], [], []]) for label in labels)
+    label_map[VocLabel.person.name][1] = [p.name for p in VocBodyPart]
+    label_map[VocLabel.person.name][2] = [a.name for a in VocAction]
+    return label_map
+
+def parse_label_map(path):
+    if not path:
+        return None
+
+    label_map = OrderedDict()
+    with open(path, 'r') as f:
+        for line in f:
+            # skip empty and commented lines
+            line = line.strip()
+            if not line or line and line[0] == '#':
+                continue
+
+            # name, color, parts, actions
+            label_desc = line.strip().split(':')
+            name = label_desc[0]
+
+            if 1 < len(label_desc) and len(label_desc[1]) != 0:
+                color = label_desc[1].split(',')
+                assert len(color) == 3, \
+                    "Label '%s' has wrong color, expected 'r,g,b', got '%s'" % \
+                    (name, color)
+                color = tuple([int(c) for c in color][::-1])
+            else:
+                color = None
+
+            if 2 < len(label_desc) and len(label_desc[2]) != 0:
+                parts = label_desc[2].split(',')
+            else:
+                parts = []
+
+            if 3 < len(label_desc) and len(label_desc[3]) != 0:
+                actions = label_desc[3].split(',')
+            else:
+                actions = []
+
+            label_map[name] = [color, parts, actions]
+    return label_map
+
+def write_label_map(path, label_map):
+    with open(path, 'w') as f:
+        for label_name, label_desc in label_map.items():
+            if label_desc[0]:
+                color_rgb = ','.join(str(c) for c in label_desc[0][::-1])
+            else:
+                color_rgb = ''
+
+            parts = ','.join(str(p) for p in label_desc[1])
+            actions = ','.join(str(a) for a in label_desc[2])
+
+            f.write('%s\n' % ':'.join([label_name, color_rgb, parts, actions]))
+
+# pylint: disable=pointless-statement
+def make_voc_categories(label_map=None):
+    if label_map is None:
+        label_map = make_voc_label_map()
+
+    categories = {}
+
+    label_categories = LabelCategories()
+    label_categories.attributes.update('difficult', 'truncated', 'occluded')
+
+    for label, desc in label_map.items():
+        label_categories.add(label, attributes=desc[2])
+    for part in set(chain(*(desc[1] for desc in label_map.values()))):
+        label_categories.add(part)
+    categories[AnnotationType.label] = label_categories
+
+    has_colors = sum(v[0] is not None for v in label_map.values())
+    if not has_colors:
+        colormap = generate_colormap(len(label_map))
+    else:
+        label_id = lambda label: label_categories.find(label)[0]
+        colormap = { label_id(name): desc[0]
+            for name, desc in label_map.items() }
+    mask_categories = MaskCategories(colormap)
+    mask_categories.inverse_colormap # force init
+    categories[AnnotationType.mask] = mask_categories
+
+    return categories
+# pylint: enable=pointless-statement

--- a/datumaro/datumaro/util/mask_tools.py
+++ b/datumaro/datumaro/util/mask_tools.py
@@ -69,6 +69,16 @@ def apply_colormap(mask, colormap=None):
     painted_mask = np.reshape(painted_mask, (*mask.shape, 3))
     return painted_mask.astype(np.float32)
 
+def remap_mask(mask, map_fn):
+    # Changes mask elements from one colormap to another
+    assert len(mask.shape) == 2
+
+    shape = mask.shape
+    mask = np.reshape(mask, (-1, 1))
+    mask = np.apply_along_axis(map_fn, 1, mask)
+    mask = np.reshape(mask, shape)
+    return mask
+
 
 def load_mask(path, colormap=None):
     mask = load_image(path)


### PR DESCRIPTION
Closes #942 

Added:
- `labelmap.txt` file support in the dataset root dir
- `--overwrite` cli option for `source export` and `project export`
- label-specific attributes
- checks that imported source or project can be read

Labelmap file example:
```
# label : RGB color : parts : actions
background:0,0,0::
aeroplane:0,0,128::
bicycle:0,128,0::
bird:0,128,128::
boat:128,0,0::
bottle:128,0,128::
bus:128,128,0::
car:128,128,128::
cat:0,0,64::
chair:0,0,192::
cow:0,128,64::
diningtable:0,128,192::
dog:128,0,64::
horse:128,0,192::
motorbike:128,128,64::
person:128,128,192:head,hand,foot:other,jumping,phoning,playinginstrument,reading,ridingbike,ridinghorse,running,takingphoto,usingcomputer,walking
pottedplant:0,64,0::
sheep:0,64,128::
sofa:0,192,0::
```

Test:
```
datum project export -d test -f voc --overwrite -- --label-map=labelmap.txt
```
Labelmap option can be `voc`, `source`, `guess` (default) and a file path.