### PR TITLE
Remove annotations

### DIFF
--- a/cvat/apps/engine/static/engine/js/annotationUI.js
+++ b/cvat/apps/engine/static/engine/js/annotationUI.js
@@ -458,7 +458,28 @@ function setupMenu(job, task, shapeCollectionModel,
                     shapeCollectionModel.empty();
                 });
         }
+    
+    
     });
+
+    $('#removeAnnotationButton1').on('click', () => {
+        if (!window.cvat.mode) {
+            hide();
+            let some= prompt('Enter range of frames: ', 'eg: 2,10/eg: 3');
+            let  some1 = some.split(",").map(Number);
+            console.log(some1);
+            shapeCollectionModel.empty1(some1);
+            historyModel.empty1(some1);
+
+            
+            
+        }
+    
+    
+    });
+
+
+
 
     // JS function cancelFullScreen don't work after pressing
     // and it is famous problem.

--- a/cvat/apps/engine/static/engine/js/history.js
+++ b/cvat/apps/engine/static/engine/js/history.js
@@ -56,7 +56,12 @@ class HistoryModel extends Listener {
         }
 
         this.notify();
+        console.log(this._redo_stack);
+        console.log(this._undo_stack);
+        
     }
+
+    
 
     redo() {
         let frame = window.cvat.player.frames.current;
@@ -87,7 +92,15 @@ class HistoryModel extends Listener {
         }
 
         this.notify();
+        console.log(this._undo_stack);
+        console.log(this._redo_stack);
+        
+
+
+
     }
+
+    
 
     addAction(name, undo, redo, frame) {
         if (this._locked) return;
@@ -113,6 +126,25 @@ class HistoryModel extends Listener {
         this.notify();
     }
 
+    empty1(entry) {
+        let undo1= this._undo_stack ;
+        if(undo1!=[]){
+            undo1=undo1.filter(item=> (item.frame<entry[0] || item.frame>entry[1]));
+            this._undo_stack=undo1;
+        }
+        console.log (undo1);
+         let redo1= this._redo_stack;
+
+         if (redo1!= []){
+             redo1=redo1.filter(item=> (item.frame<entry[0] || item.frame>entry[1]));
+             this._redo_stack=redo1;
+         }
+        console.log(redo1);
+        this._id=0;
+        this.notify();
+        
+    }
+
     get undoLength() {
         return this._undo_stack.length;
     }
@@ -127,6 +159,8 @@ class HistoryModel extends Listener {
             return `${lastUndo.name} [Frame ${lastUndo.frame}] [Id ${lastUndo.id}]`;
         }
         else return 'None';
+        
+        
     }
 
     get lastRedoText() {
@@ -135,7 +169,10 @@ class HistoryModel extends Listener {
             return `${lastRedo.name} [Frame ${lastRedo.frame}] [Id ${lastRedo.id}]`;
         }
         else return 'None';
+        
     }
+
+ 
 }
 
 

--- a/cvat/apps/engine/static/engine/js/shapeCollection.js
+++ b/cvat/apps/engine/static/engine/js/shapeCollection.js
@@ -392,6 +392,7 @@ class ShapeCollectionModel extends Listener {
             Object.keys(annotate).forEach(key=>{
                 if (entry[0]<=Number(key) && entry[1]>=Number(key)){
                 delete annotate [key];
+                this._annotationShapes=annotate;
                 }
 
             });
@@ -399,6 +400,7 @@ class ShapeCollectionModel extends Listener {
 
         else if (entry.length==1) {
             delete annotate [entry];
+            this._annotationShapes=annotate;
         }
 
         else{

--- a/cvat/apps/engine/static/engine/js/shapeCollection.js
+++ b/cvat/apps/engine/static/engine/js/shapeCollection.js
@@ -380,7 +380,37 @@ class ShapeCollectionModel extends Listener {
         this._idx = 0;
         this._colorIdx = 0;
         this._interpolate();
+           
     }
+
+
+    empty1(entry){
+        this._flush = true;
+        let annotate=this._annotationShapes;
+
+        if (entry.length==2){
+            Object.keys(annotate).forEach(key=>{
+                if (entry[0]<=Number(key) && entry[1]>=Number(key)){
+                delete annotate [key];
+                }
+
+            });
+        }
+
+        else if (entry.length==1) {
+            delete annotate [entry];
+        }
+
+        else{
+            alert('Error, incorrect input. Please try again!');
+        }
+
+        console.log(annotate);
+        
+
+    }
+
+    
 
     add(data, type) {
         this._idx += 1;

--- a/cvat/apps/engine/templates/engine/annotation.html
+++ b/cvat/apps/engine/templates/engine/annotation.html
@@ -349,7 +349,8 @@
             </select>
 
             <button id="openTaskButton" class="menuButton semiBold h2"> Open Task </button>
-            <button id="removeAnnotationButton" class="menuButton semiBold h2"> Remove Annotation </button>
+            <button id="removeAnnotationButton" class="menuButton semiBold h2">Remove all Annotation</button>
+            <button id="removeAnnotationButton1" class="menuButton semiBold h2"> Remove Annotations </button>
             <button id="settingsButton" class="menuButton semiBold h2"> Settings </button>
             <button id="fullScreenButton" class="menuButton semiBold h2"> Fullscreen Player </button>
             <button id="switchAAMButton" class="menuButton semiBold h2"> Switch AAM </button>


### PR DESCRIPTION
Issue #33  
Included a button **Remove Annotation** (remove all annotations in a single frame or a range of frames) which prompts for user input, a user can enter a frame number `number` or a range of frames by prescribing `startvalue,endvalue` and press okay. In case the user enters three numbers each followed by a comma, it displays an alert message. This removes all annotations inside the range that users specifies. 
I did not alter the functionality of original `Remove Annotation` button just changed the name to `Remove all Annotations`.
Tasks:
-[x] clears history of removed annotations
-[x] removes annotations for a range of frames / a single frame
-[  ] save work

Issues: I need some clarity on `shapes` under class `shapeCollectionModel`  in `cvat/apps/engine/static/engine/js/shapeCollection.js`. I understand that boxmodels are stored as an array in `shapes`. I'm not sure I understand how to reference them with the frames if that's possible  so that particular boxmodel  can be removed when **Remove Annotation** is invoked. Whenever I try to save the changes I am not able to see the changes, as it retains the original work. How should I proceed from here? Could you please shed some light on this issue?