### PR TITLE
[Datumaro] Dataset annotations filter

### DIFF
--- a/datumaro/datumaro/cli/project/__init__.py
+++ b/datumaro/datumaro/cli/project/__init__.py
@@ -11,6 +11,7 @@ import shutil
 
 from datumaro.components.project import Project
 from datumaro.components.comparator import Comparator
+from datumaro.components.dataset_filter import DatasetItemEncoder
 from .diff import DiffVisualizer
 from ..util.project import make_project_path, load_project
 
@@ -131,7 +132,12 @@ def build_export_parser(parser):
              "'/item[image/width < image/height]'; "
              "extract images with large-area bboxes: "
              "'/item[annotation/type=\"bbox\" and annotation/area>2000]'"
+            "filter out irrelevant annotations from items: "
+             "'/item/annotation[label = \"person\"]'"
         )
+    parser.add_argument('-a', '--filter-annotations', action='store_true',
+        help="Filter annotations instead of dataset "
+            "items (default: %(default)s)")
     parser.add_argument('-d', '--dest', dest='dst_dir', required=True,
         help="Directory to save output")
     parser.add_argument('-f', '--output-format', required=True,
@@ -158,10 +164,11 @@ def export_command(args):
     dataset = project.make_dataset()
 
     log.info("Exporting the project...")
-    dataset.export(
+    dataset.export_project(
         save_dir=dst_dir,
         output_format=args.output_format,
         filter_expr=args.filter,
+        filter_annotations=args.filter_annotations,
         cmdline_args=args.extra_args)
     log.info("Project exported to '%s' as '%s'" % \
         (dst_dir, args.output_format))
@@ -177,12 +184,21 @@ def build_docs_parser(parser):
 
 def build_extract_parser(parser):
     parser.add_argument('-e', '--filter', default=None,
-        help="Filter expression for dataset items. Examples: "
+        help="XML XPath filter expression for dataset items. Examples: "
              "extract images with width < height: "
              "'/item[image/width < image/height]'; "
              "extract images with large-area bboxes: "
              "'/item[annotation/type=\"bbox\" and annotation/area>2000]'"
+             "filter out irrelevant annotations from items: "
+             "'/item/annotation[label = \"person\"]'"
         )
+    parser.add_argument('-a', '--filter-annotations', action='store_true',
+        help="Filter annotations instead of dataset "
+            "items (default: %(default)s)")
+    parser.add_argument('--remove-empty', action='store_true',
+        help="Remove an item if there are no annotations left after filtration")
+    parser.add_argument('--dry-run', action='store_true',
+        help="Print XML representations to be filtered and exit")
     parser.add_argument('-d', '--dest', dest='dst_dir', required=True,
         help="Output directory")
     parser.add_argument('-p', '--project', dest='project_dir', default='.',
@@ -193,9 +209,27 @@ def extract_command(args):
     project = load_project(args.project_dir)
 
     dst_dir = osp.abspath(args.dst_dir)
-    os.makedirs(dst_dir, exist_ok=False)
+    if not args.dry_run:
+        os.makedirs(dst_dir, exist_ok=False)
 
-    project.make_dataset().extract(filter_expr=args.filter, save_dir=dst_dir)
+    dataset = project.make_dataset()
+
+    kwargs = {}
+    if args.filter_annotations:
+        kwargs['remove_empty'] = args.remove_empty
+
+    if args.dry_run:
+        dataset = dataset.extract(filter_expr=args.filter,
+            filter_annotations=args.filter_annotations, **kwargs)
+        for item in dataset:
+            encoded_item = DatasetItemEncoder.encode(item, dataset.categories())
+            xml_item = DatasetItemEncoder.to_string(encoded_item)
+            print(xml_item)
+        return 0
+
+    dataset.extract_project(save_dir=dst_dir, filter_expr=args.filter,
+        filter_annotations=args.filter_annotations, **kwargs)
+
     log.info("Subproject extracted to '%s'" % (dst_dir))
 
     return 0
@@ -279,7 +313,7 @@ def transform_command(args):
 
     dst_dir = osp.abspath(args.dst_dir)
     os.makedirs(dst_dir, exist_ok=False)
-    project.make_dataset().transform(
+    project.make_dataset().apply_model(
         save_dir=dst_dir,
         model_name=args.model_name)
 

--- a/datumaro/datumaro/cli/project/__init__.py
+++ b/datumaro/datumaro/cli/project/__init__.py
@@ -188,7 +188,7 @@ def build_extract_parser(parser):
              "extract images with width < height: "
              "'/item[image/width < image/height]'; "
              "extract images with large-area bboxes: "
-             "'/item[annotation/type=\"bbox\" and annotation/area>2000]'"
+             "'/item[annotation/type=\"bbox\" and annotation/area>2000]' "
              "filter out irrelevant annotations from items: "
              "'/item/annotation[label = \"person\"]'"
         )

--- a/datumaro/datumaro/cli/source/__init__.py
+++ b/datumaro/datumaro/cli/source/__init__.py
@@ -188,6 +188,9 @@ def build_export_parser(parser):
              "extract images with large-area bboxes: "
              "'/item[annotation/type=\"bbox\" and annotation/area>2000]'"
         )
+    parser.add_argument('-a', '--filter-annotations', action='store_true',
+        help="Filter annotations instead of dataset "
+            "items (default: %(default)s)")
     parser.add_argument('-d', '--dest', dest='dst_dir', required=True,
         help="Directory to save output")
     parser.add_argument('-f', '--output-format', required=True,
@@ -215,10 +218,11 @@ def export_command(args):
     dataset = source_project.make_dataset()
 
     log.info("Exporting the project...")
-    dataset.export(
+    dataset.export_project(
         save_dir=dst_dir,
         output_format=args.output_format,
         filter_expr=args.filter,
+        filter_annotations=args.filter_annotations,
         cmdline_args=args.extra_args)
     log.info("Source '%s' exported to '%s' as '%s'" % \
         (args.name, dst_dir, args.output_format))

--- a/datumaro/datumaro/components/config_model.py
+++ b/datumaro/datumaro/components/config_model.py
@@ -60,7 +60,6 @@ PROJECT_SCHEMA = _SchemaBuilder() \
     .add('subsets', list) \
     .add('sources', lambda: _DefaultConfig(
         lambda v=None: Source(v))) \
-    .add('filter', str) \
     \
     .add('project_filename', str, internal=True) \
     .add('project_dir', str, internal=True) \

--- a/datumaro/datumaro/components/converters/voc.py
+++ b/datumaro/datumaro/components/converters/voc.py
@@ -462,7 +462,7 @@ class _Converter:
         void_labels = [src_label for src_id, src_label in source_labels.items()
             if src_label not in target_labels]
         if void_labels:
-            log.warn("The following labels are remapped to background: %s" %
+            log.warning("The following labels are remapped to background: %s" %
                 ', '.join(void_labels))
 
         def map_id(src_id):

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -580,9 +580,9 @@ class _DatasetFilter:
         return filter(self.predicate, self.iterable)
 
 class _ExtractorBase(IExtractor):
-    def __init__(self, length=None):
+    def __init__(self, length=None, subsets=None):
         self._length = length
-        self._subsets = None
+        self._subsets = subsets
 
     def _init_cache(self):
         subsets = set()
@@ -612,9 +612,12 @@ class _ExtractorBase(IExtractor):
         else:
             raise Exception("Unknown subset '%s' requested" % name)
 
+    def transform(self, method, *args, **kwargs):
+        return method(self, *args, **kwargs)
+
 class DatasetIteratorWrapper(_ExtractorBase):
-    def __init__(self, iterable, categories):
-        super().__init__(length=None)
+    def __init__(self, iterable, categories, subsets=None):
+        super().__init__(length=None, subsets=subsets)
         self._iterable = iterable
         self._categories = categories
 
@@ -626,7 +629,7 @@ class DatasetIteratorWrapper(_ExtractorBase):
 
     def select(self, pred):
         return DatasetIteratorWrapper(
-            _DatasetFilter(self, pred), self.categories())
+            _DatasetFilter(self, pred), self.categories(), self.subsets())
 
 class Extractor(_ExtractorBase):
     def __init__(self, length=None):
@@ -637,7 +640,7 @@ class Extractor(_ExtractorBase):
 
     def select(self, pred):
         return DatasetIteratorWrapper(
-            _DatasetFilter(self, pred), self.categories())
+            _DatasetFilter(self, pred), self.categories(), self.subsets())
 
 
 DEFAULT_SUBSET_NAME = 'default'

--- a/datumaro/datumaro/components/launcher.py
+++ b/datumaro/datumaro/components/launcher.py
@@ -10,7 +10,7 @@ from datumaro.components.extractor import DatasetItem, Extractor
 
 # pylint: disable=no-self-use
 class Launcher:
-    def __init__(self):
+    def __init__(self, model_dir=None):
         pass
 
     def launch(self, inputs):

--- a/datumaro/tests/test_project.py
+++ b/datumaro/tests/test_project.py
@@ -134,18 +134,11 @@ class ProjectTest(TestCase):
 
     def test_can_batch_launch_custom_model(self):
         class TestExtractor(Extractor):
-            def __init__(self, url, n=0):
-                super().__init__(length=n)
-                self.n = n
-
             def __iter__(self):
-                for i in range(self.n):
+                for i in range(5):
                     yield DatasetItem(id=i, subset='train', image=i)
 
         class TestLauncher(Launcher):
-            def __init__(self, **kwargs):
-                pass
-
             def launch(self, inputs):
                 for i, inp in enumerate(inputs):
                     yield [ LabelObject(attributes={'idx': i, 'data': inp}) ]
@@ -157,7 +150,7 @@ class ProjectTest(TestCase):
         project.env.launchers.register(launcher_name, TestLauncher)
         project.add_model(model_name, { 'launcher': launcher_name })
         model = project.make_executable_model(model_name)
-        extractor = TestExtractor('', n=5)
+        extractor = TestExtractor()
 
         batch_size = 3
         executor = InferenceWrapper(extractor, model, batch_size=batch_size)
@@ -171,19 +164,12 @@ class ProjectTest(TestCase):
 
     def test_can_do_transform_with_custom_model(self):
         class TestExtractorSrc(Extractor):
-            def __init__(self, url, n=2):
-                super().__init__(length=n)
-                self.n = n
-
             def __iter__(self):
-                for i in range(self.n):
+                for i in range(2):
                     yield DatasetItem(id=i, subset='train', image=i,
                         annotations=[ LabelObject(i) ])
 
         class TestLauncher(Launcher):
-            def __init__(self, **kwargs):
-                pass
-
             def launch(self, inputs):
                 for inp in inputs:
                     yield [ LabelObject(inp) ]
@@ -191,7 +177,7 @@ class ProjectTest(TestCase):
         class TestConverter(Converter):
             def __call__(self, extractor, save_dir):
                 for item in extractor:
-                    with open(osp.join(save_dir, '%s.txt' % item.id), 'w+') as f:
+                    with open(osp.join(save_dir, '%s.txt' % item.id), 'w') as f:
                         f.write(str(item.subset) + '\n')
                         f.write(str(item.annotations[0].label) + '\n')
 
@@ -204,8 +190,8 @@ class ProjectTest(TestCase):
                 for path in self.items:
                     with open(path, 'r') as f:
                         index = osp.splitext(osp.basename(path))[0]
-                        subset = f.readline()[:-1]
-                        label = int(f.readline()[:-1])
+                        subset = f.readline().strip()
+                        label = int(f.readline().strip())
                         assert subset == 'train'
                         yield DatasetItem(id=index, subset=subset,
                             annotations=[ LabelObject(label) ])
@@ -261,12 +247,8 @@ class ProjectTest(TestCase):
 
     def test_project_filter_can_be_applied(self):
         class TestExtractor(Extractor):
-            def __init__(self, url, n=10):
-                super().__init__(length=n)
-                self.n = n
-
             def __iter__(self):
-                for i in range(self.n):
+                for i in range(10):
                     yield DatasetItem(id=i, subset='train')
 
         e_type = 'type'
@@ -331,30 +313,23 @@ class ProjectTest(TestCase):
             self.assertEqual(1, len(dataset.sources['child2']))
 
     def test_project_can_merge_item_annotations(self):
-        class TestExtractor(Extractor):
-            def __init__(self, url, v=None):
-                super().__init__()
-                self.v = v
-
+        class TestExtractor1(Extractor):
             def __iter__(self):
-                v1_item = DatasetItem(id=1, subset='train', annotations=[
+                yield DatasetItem(id=1, subset='train', annotations=[
                     LabelObject(2, id=3),
                     LabelObject(3, attributes={ 'x': 1 }),
                 ])
 
-                v2_item = DatasetItem(id=1, subset='train', annotations=[
+        class TestExtractor2(Extractor):
+            def __iter__(self):
+                yield DatasetItem(id=1, subset='train', annotations=[
                     LabelObject(3, attributes={ 'x': 1 }),
                     LabelObject(4, id=4),
                 ])
 
-                if self.v == 1:
-                    yield v1_item
-                else:
-                    yield v2_item
-
         project = Project()
-        project.env.extractors.register('t1', lambda p: TestExtractor(p, v=1))
-        project.env.extractors.register('t2', lambda p: TestExtractor(p, v=2))
+        project.env.extractors.register('t1', TestExtractor1)
+        project.env.extractors.register('t2', TestExtractor2)
         project.add_source('source1', { 'format': 't1' })
         project.add_source('source2', { 'format': 't2' })
 
@@ -494,9 +469,6 @@ class ConfigTest(TestCase):
 class ExtractorTest(TestCase):
     def test_custom_extractor_can_be_created(self):
         class CustomExtractor(Extractor):
-            def __init__(self, url):
-                super().__init__()
-
             def __iter__(self):
                 return iter([
                     DatasetItem(id=0, subset='train'),


### PR DESCRIPTION
Added:
- Dataset annotations filter in CLI: `datumaro project extract -a`

To test:
```
  -e FILTER, --filter FILTER 
                        XML XPath filter expression for dataset items.
                        Examples: 
                        - extract images with width < height:
                        '/item[image/width < image/height]'; 
                        - extract images with large-area bboxes: 
                        '/item[annotation/type="bbox" and annotation/area>2000]'
                        - filter out irrelevant annotations from items: 
                        '/item/annotation[label = "person"]'
  -a, --filter-annotations 
                        Filter annotations instead of dataset items (default: False)
  --remove-empty          
                         Remove an item if there are no annotations left after filtration
  --dry-run         Print XML representations to be filtered and exit

datum project extract -a -e '/item/annotation[label = "person"]' --remove-empty -d temp
```

In general, to filter annotations make an XPath that returns `annotation` XML elements. Check `dry-run` option to obtain XML representations of dataset items.

Resolves #994