### PR TITLE
Resolved performance bottleneck in merge function

### DIFF
--- a/cvat/apps/engine/static/engine/js/shapeMerger.js
+++ b/cvat/apps/engine/static/engine/js/shapeMerger.js
@@ -135,7 +135,6 @@ class ShapeMergerModel extends Listener {
                 object.shapes.push(
                     Object.assign(shapeDict[frame].interpolation.position,
                         {
-                            z_order: this._collectionModel.zOrder(frame).max,
                             frame: frame,
                             attributes: shapeAttributes
                         }
@@ -150,7 +149,7 @@ class ShapeMergerModel extends Listener {
                     let copy = Object.assign({}, object.shapes[object.shapes.length - 1]);
                     copy.outside = true;
                     copy.frame += 1;
-                    copy.z_order =  this._collectionModel.zOrder(frame).max;
+                    copy.z_order = 0;
                     copy.attributes = [];
                     object.shapes.push(copy);
                 }


### PR DESCRIPTION
Resolved #854

Explanations:
1. When we merge tracks, actually we shouldn't update zOrder for them shapes and set it as a maximum value within the shape frame. We can expect it has been already set automatically or by a user and it's right. 
2. When we merge shapes, we should not setup maximum or minimum values for closing outside shapes. Because they are invisible, so, let's just set 0. 