### PR TITLE
Resolved import error caused by pip 20.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN apt-get update && \
     else \
         echo export "GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o ProxyCommand='nc -X 5 -x ${socks_proxy} %h %p'\"" >> ${HOME}/.bashrc; \
     fi && \
-    python3 -m pip install --no-cache-dir -U pip setuptools && \
+    python3 -m pip install --no-cache-dir -U pip==20.0.1 setuptools && \
     ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
     add-apt-repository --remove ppa:mc3man/gstffmpeg-keep -y && \


### PR DESCRIPTION
I faced the same ImportError as raised in the https://gitter.im/opencv-cvat/public by @praffulkmr, while installing TF Object Detection API: Auto Annotation.
![Pip_error](https://user-images.githubusercontent.com/59498234/73173285-09152000-412b-11ea-8c0c-e75ad7c264b6.png)
No such error is found and able to build the docker image successfully, if the pip upgrade is set to version 20.0.1 in the Dockerfile.
