### PR TITLE
Docker compose with webpack

### DIFF
--- a/Dockerfile.dev.ui
+++ b/Dockerfile.dev.ui
@@ -1,7 +1,5 @@
 FROM node:10-alpine
 
-RUN apk update && apk add bash
-
 RUN mkdir -p /tmp/cvat-ui /tmp/cvat-core /tmp/cvat-canvas
 
 # Install dependencies

--- a/Dockerfile.dev.ui
+++ b/Dockerfile.dev.ui
@@ -1,0 +1,22 @@
+FROM node:10-alpine
+
+RUN apk update && apk add bash
+
+RUN mkdir -p /tmp/cvat-ui /tmp/cvat-core /tmp/cvat-canvas
+
+# Install dependencies
+COPY cvat-core/package*.json /tmp/cvat-core/
+COPY cvat-canvas/package*.json /tmp/cvat-canvas/
+COPY cvat-ui/package*.json /tmp/cvat-ui/
+
+# Install cvat-core dependencies
+WORKDIR /tmp/cvat-core/
+RUN npm install
+
+# Install cvat-canvas dependencies
+WORKDIR /tmp/cvat-canvas/
+RUN npm install
+
+# Install cvat-ui dependencies
+WORKDIR /tmp/cvat-ui/
+RUN npm install

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -24,6 +24,7 @@ module.exports = {
         inline: true,
         port: 3000,
         historyApiFallback: true,
+        host: '0.0.0.0',
     },
     resolve: {
         extensions: ['.tsx', '.ts', '.jsx', '.js', '.json'],

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,6 +1,9 @@
 version: "2.3"
 
 services:
+  cvat:
+    environment:
+      UI_PORT: 7081
   cvat_ui:
     image: node:12-alpine
     working_dir: /usr/cvat-ui
@@ -20,6 +23,7 @@ services:
     depends_on:
       - cvat
     ports:
+      - '7081:3000'
       - '3000:3000'
     command: >
       sh -c '

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,34 @@
+version: "2.3"
+
+services:
+  cvat_ui:
+    image: node:12-alpine
+    working_dir: /usr/cvat-ui
+    container_name: cvat_ui
+    restart: always
+    build:
+      context: ./
+      dockerfile: Dockerfile.dev.ui
+    volumes:
+      - ./cvat-ui:/usr/cvat-ui:rw
+      - ./cvat-canvas:/usr/cvat-canvas
+      - ./cvat-core:/usr/cvat-core
+    networks:
+      default:
+        aliases:
+          - ui
+    depends_on:
+      - cvat
+    ports:
+      - '3000:3000'
+    command: >
+      sh -c '
+        if test -d /usr/cvat-ui/node_modules;
+            then echo usr/cvat-ui/node_modules exist;
+        else
+          cp -a /tmp/cvat-ui/node_modules /usr/cvat-ui;
+          cp -a /tmp/cvat-core/node_modules /usr/cvat-core;
+          cp -a /tmp/cvat-canvas/node_modules /usr/cvat-canvas;
+        fi &&
+        npm run start
+      '


### PR DESCRIPTION
I've added dev mode for webpack in docker-compose
Command to run app: `docker-compose -f docker-compose.yml -f docker-compose.dev.yml up`

There is problem with node-sass: it should be compiled for a specific OS. 
It was solved so: 
1. docker installs npm modules in tmp files
1. docker-comopose mount host folders to container (cvat-ui, cvat-core, cvat-canvas)
1. in case when there is no node_modules folder it will be copied from container to local machine (once at first run)