### PR TITLE
Update base.py

### DIFF
--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -192,7 +192,8 @@ UI_PORT = os.environ.get('UI_PORT', '3000')
 CORS_ALLOW_CREDENTIALS = True
 CSRF_TRUSTED_ORIGINS = [UI_HOST]
 UI_URL = '{}://{}'.format(UI_SCHEME, UI_HOST)
-if len(UI_URL):
+
+if UI_PORT and UI_PORT != '80':
     UI_URL += ':{}'.format(UI_PORT)
 
 CORS_ORIGIN_WHITELIST = [UI_URL]


### PR DESCRIPTION
Modification necessary for using CVAT from remote machines when accessing with FQDNs
See https://github.com/opencv/cvat/issues/1011#issue-542817055
and https://github.com/opencv/cvat/pull/1098

"I believe the reason for this is that sometimes if the port number is :80 and the URL is not in the LAN (:port), but instead it is a Fully Qualified Domain Name (:port), the port 80 is redundant (mydomain.com:80) and the errors arise."