### PR TITLE
Add extreme clicking method in cvat-canvas and cvat-ui

### DIFF
--- a/cvat-canvas/README.md
+++ b/cvat-canvas/README.md
@@ -40,6 +40,7 @@ Canvas itself handles:
     interface DrawData {
         enabled: boolean;
         shapeType?: string;
+        rectDrawingMethod?: string;
         numberOfPoints?: number;
         initialState?: any;
         crosshair?: boolean;

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -40,7 +40,7 @@ export interface ActiveElement {
 export interface DrawData {
     enabled: boolean;
     shapeType?: string;
-    boxDrawingType?: string;
+    rectDrawingMethod?: string;
     numberOfPoints?: number;
     initialState?: any;
     crosshair?: boolean;

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -40,6 +40,7 @@ export interface ActiveElement {
 export interface DrawData {
     enabled: boolean;
     shapeType?: string;
+    boxDrawingType?: string;
     numberOfPoints?: number;
     initialState?: any;
     crosshair?: boolean;

--- a/cvat-canvas/src/typescript/drawHandler.ts
+++ b/cvat-canvas/src/typescript/drawHandler.ts
@@ -203,40 +203,39 @@ export class DrawHandlerImpl implements DrawHandler {
 
     private drawBoxBy4Points(): void {
         let numberOfPoints = 0;
-        this.drawInstance = (this.canvas as any).polygon().draw({
-            snapToGrid: 0.1,
-        }).addClass('cvat_canvas_shape_drawing').style({
-            'stroke-width': 0,
-            opacity: 0,
-        }).on('drawstart', () => {
-            // init numberOfPoints as one on drawstart
-            numberOfPoints = 1;
-        }).on('drawpoint', (e: CustomEvent) => {
-            // increase numberOfPoints by one on drawpoint
-            numberOfPoints += 1;
+        this.drawInstance = (this.canvas as any).polygon()
+            .addClass('cvat_canvas_shape_drawing').attr({
+                'stroke-width': 0,
+                opacity: 0,
+            }).on('drawstart', () => {
+                // init numberOfPoints as one on drawstart
+                numberOfPoints = 1;
+            }).on('drawpoint', (e: CustomEvent) => {
+                // increase numberOfPoints by one on drawpoint
+                numberOfPoints += 1;
 
-            // finish if numberOfPoints are exactly four
-            if (numberOfPoints === 4) {
-                const bbox = (e.target as SVGPolylineElement).getBBox();
-                const [xtl, ytl, xbr, ybr] = this.getFinalRectCoordinates(bbox);
+                // finish if numberOfPoints are exactly four
+                if (numberOfPoints === 4) {
+                    const bbox = (e.target as SVGPolylineElement).getBBox();
+                    const [xtl, ytl, xbr, ybr] = this.getFinalRectCoordinates(bbox);
 
-                if ((xbr - xtl) * (ybr - ytl) >= consts.AREA_THRESHOLD) {
-                    this.onDrawDone({
-                        shapeType: this.drawData.shapeType,
-                        points: [xtl, ytl, xbr, ybr],
-                    });
-                } else {
-                    this.onDrawDone(null);
+                    if ((xbr - xtl) * (ybr - ytl) >= consts.AREA_THRESHOLD) {
+                        this.onDrawDone({
+                            shapeType: this.drawData.shapeType,
+                            points: [xtl, ytl, xbr, ybr],
+                        });
+                    } else {
+                        this.onDrawDone(null);
+                    }
                 }
-            }
-        }).on('undopoint', () => {
-            if (numberOfPoints > 0) {
-                numberOfPoints -= 1;
-            }
-        }).off('drawdone').on('drawdone', () => {
-            // close drawing mode without drawing rect
-            this.onDrawDone(null);
-        });
+            }).on('undopoint', () => {
+                if (numberOfPoints > 0) {
+                    numberOfPoints -= 1;
+                }
+            }).off('drawdone').on('drawdone', () => {
+                // close drawing mode without drawing rect
+                this.onDrawDone(null);
+            });
 
         this.drawPolyshape();
     }

--- a/cvat-canvas/src/typescript/drawHandler.ts
+++ b/cvat-canvas/src/typescript/drawHandler.ts
@@ -160,7 +160,8 @@ export class DrawHandlerImpl implements DrawHandler {
             if (!this.drawData.initialState) {
                 const { drawInstance } = this;
                 this.drawInstance = null;
-                if (this.drawData.shapeType === 'rectangle') {
+                if (this.drawData.shapeType === 'rectangle'
+                    && this.drawData.rectDrawingMethod !== 'by_four_points') {
                     drawInstance.draw('cancel');
                 } else {
                     drawInstance.draw('done');
@@ -579,14 +580,14 @@ export class DrawHandlerImpl implements DrawHandler {
             this.setupPasteEvents();
         } else {
             if (this.drawData.shapeType === 'rectangle') {
-                if (this.drawData.boxDrawingType === 'by_two_points') {
+                if (this.drawData.rectDrawingMethod === 'by_four_points') {
+                    // draw box by extreme clicking
+                    this.drawBoxBy4Points();
+                } else {
                     // default box drawing
                     this.drawBox();
                     // Draw instance was initialized after drawBox();
                     this.shapeSizeElement = displayShapeSize(this.canvas, this.text);
-                } else if (this.drawData.boxDrawingType === 'by_four_points') {
-                    // draw box by extreme clicking
-                    this.drawBoxBy4Points();
                 }
             } else if (this.drawData.shapeType === 'polygon') {
                 this.drawPolygon();
@@ -595,7 +596,6 @@ export class DrawHandlerImpl implements DrawHandler {
             } else if (this.drawData.shapeType === 'points') {
                 this.drawPoints();
             }
-
             this.setupDrawEvents();
         }
     }

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -583,7 +583,7 @@ export function drawShape(
     labelID: number,
     objectType: ObjectType,
     points?: number,
-    boxDrawingType?: string,
+    rectDrawingMethod?: string,
 ): AnyAction {
     let activeControl = ActiveControl.DRAW_RECTANGLE;
     if (shapeType === ShapeType.POLYGON) {
@@ -602,7 +602,7 @@ export function drawShape(
             objectType,
             points,
             activeControl,
-            boxDrawingType
+            rectDrawingMethod,
         },
     };
 }

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -583,6 +583,7 @@ export function drawShape(
     labelID: number,
     objectType: ObjectType,
     points?: number,
+    boxDrawingType?: string,
 ): AnyAction {
     let activeControl = ActiveControl.DRAW_RECTANGLE;
     if (shapeType === ShapeType.POLYGON) {
@@ -601,6 +602,7 @@ export function drawShape(
             objectType,
             points,
             activeControl,
+            boxDrawingType
         },
     };
 }

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -6,22 +6,27 @@ import {
     Select,
     Button,
     InputNumber,
+    Radio
 } from 'antd';
 
+import { RadioChangeEvent } from 'antd/lib/radio';
 import Text from 'antd/lib/typography/Text';
 
 import {
     ShapeType,
+    BoxDrawingType
 } from 'reducers/interfaces';
 
 interface Props {
     shapeType: ShapeType;
+    boxDrawingType: BoxDrawingType;
     labels: any[];
     minimumPoints: number;
     numberOfPoints?: number;
     selectedLabeID: number;
     onChangeLabel(value: string): void;
     onChangePoints(value: number | undefined): void;
+    onChangeBoxDrawingType(value: string): void;
     onDrawTrack(): void;
     onDrawShape(): void;
 }
@@ -37,6 +42,7 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
         onDrawShape,
         onChangeLabel,
         onChangePoints,
+        onChangeBoxDrawingType,
     } = props;
 
     return (
@@ -71,7 +77,39 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
                 </Col>
             </Row>
             {
-                shapeType !== ShapeType.RECTANGLE && (
+                shapeType === ShapeType.RECTANGLE ? (
+                    <>
+                        <Row>
+                            <Col>
+                                <Text className='cvat-text-color'> Drawing method </Text>
+                            </Col>
+                        </Row>
+                        <Row type='flex' justify='space-around'>
+                            <Col>
+                                <Radio.Group
+                                    style={{ display: 'flex' }}
+                                    defaultValue={BoxDrawingType.BY_TWO_POINTS}
+                                    onChange={(event: RadioChangeEvent): void => {
+                                        onChangeBoxDrawingType(event.target.value);
+                                    }}
+                                    >
+                                    <Radio
+                                        value={BoxDrawingType.BY_TWO_POINTS}
+                                        style={{ width: 'auto' }}
+                                    >
+                                        By 2 Points
+                                    </Radio>
+                                    <Radio
+                                        value={BoxDrawingType.BY_FOUR_POINTS}
+                                        style={{ width: 'auto' }}
+                                    >
+                                        By 4 Points
+                                    </Radio>
+                                </Radio.Group>
+                            </Col>
+                        </Row>
+                    </>
+                ) : (
                     <Row type='flex' justify='space-around' align='middle'>
                         <Col span={14}>
                             <Text className='cvat-text-color'> Number of points: </Text>

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -6,7 +6,7 @@ import {
     Select,
     Button,
     InputNumber,
-    Radio
+    Radio,
 } from 'antd';
 
 import { RadioChangeEvent } from 'antd/lib/radio';
@@ -14,19 +14,19 @@ import Text from 'antd/lib/typography/Text';
 
 import {
     ShapeType,
-    BoxDrawingType
+    RectDrawingMethod,
 } from 'reducers/interfaces';
 
 interface Props {
     shapeType: ShapeType;
-    boxDrawingType: BoxDrawingType;
+    rectDrawingMethod: RectDrawingMethod;
     labels: any[];
     minimumPoints: number;
     numberOfPoints?: number;
     selectedLabeID: number;
     onChangeLabel(value: string): void;
     onChangePoints(value: number | undefined): void;
-    onChangeBoxDrawingType(value: string): void;
+    onChangeRectDrawingMethod(event: RadioChangeEvent): void;
     onDrawTrack(): void;
     onDrawShape(): void;
 }
@@ -42,7 +42,7 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
         onDrawShape,
         onChangeLabel,
         onChangePoints,
-        onChangeBoxDrawingType,
+        onChangeRectDrawingMethod,
     } = props;
 
     return (
@@ -88,19 +88,17 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
                             <Col>
                                 <Radio.Group
                                     style={{ display: 'flex' }}
-                                    defaultValue={BoxDrawingType.BY_TWO_POINTS}
-                                    onChange={(event: RadioChangeEvent): void => {
-                                        onChangeBoxDrawingType(event.target.value);
-                                    }}
-                                    >
+                                    defaultValue={RectDrawingMethod.BY_TWO_POINTS}
+                                    onChange={onChangeRectDrawingMethod}
+                                >
                                     <Radio
-                                        value={BoxDrawingType.BY_TWO_POINTS}
+                                        value={RectDrawingMethod.BY_TWO_POINTS}
                                         style={{ width: 'auto' }}
                                     >
                                         By 2 Points
                                     </Radio>
                                     <Radio
-                                        value={BoxDrawingType.BY_FOUR_POINTS}
+                                        value={RectDrawingMethod.BY_FOUR_POINTS}
                                         style={{ width: 'auto' }}
                                     >
                                         By 4 Points

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -5,6 +5,7 @@ import {
     CombinedState,
     ShapeType,
     ObjectType,
+    BoxDrawingType
 } from 'reducers/interfaces';
 
 import {
@@ -23,6 +24,7 @@ interface DispatchToProps {
         labelID: number,
         objectType: ObjectType,
         points?: number,
+        boxDrawingType?: string,
     ): void;
 }
 
@@ -39,8 +41,9 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
             labelID: number,
             objectType: ObjectType,
             points?: number,
+            boxDrawingType?: string,
         ): void {
-            dispatch(drawShape(shapeType, labelID, objectType, points));
+            dispatch(drawShape(shapeType, labelID, objectType, points, boxDrawingType));
         },
     };
 }
@@ -67,6 +70,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
 type Props = StateToProps & DispatchToProps;
 
 interface State {
+    boxDrawingType?: string;
     numberOfPoints?: number;
     selectedLabelID: number;
 }
@@ -77,6 +81,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         super(props);
 
         const defaultLabelID = props.labels[0].id;
+        const defaultBoxDrawingType = BoxDrawingType.BY_TWO_POINTS;
         this.state = {
             selectedLabelID: defaultLabelID,
         };
@@ -91,6 +96,9 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         if (shapeType === ShapeType.POINTS) {
             this.minimumPoints = 1;
         }
+        if (shapeType === ShapeType.RECTANGLE) {
+            this.state.boxDrawingType = defaultBoxDrawingType;
+        }
     }
 
     private onDraw(objectType: ObjectType): void {
@@ -101,6 +109,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         } = this.props;
 
         const {
+            boxDrawingType,
             numberOfPoints,
             selectedLabelID,
         } = this.state;
@@ -108,6 +117,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         canvasInstance.cancel();
         canvasInstance.draw({
             enabled: true,
+            boxDrawingType,
             numberOfPoints,
             shapeType,
             crosshair: shapeType === ShapeType.RECTANGLE,
@@ -115,6 +125,12 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
 
         onDrawStart(shapeType, selectedLabelID,
             objectType, numberOfPoints);
+    }
+
+    private onChangeBoxDrawingType = (value: string): void => {
+        this.setState({
+            boxDrawingType: value
+        });
     }
 
     private onDrawShape = (): void => {
@@ -163,6 +179,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
                 numberOfPoints={numberOfPoints}
                 onChangeLabel={this.onChangeLabel}
                 onChangePoints={this.onChangePoints}
+                onChangeBoxDrawingType={this.onChangeBoxDrawingType}
                 onDrawTrack={this.onDrawTrack}
                 onDrawShape={this.onDrawShape}
             />

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { RadioChangeEvent } from 'antd/lib/radio';
 
 import {
     CombinedState,
     ShapeType,
     ObjectType,
-    BoxDrawingType
+    RectDrawingMethod,
 } from 'reducers/interfaces';
 
 import {
@@ -24,7 +25,7 @@ interface DispatchToProps {
         labelID: number,
         objectType: ObjectType,
         points?: number,
-        boxDrawingType?: string,
+        rectDrawingMethod?: string,
     ): void;
 }
 
@@ -41,9 +42,9 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
             labelID: number,
             objectType: ObjectType,
             points?: number,
-            boxDrawingType?: string,
+            rectDrawingMethod?: string,
         ): void {
-            dispatch(drawShape(shapeType, labelID, objectType, points, boxDrawingType));
+            dispatch(drawShape(shapeType, labelID, objectType, points, rectDrawingMethod));
         },
     };
 }
@@ -70,7 +71,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
 type Props = StateToProps & DispatchToProps;
 
 interface State {
-    boxDrawingType?: string;
+    rectDrawingMethod?: string;
     numberOfPoints?: number;
     selectedLabelID: number;
 }
@@ -81,7 +82,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         super(props);
 
         const defaultLabelID = props.labels[0].id;
-        const defaultBoxDrawingType = BoxDrawingType.BY_TWO_POINTS;
+        const defaultRectDrawingMethod = RectDrawingMethod.BY_TWO_POINTS;
         this.state = {
             selectedLabelID: defaultLabelID,
         };
@@ -97,7 +98,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
             this.minimumPoints = 1;
         }
         if (shapeType === ShapeType.RECTANGLE) {
-            this.state.boxDrawingType = defaultBoxDrawingType;
+            this.state.rectDrawingMethod = defaultRectDrawingMethod;
         }
     }
 
@@ -109,7 +110,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         } = this.props;
 
         const {
-            boxDrawingType,
+            rectDrawingMethod,
             numberOfPoints,
             selectedLabelID,
         } = this.state;
@@ -117,7 +118,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         canvasInstance.cancel();
         canvasInstance.draw({
             enabled: true,
-            boxDrawingType,
+            rectDrawingMethod,
             numberOfPoints,
             shapeType,
             crosshair: shapeType === ShapeType.RECTANGLE,
@@ -127,11 +128,11 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
             objectType, numberOfPoints);
     }
 
-    private onChangeBoxDrawingType = (value: string): void => {
+    private onChangeRectDrawingMethod = (event: RadioChangeEvent): void => {
         this.setState({
-            boxDrawingType: value
+            rectDrawingMethod: event.target.value,
         });
-    }
+    };
 
     private onDrawShape = (): void => {
         this.onDraw(ObjectType.SHAPE);
@@ -179,7 +180,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
                 numberOfPoints={numberOfPoints}
                 onChangeLabel={this.onChangeLabel}
                 onChangePoints={this.onChangePoints}
-                onChangeBoxDrawingType={this.onChangeBoxDrawingType}
+                onChangeRectDrawingMethod={this.onChangeRectDrawingMethod}
                 onDrawTrack={this.onDrawTrack}
                 onDrawShape={this.onDrawShape}
             />

--- a/cvat-ui/src/reducers/annotation-reducer.ts
+++ b/cvat-ui/src/reducers/annotation-reducer.ts
@@ -338,6 +338,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                 objectType,
                 points,
                 activeControl,
+                rectDrawingMethod,
             } = action.payload;
 
             return {
@@ -355,6 +356,7 @@ export default (state = defaultState, action: AnyAction): AnnotationState => {
                     activeNumOfPoints: points,
                     activeObjectType: objectType,
                     activeShapeType: shapeType,
+                    activeRectDrawingMethod: rectDrawingMethod,
                 },
             };
         }

--- a/cvat-ui/src/reducers/interfaces.ts
+++ b/cvat-ui/src/reducers/interfaces.ts
@@ -239,6 +239,11 @@ export enum ActiveControl {
     EDIT = 'edit',
 }
 
+export enum BoxDrawingType {
+    BY_TWO_POINTS = 'by_two_points',
+    BY_FOUR_POINTS = 'by_four_points'
+}
+
 export enum ShapeType {
     RECTANGLE = 'rectangle',
     POLYGON = 'polygon',

--- a/cvat-ui/src/reducers/interfaces.ts
+++ b/cvat-ui/src/reducers/interfaces.ts
@@ -239,7 +239,7 @@ export enum ActiveControl {
     EDIT = 'edit',
 }
 
-export enum BoxDrawingType {
+export enum RectDrawingMethod {
     BY_TWO_POINTS = 'by_two_points',
     BY_FOUR_POINTS = 'by_four_points'
 }
@@ -302,6 +302,7 @@ export interface AnnotationState {
     };
     drawing: {
         activeShapeType: ShapeType;
+        activeRectDrawingMethod?: RectDrawingMethod;
         activeNumOfPoints?: number;
         activeLabelID: number;
         activeObjectType: ObjectType;


### PR DESCRIPTION
Hi, 
This is the reimplementation of [extreme clicking](https://arxiv.org/pdf/1708.02750.pdf) (#1111) in new UI with React and Ant Design. `Drawing Method` option is added in rectangle drawing popover. The conventional bbox drawing method (`By 2 Points`) is selected by default. Extreme clicking method is available with `By 4 Points`. Drawing finishes right after the fourth click, as it does in #1111. Here are sample images for this feature.
![aa](https://user-images.githubusercontent.com/19547969/73950778-dabfed80-493f-11ea-8a16-aeca7d308f29.jpg)
![track](https://user-images.githubusercontent.com/19547969/73950808-e7dcdc80-493f-11ea-8ad8-56bdd4093ed0.gif)
