### PR TITLE
Hotfix: fixed skikit-image version 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.2] - 2019-12-15
+### Fixed
+- Frozen version of scikit-image==0.15 in requirements.txt because next releases don't support Python 3.5
+
 ## [0.5.1] - 2019-10-17
 ### Added
 - Integration with Zenodo.org (DOI)

--- a/cvat/requirements/base.txt
+++ b/cvat/requirements/base.txt
@@ -38,7 +38,7 @@ pascal_voc_writer==0.1.4
 django-rest-auth[with_social]==0.9.5
 cython==0.29.13
 matplotlib==3.0.3
-scikit-image>=0.14.0
+scikit-image==0.15.0
 tensorflow==1.12.3
 django-cors-headers==3.0.2
 furl==2.0.0


### PR DESCRIPTION
scikit-image > 0.15 don't support python 3.5

Resolved #962

We also need to create a new release