### PR TITLE
[Datumaro] Introduce image info

### DIFF
--- a/cvat/apps/dataset_manager/export_templates/plugins/cvat_rest_api_task_images.py
+++ b/cvat/apps/dataset_manager/export_templates/plugins/cvat_rest_api_task_images.py
@@ -13,7 +13,7 @@ from datumaro.components.config import (Config,
     SchemaBuilder as _SchemaBuilder,
 )
 import datumaro.components.extractor as datumaro
-from datumaro.util.image import lazy_image, load_image
+from datumaro.util.image import lazy_image, load_image, Image
 
 from cvat.utils.cli.core import CLI as CVAT_CLI, CVAT_API_V1
 
@@ -103,8 +103,11 @@ class cvat_rest_api_task_images(datumaro.SourceExtractor):
         items = []
         for entry in image_list:
             item_id = entry['id']
-            item = datumaro.DatasetItem(
-                id=item_id, image=self._make_image_loader(item_id))
+            size = None
+            if entry.get('height') and entry.get('width'):
+                size = (entry['height'], entry['width'])
+            image = Image(data=self._make_image_loader(item_id), size=size)
+            item = datumaro.DatasetItem(id=item_id, image=image)
             items.append((item.id, item))
 
         items = sorted(items, key=lambda e: int(e[0]))

--- a/datumaro/datumaro/cli/contexts/project/__init__.py
+++ b/datumaro/datumaro/cli/contexts/project/__init__.py
@@ -156,15 +156,16 @@ def import_command(args):
     if project_name is None:
         project_name = osp.basename(project_dir)
 
-    extra_args = {}
     try:
         env = Environment()
         importer = env.make_importer(args.format)
-        if hasattr(importer, 'from_cmdline'):
-            extra_args = importer.from_cmdline(args.extra_args)
     except KeyError:
         raise CliException("Importer for format '%s' is not found" % \
             args.format)
+
+    extra_args = {}
+    if hasattr(importer, 'from_cmdline'):
+        extra_args = importer.from_cmdline(args.extra_args)
 
     log.info("Importing project from '%s' as '%s'" % \
         (args.source, args.format))
@@ -293,12 +294,13 @@ def export_command(args):
 
     try:
         converter = project.env.converters.get(args.format)
-        if hasattr(converter, 'from_cmdline'):
-            extra_args = converter.from_cmdline(args.extra_args)
-            converter = converter(**extra_args)
     except KeyError:
         raise CliException("Converter for format '%s' is not found" % \
             args.format)
+
+    if hasattr(converter, 'from_cmdline'):
+        extra_args = converter.from_cmdline(args.extra_args)
+        converter = converter(**extra_args)
 
     filter_args = FilterModes.make_filter_args(args.filter_mode)
 
@@ -559,13 +561,14 @@ def transform_command(args):
             (project.config.project_name, make_file_name(args.transform)))
     dst_dir = osp.abspath(dst_dir)
 
-    extra_args = {}
     try:
         transform = project.env.transforms.get(args.transform)
-        if hasattr(transform, 'from_cmdline'):
-            extra_args = transform.from_cmdline(args.extra_args)
     except KeyError:
         raise CliException("Transform '%s' is not found" % args.transform)
+
+    extra_args = {}
+    if hasattr(transform, 'from_cmdline'):
+        extra_args = transform.from_cmdline(args.extra_args)
 
     log.info("Loading the project...")
     dataset = project.make_dataset()

--- a/datumaro/datumaro/components/dataset_filter.py
+++ b/datumaro/datumaro/components/dataset_filter.py
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 from lxml import etree as ET # NOTE: lxml has proper XPath implementation
-from datumaro.components.extractor import (DatasetItem, Extractor,
+from datumaro.components.extractor import (Transform,
     Annotation, AnnotationType,
     Label, Mask, Points, Polygon, PolyLine, Bbox, Caption,
 )
@@ -218,39 +218,9 @@ def XPathDatasetFilter(extractor, xpath=None):
         DatasetItemEncoder.encode(item, extractor.categories())))
     return extractor.select(f)
 
-class XPathAnnotationsFilter(Extractor): # NOTE: essentially, a transform
-    class ItemWrapper(DatasetItem):
-        def __init__(self, item, annotations):
-            self._item = item
-            self._annotations = annotations
-
-        @DatasetItem.id.getter
-        def id(self):
-            return self._item.id
-
-        @DatasetItem.subset.getter
-        def subset(self):
-            return self._item.subset
-
-        @DatasetItem.path.getter
-        def path(self):
-            return self._item.path
-
-        @DatasetItem.annotations.getter
-        def annotations(self):
-            return self._annotations
-
-        @DatasetItem.has_image.getter
-        def has_image(self):
-            return self._item.has_image
-
-        @DatasetItem.image.getter
-        def image(self):
-            return self._item.image
-
+class XPathAnnotationsFilter(Transform):
     def __init__(self, extractor, xpath=None, remove_empty=False):
-        super().__init__()
-        self._extractor = extractor
+        super().__init__(extractor)
 
         if xpath is not None:
             xpath = ET.XPath(xpath)
@@ -258,24 +228,16 @@ class XPathAnnotationsFilter(Extractor): # NOTE: essentially, a transform
 
         self._remove_empty = remove_empty
 
-    def __len__(self):
-        return len(self._extractor)
-
     def __iter__(self):
         for item in self._extractor:
-            item = self._filter_item(item)
+            item = self.transform_item(item)
             if item is not None:
                 yield item
 
-    def subsets(self):
-        return self._extractor.subsets()
-
-    def categories(self):
-        return self._extractor.categories()
-
-    def _filter_item(self, item):
+    def transform_item(self, item):
         if self._filter is None:
             return item
+
         encoded = DatasetItemEncoder.encode(item, self._extractor.categories())
         filtered = self._filter(encoded)
         filtered = [elem for elem in filtered if elem.tag == 'annotation']
@@ -285,4 +247,4 @@ class XPathAnnotationsFilter(Extractor): # NOTE: essentially, a transform
 
         if self._remove_empty and len(annotations) == 0:
             return None
-        return self.ItemWrapper(item, annotations)
+        return self.wrap_item(item, annotations=annotations)

--- a/datumaro/datumaro/components/dataset_filter.py
+++ b/datumaro/datumaro/components/dataset_filter.py
@@ -31,11 +31,12 @@ class DatasetItemEncoder:
     def encode_image(cls, image):
         image_elem = ET.Element('image')
 
-        h, w = image.shape[:2]
-        c = 1 if len(image.shape) == 2 else image.shape[2]
+        h, w = image.size
         ET.SubElement(image_elem, 'width').text = str(w)
         ET.SubElement(image_elem, 'height').text = str(h)
-        ET.SubElement(image_elem, 'depth').text = str(c)
+
+        ET.SubElement(image_elem, 'has_data').text = '%d' % int(image.has_data)
+        ET.SubElement(image_elem, 'path').text = image.path
 
         return image_elem
 
@@ -81,10 +82,6 @@ class DatasetItemEncoder:
         ET.SubElement(ann_elem, 'label').text = \
             str(cls._get_label(obj.label, categories))
         ET.SubElement(ann_elem, 'label_id').text = str(obj.label)
-
-        mask = obj.image
-        if mask is not None:
-            ann_elem.append(cls.encode_image(mask))
 
         return ann_elem
 

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -637,6 +637,16 @@ class DatasetItem:
             (self.has_image and np.array_equal(self.image, other.image) or \
                 not self.has_image)
 
+    def wrap(item, **kwargs):
+        expected_args = {'id', 'annotations', 'subset', 'path', 'image'}
+        for k in expected_args:
+            if k not in kwargs:
+                if k == 'image' and item.has_image:
+                    kwargs[k] = lambda: item.image
+                else:
+                    kwargs[k] = getattr(item, k)
+        return DatasetItem(**kwargs)
+
 class IExtractor:
     def __iter__(self):
         raise NotImplementedError()
@@ -741,16 +751,9 @@ class Importer:
         raise NotImplementedError()
 
 class Transform(Extractor):
-    @classmethod
-    def wrap_item(cls, item, **kwargs):
-        expected_args = {'id', 'annotations', 'subset', 'path', 'image'}
-        for k in expected_args:
-            if k not in kwargs:
-                if k == 'image' and item.has_image:
-                    kwargs[k] = lambda: item.image
-                else:
-                    kwargs[k] = getattr(item, k)
-        return DatasetItem(**kwargs)
+    @staticmethod
+    def wrap_item(item, **kwargs):
+        return item.wrap(**kwargs)
 
     def __init__(self, extractor):
         super().__init__()

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -576,18 +576,10 @@ class Caption(Annotation):
 
 class DatasetItem:
     # pylint: disable=redefined-builtin
-    def __init__(self, id, annotations=None,
-            subset=None, path=None, image=None, name=None):
+    def __init__(self, id=None, annotations=None,
+            subset=None, path=None, image=None):
         assert id is not None
-        id = str(id)
-        # TODO: if not isinstance(id, int):
-        #     id = int(id)
-        self._id = id
-
-        assert name is None or isinstance(name, str)
-        if not name:
-            name = str(id)
-        self._name = name
+        self._id = str(id)
 
         if subset is None:
             subset = ''
@@ -609,6 +601,8 @@ class DatasetItem:
 
         if callable(image) or isinstance(image, np.ndarray):
             image = Image(data=image)
+        elif isinstance(image, str):
+            image = Image(path=image)
         assert image is None or isinstance(image, Image)
         self._image = image
     # pylint: enable=redefined-builtin
@@ -616,10 +610,6 @@ class DatasetItem:
     @property
     def id(self):
         return self._id
-
-    @property
-    def name(self):
-        return self._name
 
     @property
     def subset(self):
@@ -647,12 +637,12 @@ class DatasetItem:
         return \
             (self.id == other.id) and \
             (self.subset == other.subset) and \
-            (self.annotations == other.annotations) and \
             (self.path == other.path) and \
+            (self.annotations == other.annotations) and \
             (self.image == other.image)
 
     def wrap(item, **kwargs):
-        expected_args = {'id', 'annotations', 'subset', 'path', 'image', 'name'}
+        expected_args = {'id', 'annotations', 'subset', 'path', 'image'}
         for k in expected_args:
             if k not in kwargs:
                 kwargs[k] = getattr(item, k)
@@ -675,9 +665,6 @@ class IExtractor:
         raise NotImplementedError()
 
     def select(self, pred):
-        raise NotImplementedError()
-
-    def get(self, item_id, subset=None, path=None):
         raise NotImplementedError()
 
 class _DatasetFilter:

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -414,7 +414,7 @@ class Dataset(Extractor):
             elif current_item.image.has_data:
                 image = current_item.image
         elif existing_item.has_image:
-            image = existing_item
+            image = existing_item.image
         elif current_item.has_image:
             image = current_item.image
 

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -302,45 +302,6 @@ class Subset(Extractor):
     def categories(self):
         return self._parent.categories()
 
-class DatasetItemWrapper(DatasetItem):
-    def __init__(self, item, path, annotations, image=None):
-        self._item = item
-        if path is None:
-            path = []
-        self._path = path
-        self._annotations = annotations
-        self._image = image
-
-    @DatasetItem.id.getter
-    def id(self):
-        return self._item.id
-
-    @DatasetItem.subset.getter
-    def subset(self):
-        return self._item.subset
-
-    @DatasetItem.path.getter
-    def path(self):
-        return self._path
-
-    @DatasetItem.annotations.getter
-    def annotations(self):
-        return self._annotations
-
-    @DatasetItem.has_image.getter
-    def has_image(self):
-        if self._image is not None:
-            return True
-        return self._item.has_image
-
-    @DatasetItem.image.getter
-    def image(self):
-        if self._image is not None:
-            if callable(self._image):
-                return self._image()
-            return self._image
-        return self._item.image
-
 class Dataset(Extractor):
     @classmethod
     def from_extractors(cls, *sources):
@@ -369,12 +330,11 @@ class Dataset(Extractor):
                         # TODO: think of image comparison
                         image = cls._lazy_image(existing_item)
 
-                    item = DatasetItemWrapper(item=item, path=path,
+                    item = item.wrap(path=path,
                         image=image, annotations=self._merge_anno(
                             existing_item.annotations, item.annotations))
                 else:
-                    item = DatasetItemWrapper(item=item, path=path,
-                        annotations=item.annotations)
+                    item = item.wrap(path=path, annotations=item.annotations)
 
                 subsets[item.subset].items[item.id] = item
 
@@ -423,8 +383,7 @@ class Dataset(Extractor):
         if subset is None:
             subset = item.subset
 
-        item = DatasetItemWrapper(item=item, path=None,
-            annotations=item.annotations)
+        item = item.wrap(path=None, annotations=item.annotations)
         if item.subset not in self._subsets:
             self._subsets[item.subset] = Subset(self)
         self._subsets[subset].items[item_id] = item
@@ -528,7 +487,7 @@ class ProjectDataset(Dataset):
                     path = existing_item.path
                     if item.path != path:
                         path = None # NOTE: move to our own dataset
-                    item = DatasetItemWrapper(item=item, path=path,
+                    item = item.wrap(path=path,
                         image=image, annotations=self._merge_anno(
                             existing_item.annotations, item.annotations))
                 else:
@@ -542,8 +501,7 @@ class ProjectDataset(Dataset):
                         if path is None:
                             path = []
                         path = [source_name] + path
-                    item = DatasetItemWrapper(item=item, path=path,
-                        annotations=item.annotations)
+                    item = item.wrap(path=path, annotations=item.annotations)
 
                 subsets[item.subset].items[item.id] = item
 
@@ -558,7 +516,7 @@ class ProjectDataset(Dataset):
                         if existing_item.has_image:
                             # TODO: think of image comparison
                             image = self._lazy_image(existing_item)
-                        item = DatasetItemWrapper(item=item, path=None,
+                        item = item.wrap(path=None,
                             annotations=item.annotations, image=image)
 
                 subsets[item.subset].items[item.id] = item
@@ -597,8 +555,7 @@ class ProjectDataset(Dataset):
         if subset is None:
             subset = item.subset
 
-        item = DatasetItemWrapper(item=item, path=path,
-            annotations=item.annotations)
+        item = item.wrap(path=path, annotations=item.annotations)
         if item.subset not in self._subsets:
             self._subsets[item.subset] = Subset(self)
         self._subsets[subset].items[item_id] = item

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -411,11 +411,22 @@ class Dataset(Extractor):
         if existing_item.has_image and current_item.has_image:
             if existing_item.image.has_data:
                 image = existing_item.image
-            elif current_item.image.has_data:
+            else:
                 image = current_item.image
+
+            if existing_item.image.path != current_item.image.path:
+                if not existing_item.image.path:
+                    image._path = current_item.image.path
+
+            if all([existing_item.image._size, current_item.image._size]):
+                assert existing_item.image._size == current_item.image._size, "Image info differs for item '%s'" % item.id
+            elif existing_item.image._size:
+                image._size = existing_item.image._size
+            else:
+                image._size = current_item.image._size
         elif existing_item.has_image:
             image = existing_item.image
-        elif current_item.has_image:
+        else:
             image = current_item.image
 
         return existing_item.wrap(path=path,

--- a/datumaro/datumaro/plugins/coco_format/converter.py
+++ b/datumaro/datumaro/plugins/coco_format/converter.py
@@ -547,7 +547,7 @@ class _Converter:
         filename += CocoPath.IMAGE_EXT
         path = osp.join(self._images_dir, filename)
         save_image(path, image)
-        return path
+        return filename
 
     def convert(self):
         self._make_dirs()

--- a/datumaro/datumaro/plugins/coco_format/extractor.py
+++ b/datumaro/datumaro/plugins/coco_format/extractor.py
@@ -15,7 +15,7 @@ from datumaro.components.extractor import (SourceExtractor,
     AnnotationType, Label, RleMask, Points, Polygon, Bbox, Caption,
     LabelCategories, PointsCategories
 )
-from datumaro.util.image import lazy_image
+from datumaro.util.image import Image
 
 from .format import CocoTask, CocoPath
 
@@ -117,7 +117,15 @@ class _CocoExtractor(SourceExtractor):
 
         for img_id in loader.getImgIds():
             image_info = loader.loadImgs(img_id)[0]
-            image = self._find_image(image_info['file_name'])
+            image_path = self._find_image(image_info['file_name'])
+            if not image_path:
+                image_path = image_info['file_name']
+            image_size = (image_info.get('height'), image_info.get('width'))
+            if all(image_size):
+                image_size = (int(image_size[0]), int(image_size[1]))
+            else:
+                image_size = None
+            image = Image(path=image_path, size=image_size)
 
             anns = loader.getAnnIds(imgIds=img_id)
             anns = loader.loadAnns(anns)
@@ -232,7 +240,8 @@ class _CocoExtractor(SourceExtractor):
         ]
         for image_path in search_paths:
             if osp.exists(image_path):
-                return lazy_image(image_path)
+                return image_path
+        return None
 
 class CocoImageInfoExtractor(_CocoExtractor):
     def __init__(self, path, **kwargs):

--- a/datumaro/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/datumaro/plugins/cvat_format/extractor.py
@@ -12,7 +12,7 @@ from datumaro.components.extractor import (SourceExtractor,
     AnnotationType, Points, Polygon, PolyLine, Bbox,
     LabelCategories
 )
-from datumaro.util.image import lazy_image
+from datumaro.util.image import Image
 
 from .format import CvatPath
 
@@ -67,7 +67,7 @@ class CvatExtractor(SourceExtractor):
         context = ET.ElementTree.iterparse(path, events=("start", "end"))
         context = iter(context)
 
-        categories = cls._parse_meta(context)
+        categories, frame_size = cls._parse_meta(context)
 
         items = OrderedDict()
 
@@ -81,11 +81,15 @@ class CvatExtractor(SourceExtractor):
                         'id': el.attrib.get('id'),
                         'label': el.attrib.get('label'),
                         'group': int(el.attrib.get('group_id', 0)),
+                        'height': frame_size[0],
+                        'width': frame_size[1],
                     }
                 elif el.tag == 'image':
                     image = {
                         'name': el.attrib.get('name'),
                         'frame': el.attrib['id'],
+                        'width': el.attrib.get('width'),
+                        'height': el.attrib.get('height'),
                     }
                 elif el.tag in cls._SUPPORTED_SHAPES and (track or image):
                     shape = {
@@ -130,10 +134,7 @@ class CvatExtractor(SourceExtractor):
                         for pair in el.attrib['points'].split(';'):
                             shape['points'].extend(map(float, pair.split(',')))
 
-                    frame_desc = items.get(shape['frame'], {
-                        'name': shape.get('name'),
-                        'annotations': [],
-                    })
+                    frame_desc = items.get(shape['frame'], {'annotations': []})
                     frame_desc['annotations'].append(
                         cls._parse_ann(shape, categories))
                     items[shape['frame']] = frame_desc
@@ -142,6 +143,13 @@ class CvatExtractor(SourceExtractor):
                 elif el.tag == 'track':
                     track = None
                 elif el.tag == 'image':
+                    frame_desc = items.get(image['frame'], {'annotations': []})
+                    frame_desc.update({
+                        'name': image.get('name'),
+                        'height': image.get('height'),
+                        'width': image.get('width'),
+                    })
+                    items[image['frame']] = frame_desc
                     image = None
                 el.clear()
 
@@ -155,6 +163,7 @@ class CvatExtractor(SourceExtractor):
 
         categories = {}
 
+        frame_size = None
         has_z_order = False
         mode = 'annotation'
         labels = OrderedDict()
@@ -183,6 +192,10 @@ class CvatExtractor(SourceExtractor):
                 if accepted('annotations', 'meta'): pass
                 elif accepted('meta', 'task'): pass
                 elif accepted('task', 'z_order'): pass
+                elif accepted('task', 'original_size'):
+                    frame_size = [None, None]
+                elif accepted('original_size', 'height', next_state='frame_height'): pass
+                elif accepted('original_size', 'width', next_state='frame_width'): pass
                 elif accepted('task', 'labels'): pass
                 elif accepted('labels', 'label'):
                     label = { 'name': None, 'attributes': set() }
@@ -202,6 +215,11 @@ class CvatExtractor(SourceExtractor):
                 elif consumed('task', 'task'): pass
                 elif consumed('z_order', 'z_order'):
                     has_z_order = (el.text == 'True')
+                elif consumed('original_size', 'original_size'): pass
+                elif consumed('frame_height', 'height'):
+                    frame_size[0] = int(el.text)
+                elif consumed('frame_width', 'width'):
+                    frame_size[1] = int(el.text)
                 elif consumed('label_name', 'name'):
                     label['name'] = el.text
                 elif consumed('attr_name', 'name'):
@@ -231,7 +249,7 @@ class CvatExtractor(SourceExtractor):
 
         categories[AnnotationType.label] = label_cat
 
-        return categories
+        return categories, frame_size
 
     @classmethod
     def _parse_ann(cls, ann, categories):
@@ -278,26 +296,37 @@ class CvatExtractor(SourceExtractor):
 
     def _load_items(self, parsed):
         for item_id, item_desc in parsed.items():
+            image = None
             file_name = item_desc.get('name')
             if not file_name:
                 file_name = item_id
-            image = self._find_image(file_name)
+            image_path = self._find_image(file_name)
+            image_size = (item_desc.get('height'), item_desc.get('width'))
+            if all(image_size):
+                image_size = (int(image_size[0]), int(image_size[1]))
+            else:
+                image_size = None
+            if image_path:
+                image = Image(path=image_path, size=image_size)
+            elif image_size:
+                image = Image(size=image_size)
 
             parsed[item_id] = DatasetItem(id=item_id, subset=self._subset,
-                image=image, annotations=item_desc.get('annotations', None))
+                image=image, annotations=item_desc.get('annotations'))
         return parsed
 
     def _find_image(self, file_name):
-        search_paths = [
-            osp.join(osp.dirname(self._path), file_name)
-        ]
+        search_paths = []
         if self._images_dir:
             search_paths += [
                 osp.join(self._images_dir, file_name),
                 osp.join(self._images_dir, self._subset or DEFAULT_SUBSET_NAME,
                     file_name),
             ]
+        search_paths += [
+            osp.join(osp.dirname(self._path), file_name)
+        ]
         for image_path in search_paths:
             if osp.isfile(image_path):
-                return lazy_image(image_path)
+                return image_path
         return None

--- a/datumaro/datumaro/plugins/cvat_format/extractor.py
+++ b/datumaro/datumaro/plugins/cvat_format/extractor.py
@@ -295,23 +295,22 @@ class CvatExtractor(SourceExtractor):
             raise NotImplementedError("Unknown annotation type '%s'" % ann_type)
 
     def _load_items(self, parsed):
-        for item_id, item_desc in parsed.items():
-            image = None
-            file_name = item_desc.get('name')
-            if not file_name:
-                file_name = item_id
-            image_path = self._find_image(file_name)
+        for frame_id, item_desc in parsed.items():
+            filename = item_desc.get('name')
+            if filename:
+                filename = self._find_image(filename)
+            if not filename:
+                filename = item_desc.get('name')
             image_size = (item_desc.get('height'), item_desc.get('width'))
             if all(image_size):
                 image_size = (int(image_size[0]), int(image_size[1]))
             else:
                 image_size = None
-            if image_path:
-                image = Image(path=image_path, size=image_size)
-            elif image_size:
-                image = Image(size=image_size)
+            image = None
+            if filename:
+                image = Image(path=filename, size=image_size)
 
-            parsed[item_id] = DatasetItem(id=item_id, subset=self._subset,
+            parsed[frame_id] = DatasetItem(id=frame_id, subset=self._subset,
                 image=image, annotations=item_desc.get('annotations'))
         return parsed
 

--- a/datumaro/datumaro/plugins/datumaro_format/converter.py
+++ b/datumaro/datumaro/plugins/datumaro_format/converter.py
@@ -58,6 +58,11 @@ class _SubsetWriter:
         }
         if item.path:
             item_desc['path'] = item.path
+        if item.has_image:
+            item_desc['image'] = {
+                'size': item.image.size,
+                'path': item.image.path,
+            }
         self.items.append(item_desc)
 
         for ann in item.annotations:
@@ -226,7 +231,7 @@ class _SubsetWriter:
         return converted
 
 class _Converter:
-    def __init__(self, extractor, save_dir, save_images=False,):
+    def __init__(self, extractor, save_dir, save_images=False):
         self._extractor = extractor
         self._save_dir = save_dir
         self._save_images = save_images
@@ -258,14 +263,15 @@ class _Converter:
             writer = subsets[subset]
 
             if self._save_images:
-                self._save_image(item)
+                if item.has_image:
+                    self._save_image(item)
             writer.write_item(item)
 
         for subset, writer in subsets.items():
             writer.write(annotations_dir)
 
     def _save_image(self, item):
-        image = item.image
+        image = item.image.data
         if image is None:
             return
 

--- a/datumaro/datumaro/plugins/datumaro_format/converter.py
+++ b/datumaro/datumaro/plugins/datumaro_format/converter.py
@@ -30,9 +30,9 @@ def _cast(value, type_conv, default=None):
         return default
 
 class _SubsetWriter:
-    def __init__(self, name, converter):
+    def __init__(self, name, context):
         self._name = name
-        self._converter = converter
+        self._context = context
 
         self._data = {
             'info': {},
@@ -59,9 +59,13 @@ class _SubsetWriter:
         if item.path:
             item_desc['path'] = item.path
         if item.has_image:
+            path = item.image.path
+            if self._context._save_images:
+                path = self._context._save_image(item)
+
             item_desc['image'] = {
                 'size': item.image.size,
-                'path': item.image.path,
+                'path': path,
             }
         self.items.append(item_desc)
 
@@ -128,7 +132,7 @@ class _SubsetWriter:
         self._next_mask_id += 1
 
         filename = '%d%s' % (mask_id, DatumaroPath.MASK_EXT)
-        masks_dir = osp.join(self._converter._annotations_dir,
+        masks_dir = osp.join(self._context._annotations_dir,
             DatumaroPath.MASKS_DIR)
         os.makedirs(masks_dir, exist_ok=True)
         path = osp.join(masks_dir, filename)
@@ -262,9 +266,6 @@ class _Converter:
                 subset = DEFAULT_SUBSET_NAME
             writer = subsets[subset]
 
-            if self._save_images:
-                if item.has_image:
-                    self._save_image(item)
             writer.write_item(item)
 
         for subset, writer in subsets.items():
@@ -273,11 +274,17 @@ class _Converter:
     def _save_image(self, item):
         image = item.image.data
         if image is None:
-            return
+            return ''
 
-        image_path = osp.join(self._images_dir,
-            str(item.id) + DatumaroPath.IMAGE_EXT)
+        filename = item.image.filename
+        if filename:
+            filename = osp.splitext(filename)[0]
+        else:
+            filename = item.id
+        filename += DatumaroPath.IMAGE_EXT
+        image_path = osp.join(self._images_dir, filename)
         save_image(image_path, image)
+        return filename
 
 class DatumaroConverter(Converter, CliPlugin):
     @classmethod

--- a/datumaro/datumaro/plugins/datumaro_format/extractor.py
+++ b/datumaro/datumaro/plugins/datumaro_format/extractor.py
@@ -12,7 +12,7 @@ from datumaro.components.extractor import (SourceExtractor,
     AnnotationType, Label, Mask, Points, Polygon, PolyLine, Bbox, Caption,
     LabelCategories, MaskCategories, PointsCategories
 )
-from datumaro.util.image import lazy_image
+from datumaro.util.image import Image
 from datumaro.util.mask_tools import lazy_mask
 
 from .format import DatumaroPath
@@ -93,11 +93,20 @@ class DatumaroExtractor(SourceExtractor):
         items = []
         for item_desc in parsed['items']:
             item_id = item_desc['id']
+
             image = None
-            image_path = osp.join(self._path, DatumaroPath.IMAGES_DIR,
-                item_id + DatumaroPath.IMAGE_EXT)
-            if osp.exists(image_path):
-                image = lazy_image(image_path)
+            image_info = item_desc.get('image', {})
+            if image_info.get('path'):
+                image_path = osp.join(self._path, DatumaroPath.IMAGES_DIR,
+                    image_info['path'])
+            else:
+                image_path = osp.join(self._path, DatumaroPath.IMAGES_DIR,
+                    item_id + DatumaroPath.IMAGE_EXT)
+            image_size = image_info.get('size')
+            if osp.isfile(image_path):
+                image = Image(path=image_path, size=image_size)
+            elif image_size:
+                image = Image(size=image_size)
 
             annotations = self._load_annotations(item_desc)
 

--- a/datumaro/datumaro/plugins/datumaro_format/extractor.py
+++ b/datumaro/datumaro/plugins/datumaro_format/extractor.py
@@ -96,17 +96,10 @@ class DatumaroExtractor(SourceExtractor):
 
             image = None
             image_info = item_desc.get('image', {})
-            if image_info.get('path'):
+            if image_info:
                 image_path = osp.join(self._path, DatumaroPath.IMAGES_DIR,
-                    image_info['path'])
-            else:
-                image_path = osp.join(self._path, DatumaroPath.IMAGES_DIR,
-                    item_id + DatumaroPath.IMAGE_EXT)
-            image_size = image_info.get('size')
-            if osp.isfile(image_path):
-                image = Image(path=image_path, size=image_size)
-            elif image_size:
-                image = Image(size=image_size)
+                    image_info.get('path', '')) # relative or absolute fits
+                image = Image(path=image_path, size=image_info.get('size'))
 
             annotations = self._load_annotations(item_desc)
 

--- a/datumaro/datumaro/plugins/image_dir.py
+++ b/datumaro/datumaro/plugins/image_dir.py
@@ -9,7 +9,7 @@ import os.path as osp
 
 from datumaro.components.extractor import DatasetItem, SourceExtractor, Importer
 from datumaro.components.converter import Converter
-from datumaro.util.image import lazy_image, save_image
+from datumaro.util.image import save_image
 
 
 class ImageDirImporter(Importer):
@@ -45,7 +45,7 @@ class ImageDirExtractor(SourceExtractor):
             path = osp.join(url, name)
             if self._is_image(path):
                 item_id = osp.splitext(name)[0]
-                item = DatasetItem(id=item_id, image=lazy_image(path))
+                item = DatasetItem(id=item_id, image=path)
                 items.append((item.id, item))
 
         items = sorted(items, key=lambda e: e[0])
@@ -82,8 +82,10 @@ class ImageDirConverter(Converter):
 
         for item in extractor:
             if item.has_image and item.image.has_data:
-                file_name = item.name
-                if not file_name:
-                    file_name = str(item.id)
-                file_name += '.jpg'
-                save_image(osp.join(save_dir, file_name), item.image.data)
+                filename = item.image.filename
+                if filename:
+                    filename = osp.splitext(filename)[0]
+                else:
+                    filename = item.id
+                filename += '.jpg'
+                save_image(osp.join(save_dir, filename), item.image.data)

--- a/datumaro/datumaro/plugins/image_dir.py
+++ b/datumaro/datumaro/plugins/image_dir.py
@@ -8,7 +8,8 @@ import os
 import os.path as osp
 
 from datumaro.components.extractor import DatasetItem, SourceExtractor, Importer
-from datumaro.util.image import lazy_image
+from datumaro.components.converter import Converter
+from datumaro.util.image import lazy_image, save_image
 
 
 class ImageDirImporter(Importer):
@@ -73,3 +74,16 @@ class ImageDirExtractor(SourceExtractor):
             if osp.isfile(path) and path.endswith(ext):
                 return True
         return False
+
+
+class ImageDirConverter(Converter):
+    def __call__(self, extractor, save_dir):
+        os.makedirs(save_dir, exist_ok=True)
+
+        for item in extractor:
+            if item.has_image and item.image.has_data:
+                file_name = item.name
+                if not file_name:
+                    file_name = str(item.id)
+                file_name += '.jpg'
+                save_image(osp.join(save_dir, file_name), item.image.data)

--- a/datumaro/datumaro/plugins/transforms.py
+++ b/datumaro/datumaro/plugins/transforms.py
@@ -28,7 +28,7 @@ class CropCoveredSegments(Transform, CliPlugin):
 
         if not item.has_image:
             raise Exception("Image info is required for this transform")
-        h, w = item.image.shape[:2]
+        h, w = item.image.size
         segments = self.crop_segments(segments, w, h)
 
         annotations += segments
@@ -107,7 +107,7 @@ class MergeInstanceSegments(Transform, CliPlugin):
 
         if not item.has_image:
             raise Exception("Image info is required for this transform")
-        h, w = item.image.shape[:2]
+        h, w = item.image.size
         instances = self.find_instances(segments)
         segments = [self.merge_segments(i, w, h, self._include_polygons)
             for i in instances]
@@ -196,7 +196,7 @@ class PolygonsToMasks(Transform, CliPlugin):
             if ann.type == AnnotationType.polygon:
                 if not item.has_image:
                     raise Exception("Image info is required for this transform")
-                h, w = item.image.shape[:2]
+                h, w = item.image.size
                 annotations.append(self.convert_polygon(ann, h, w))
             else:
                 annotations.append(ann)

--- a/datumaro/datumaro/plugins/transforms.py
+++ b/datumaro/datumaro/plugins/transforms.py
@@ -5,6 +5,7 @@
 
 from itertools import groupby
 import logging as log
+import os.path as osp
 
 import pycocotools.mask as mask_utils
 
@@ -273,7 +274,6 @@ class Reindex(Transform, CliPlugin):
         for i, item in enumerate(self._extractor):
             yield self.wrap_item(item, id=i + self._start)
 
-
 class MapSubsets(Transform, CliPlugin):
     @staticmethod
     def _mapping_arg(s):
@@ -303,3 +303,10 @@ class MapSubsets(Transform, CliPlugin):
     def transform_item(self, item):
         return self.wrap_item(item,
             subset=self._mapping.get(item.subset, item.subset))
+
+class IdFromImageName(Transform, CliPlugin):
+    def transform_item(self, item):
+        name = item.id
+        if item.has_image and item.image.filename:
+            name = osp.splitext(item.image.filename)[0]
+        return self.wrap_item(item, id=name)

--- a/datumaro/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/datumaro/plugins/voc_format/converter.py
@@ -135,10 +135,17 @@ class _Converter:
             for item in subset:
                 log.debug("Converting item '%s'", item.id)
 
+                image_filename = ''
+                if item.has_image:
+                    image_filename = item.image.filename
                 if self._save_images:
                     if item.has_image and item.image.has_data:
-                        save_image(osp.join(self._images_dir,
-                                item.id + VocPath.IMAGE_EXT),
+                        if image_filename:
+                            image_filename = osp.splitext(image_filename)[0]
+                        else:
+                            image_filename = item.id
+                        image_filename += VocPath.IMAGE_EXT
+                        save_image(osp.join(self._images_dir, image_filename),
                             item.image.data)
                     else:
                         log.debug("Item '%s' has no image" % item.id)
@@ -161,8 +168,7 @@ class _Converter:
                     else:
                         folder = ''
                     ET.SubElement(root_elem, 'folder').text = folder
-                    ET.SubElement(root_elem, 'filename').text = \
-                        item.id + VocPath.IMAGE_EXT
+                    ET.SubElement(root_elem, 'filename').text = image_filename
 
                     source_elem = ET.SubElement(root_elem, 'source')
                     ET.SubElement(source_elem, 'database').text = 'Unknown'

--- a/datumaro/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/datumaro/plugins/voc_format/converter.py
@@ -170,9 +170,12 @@ class _Converter:
                     ET.SubElement(source_elem, 'image').text = 'Unknown'
 
                     if item.has_image:
-                        image_shape = item.image.shape
-                        h, w = image_shape[:2]
-                        c = 1 if len(image_shape) == 2 else image_shape[2]
+                        h, w = item.image.size
+                        if item.image.has_data:
+                            image_shape = item.image.data.shape
+                            c = 1 if len(image_shape) == 2 else image_shape[2]
+                        else:
+                            c = 3
                         size_elem = ET.SubElement(root_elem, 'size')
                         ET.SubElement(size_elem, 'width').text = str(w)
                         ET.SubElement(size_elem, 'height').text = str(h)

--- a/datumaro/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/datumaro/plugins/voc_format/converter.py
@@ -136,10 +136,10 @@ class _Converter:
                 log.debug("Converting item '%s'", item.id)
 
                 if self._save_images:
-                    if item.has_image:
+                    if item.has_image and item.image.has_data:
                         save_image(osp.join(self._images_dir,
                                 item.id + VocPath.IMAGE_EXT),
-                            item.image)
+                            item.image.data)
                     else:
                         log.debug("Item '%s' has no image" % item.id)
 
@@ -467,7 +467,8 @@ class _Converter:
     def _make_label_id_map(self):
         source_labels = {
             id: label.name for id, label in
-            enumerate(self._extractor.categories()[AnnotationType.label].items)
+            enumerate(self._extractor.categories().get(
+                AnnotationType.label, LabelCategories()).items)
         }
         target_labels = {
             label.name: id for id, label in

--- a/datumaro/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/datumaro/plugins/voc_format/converter.py
@@ -511,7 +511,11 @@ class VocConverter(Converter, CliPlugin):
     def _get_labelmap(s):
         if osp.isfile(s):
             return s
-        return LabelmapType[s].name
+        try:
+            return LabelmapType[s].name
+        except KeyError:
+            import argparse
+            raise argparse.ArgumentTypeError()
 
     @classmethod
     def build_cmdline_parser(cls, **kwargs):

--- a/datumaro/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/datumaro/plugins/voc_format/extractor.py
@@ -86,6 +86,8 @@ class VocExtractor(SourceExtractor):
                 ann_file_data = f.read()
                 ann_file_root = ET.fromstring(ann_file_data)
                 item = ann_file_root.find('filename').text
+                if not item:
+                    item = ann_item
                 item = osp.splitext(item)[0]
                 det_annotations[item] = ann_file_data
 
@@ -130,11 +132,8 @@ class VocExtractor(SourceExtractor):
                 yield item
 
     def _get(self, item_id, subset_name):
-        image = None
-        image_path = osp.join(self._path, VocPath.IMAGES_DIR,
+        image = osp.join(self._path, VocPath.IMAGES_DIR,
             item_id + VocPath.IMAGE_EXT)
-        if osp.isfile(image_path):
-            image = lazy_image(image_path)
 
         annotations = self._get_annotations(item_id)
 

--- a/datumaro/datumaro/plugins/yolo_format/converter.py
+++ b/datumaro/datumaro/plugins/yolo_format/converter.py
@@ -80,12 +80,16 @@ class YoloConverter(Converter, CliPlugin):
                     osp.basename(subset_dir), image_name)
 
                 if self._save_images:
-                    if item.has_image:
-                        save_image(osp.join(subset_dir, image_name), item.image)
+                    if item.has_image and item.image.has_data:
+                        save_image(osp.join(subset_dir, image_name),
+                            item.image.data)
                     else:
-                        log.debug("Item '%s' has no images" % item.id)
+                        log.warning("Item '%s' has no image" % item.id)
 
-                height, width = item.image.shape[:2]
+                if not item.has_image:
+                    raise Exception("Failed to export item '%s': "
+                        "item has no image info" % item.id)
+                height, width = item.image.size
 
                 yolo_annotation = ''
                 for bbox in item.annotations:

--- a/datumaro/datumaro/plugins/yolo_format/converter.py
+++ b/datumaro/datumaro/plugins/yolo_format/converter.py
@@ -75,21 +75,24 @@ class YoloConverter(Converter, CliPlugin):
             image_paths = OrderedDict()
 
             for item in subset:
-                image_name = '%s.jpg' % item.id
-                image_paths[item.id] = osp.join('data',
-                    osp.basename(subset_dir), image_name)
-
-                if self._save_images:
-                    if item.has_image and item.image.has_data:
-                        save_image(osp.join(subset_dir, image_name),
-                            item.image.data)
-                    else:
-                        log.warning("Item '%s' has no image" % item.id)
-
                 if not item.has_image:
                     raise Exception("Failed to export item '%s': "
                         "item has no image info" % item.id)
                 height, width = item.image.size
+
+                image_name = item.image.filename
+                item_name = osp.splitext(item.image.filename)[0]
+                if self._save_images:
+                    if item.has_image and item.image.has_data:
+                        if not item_name:
+                            item_name = item.id
+                        image_name = item_name + '.jpg'
+                        save_image(osp.join(subset_dir, image_name),
+                            item.image.data)
+                    else:
+                        log.warning("Item '%s' has no image" % item.id)
+                image_paths[item.id] = osp.join('data',
+                    osp.basename(subset_dir), image_name)
 
                 yolo_annotation = ''
                 for bbox in item.annotations:
@@ -102,7 +105,7 @@ class YoloConverter(Converter, CliPlugin):
                     yolo_bb = ' '.join('%.6f' % p for p in yolo_bb)
                     yolo_annotation += '%s %s\n' % (bbox.label, yolo_bb)
 
-                annotation_path = osp.join(subset_dir, '%s.txt' % item.id)
+                annotation_path = osp.join(subset_dir, '%s.txt' % item_name)
                 with open(annotation_path, 'w') as f:
                     f.write(yolo_annotation)
 

--- a/datumaro/datumaro/plugins/yolo_format/format.py
+++ b/datumaro/datumaro/plugins/yolo_format/format.py
@@ -7,3 +7,5 @@
 class YoloPath:
     DEFAULT_SUBSET_NAME = 'train'
     SUBSET_NAMES = ['train', 'valid']
+
+    IMAGE_META_FILE = 'images.meta'

--- a/datumaro/datumaro/plugins/yolo_format/importer.py
+++ b/datumaro/datumaro/plugins/yolo_format/importer.py
@@ -15,18 +15,20 @@ class YoloImporter(Importer):
         from datumaro.components.project import Project # cyclic import
         project = Project()
 
-        if not osp.exists(path):
-            raise Exception("Failed to find 'yolo' dataset at '%s'" % path)
-
         if path.endswith('.data') and osp.isfile(path):
             config_paths = [path]
         else:
             config_paths = glob(osp.join(path, '*.data'))
 
+        if not osp.exists(path) or not config_paths:
+            raise Exception("Failed to find 'yolo' dataset at '%s'" % path)
+
         for config_path in config_paths:
             log.info("Found a dataset at '%s'" % config_path)
 
-            source_name = osp.splitext(osp.basename(config_path))[0]
+            source_name = '%s_%s' % (
+                osp.basename(osp.dirname(config_path)),
+                osp.splitext(osp.basename(config_path))[0])
             project.add_source(source_name, {
                 'url': config_path,
                 'format': 'yolo',

--- a/datumaro/datumaro/util/image.py
+++ b/datumaro/datumaro/util/image.py
@@ -7,6 +7,7 @@
 
 from io import BytesIO
 import numpy as np
+import os.path as osp
 
 from enum import Enum
 _IMAGE_BACKENDS = Enum('_IMAGE_BACKENDS', ['cv2', 'PIL'])
@@ -166,25 +167,30 @@ class Image:
             size=None):
         assert size is None or len(size) == 2
         if size is not None:
-            assert 0 < size[0] and 0 < size[1], size
+            assert len(size) == 2 and 0 < size[0] and 0 < size[1], size
             size = tuple(size)
         else:
             size = None
         self._size = size # (H, W)
 
         assert path is None or isinstance(path, str)
-        if not path:
+        if path is None:
             path = ''
         self._path = path
 
-        assert any(e is not None for e in (data, path, loader, size)), "Image can not be empty"
-        if data is None and (path or loader is not None):
-            data = lazy_image(path, loader=loader, cache=cache)
+        assert data is not None or path, "Image can not be empty"
+        if data is None and path:
+            if osp.isfile(path):
+                data = lazy_image(path, loader=loader, cache=cache)
         self._data = data
 
     @property
     def path(self):
         return self._path
+
+    @property
+    def filename(self):
+        return osp.basename(self._path)
 
     @property
     def data(self):

--- a/datumaro/datumaro/util/image.py
+++ b/datumaro/datumaro/util/image.py
@@ -123,14 +123,16 @@ def decode_image(image_bytes):
 
 
 class lazy_image:
-    def __init__(self, path, loader=load_image, cache=None):
+    def __init__(self, path, loader=None, cache=None):
+        if loader is None:
+            loader = load_image
         self.path = path
         self.loader = loader
 
         # Cache:
         # - False: do not cache
-        # - None: use default (don't store in a class variable)
-        # - object: use this object as a cache
+        # - None: use the global cache
+        # - object: an object to be used as cache
         assert cache in {None, False} or isinstance(cache, object)
         self.cache = cache
 
@@ -138,9 +140,9 @@ class lazy_image:
         image = None
         image_id = hash(self) # path is not necessary hashable or a file path
 
-        cache = self._get_cache()
+        cache = self._get_cache(self.cache)
         if cache is not None:
-            image = self._get_cache().get(image_id)
+            image = cache.get(image_id)
 
         if image is None:
             image = self.loader(self.path)
@@ -148,8 +150,8 @@ class lazy_image:
                 cache.push(image_id, image)
         return image
 
-    def _get_cache(self):
-        cache = self.cache
+    @staticmethod
+    def _get_cache(cache):
         if cache is None:
             cache = _ImageCache.get_instance()
         elif cache == False:
@@ -158,3 +160,58 @@ class lazy_image:
 
     def __hash__(self):
         return hash((id(self), self.path, self.loader))
+
+class Image:
+    def __init__(self, data=None, path=None, loader=None, cache=None,
+            size=None):
+        assert size is None or len(size) == 2
+        if size is not None:
+            assert 0 < size[0] and 0 < size[1], size
+            size = tuple(size)
+        else:
+            size = None
+        self._size = size # (H, W)
+
+        assert path is None or isinstance(path, str)
+        if not path:
+            path = ''
+        self._path = path
+
+        assert any(e is not None for e in (data, path, loader, size)), "Image can not be empty"
+        if data is None and (path or loader is not None):
+            data = lazy_image(path, loader=loader, cache=cache)
+        self._data = data
+
+    @property
+    def path(self):
+        return self._path
+
+    @property
+    def data(self):
+        if callable(self._data):
+            return self._data()
+        return self._data
+
+    @property
+    def has_data(self):
+        return self._data is not None
+
+    @property
+    def size(self):
+        if self._size is None:
+            data = self.data
+            if data is not None:
+                self._size = data.shape[:2]
+        return self._size
+
+    def __eq__(self, other):
+        if isinstance(other, np.ndarray):
+            return self.has_data and np.array_equal(self.data, other)
+
+        if not isinstance(other, __class__):
+            return False
+        return \
+            (np.array_equal(self.size, other.size)) and \
+            (self.has_data == other.has_data) and \
+            (self.has_data and np.array_equal(self.data, other.data) or \
+                not self.has_data)

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -19,8 +19,7 @@ from datumaro.plugins.coco_format.converter import (
     CocoLabelsConverter,
 )
 from datumaro.plugins.coco_format.importer import CocoImporter
-from datumaro.util.image import save_image
-from datumaro.util import find
+from datumaro.util.image import save_image, Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -100,7 +99,7 @@ class CocoImporterTest(TestCase):
         os.makedirs(img_dir)
         os.makedirs(ann_dir)
 
-        image = np.ones((10, 5, 3), dtype=np.uint8)
+        image = np.ones((10, 5, 3))
         save_image(osp.join(img_dir, '000000000001.jpg'), image)
 
         annotation = self.generate_annotation()
@@ -109,30 +108,33 @@ class CocoImporterTest(TestCase):
             json.dump(annotation, outfile)
 
     def test_can_import(self):
+        class DstExtractor(Extractor):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, image=np.ones((10, 5, 3)), subset='val',
+                        annotations=[
+                            Polygon([0, 0, 1, 0, 1, 2, 0, 2], label=0,
+                                id=1, group=1, attributes={'is_crowd': False}),
+                            Mask(np.array(
+                                [[1, 0, 0, 1, 0]] * 5 +
+                                [[1, 1, 1, 1, 0]] * 5
+                                ), label=0,
+                                id=2, group=2, attributes={'is_crowd': True}),
+                        ]
+                    ),
+                ])
+
+            def categories(self):
+                label_cat = LabelCategories()
+                label_cat.add('TEST')
+                return { AnnotationType.label: label_cat }
+
         with TestDir() as test_dir:
             self.COCO_dataset_generate(test_dir)
-            project = Project.import_from(test_dir, 'coco')
-            dataset = project.make_dataset()
 
-            self.assertListEqual(['val'], sorted(dataset.subsets()))
-            self.assertEqual(1, len(dataset))
+            dataset = Project.import_from(test_dir, 'coco').make_dataset()
 
-            item = next(iter(dataset))
-            self.assertTrue(item.has_image)
-            self.assertEqual(np.sum(item.image), np.prod(item.image.shape))
-            self.assertEqual(2, len(item.annotations))
-
-            ann_1 = find(item.annotations, lambda x: x.id == 1)
-            ann_1_poly = find(item.annotations, lambda x: \
-                x.group == ann_1.id and x.type == AnnotationType.polygon)
-            self.assertFalse(ann_1 is None)
-            self.assertFalse(ann_1_poly is None)
-
-            ann_2 = find(item.annotations, lambda x: x.id == 2)
-            ann_2_mask = find(item.annotations, lambda x: \
-                x.group == ann_2.id and x.type == AnnotationType.mask)
-            self.assertFalse(ann_2 is None)
-            self.assertFalse(ann_2_mask is None)
+            compare_datasets(self, DstExtractor(), dataset)
 
 class CocoConverterTest(TestCase):
     def _test_save_and_load(self, source_dataset, converter, test_dir,
@@ -629,6 +631,17 @@ class CocoConverterTest(TestCase):
                 return {
                     AnnotationType.label: label_cat,
                 }
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(TestExtractor(),
+                CocoConverter(), test_dir)
+
+    def test_can_save_dataset_with_image_info(self):
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, image=Image(size=(10, 15))),
+                ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -640,7 +640,7 @@ class CocoConverterTest(TestCase):
         class TestExtractor(Extractor):
             def __iter__(self):
                 return iter([
-                    DatasetItem(id=1, image=Image(size=(10, 15))),
+                    DatasetItem(id=1, image=Image(path='1.jpg', size=(10, 15))),
                 ])
 
         with TestDir() as test_dir:

--- a/datumaro/tests/test_cvat_format.py
+++ b/datumaro/tests/test_cvat_format.py
@@ -12,7 +12,7 @@ from datumaro.components.extractor import (Extractor, DatasetItem,
 from datumaro.plugins.cvat_format.importer import CvatImporter
 from datumaro.plugins.cvat_format.converter import CvatConverter
 from datumaro.plugins.cvat_format.format import CvatPath
-from datumaro.util.image import save_image
+from datumaro.util.image import save_image, Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -82,7 +82,7 @@ class CvatExtractorTest(TestCase):
         save_image(osp.join(images_dir, 'img1.jpg'), np.ones((10, 10, 3)))
         item2_elem = ET.SubElement(root_elem, 'image')
         item2_elem.attrib.update({
-            'id': '1', 'name': 'img1', 'width': '8', 'height': '8'
+            'id': '1', 'name': 'img1', 'width': '10', 'height': '10'
         })
 
         item2_ann1_elem = ET.SubElement(item2_elem, 'polygon')
@@ -192,6 +192,8 @@ class CvatConverterTest(TestCase):
                             PolyLine([5, 0, 9, 0, 5, 5]), # will be skipped as no label
                         ]
                     ),
+
+                    DatasetItem(id=3, subset='s3', image=Image(size=(2, 4))),
                 ])
 
             def categories(self):
@@ -232,6 +234,8 @@ class CvatConverterTest(TestCase):
                                 attributes={ 'z_order': 1, 'occluded': False }),
                         ]
                     ),
+
+                    DatasetItem(id=3, subset='s3', image=Image(size=(2, 4))),
                 ])
 
             def categories(self):

--- a/datumaro/tests/test_cvat_format.py
+++ b/datumaro/tests/test_cvat_format.py
@@ -159,7 +159,7 @@ class CvatConverterTest(TestCase):
         label_categories.items[2].attributes.update(['a1', 'a2'])
         label_categories.attributes.update(['z_order', 'occluded'])
 
-        class SrcTestExtractor(Extractor):
+        class SrcExtractor(Extractor):
             def __iter__(self):
                 return iter([
                     DatasetItem(id=0, subset='s1', image=np.zeros((5, 10, 3)),
@@ -193,13 +193,14 @@ class CvatConverterTest(TestCase):
                         ]
                     ),
 
-                    DatasetItem(id=3, subset='s3', image=Image(size=(2, 4))),
+                    DatasetItem(id=3, subset='s3', image=Image(
+                        path='3.jpg', size=(2, 4))),
                 ])
 
             def categories(self):
                 return { AnnotationType.label: label_categories }
 
-        class DstTestExtractor(Extractor):
+        class DstExtractor(Extractor):
             def __iter__(self):
                 return iter([
                     DatasetItem(id=0, subset='s1', image=np.zeros((5, 10, 3)),
@@ -235,13 +236,14 @@ class CvatConverterTest(TestCase):
                         ]
                     ),
 
-                    DatasetItem(id=3, subset='s3', image=Image(size=(2, 4))),
+                    DatasetItem(id=3, subset='s3', image=Image(
+                        path='3.jpg', size=(2, 4))),
                 ])
 
             def categories(self):
                 return { AnnotationType.label: label_categories }
 
         with TestDir() as test_dir:
-            self._test_save_and_load(SrcTestExtractor(),
+            self._test_save_and_load(SrcExtractor(),
                 CvatConverter(save_images=True), test_dir,
-                target_dataset=DstTestExtractor())
+                target_dataset=DstExtractor())

--- a/datumaro/tests/test_datumaro_format.py
+++ b/datumaro/tests/test_datumaro_format.py
@@ -9,8 +9,9 @@ from datumaro.components.extractor import (Extractor, DatasetItem,
     LabelCategories, MaskCategories, PointsCategories
 )
 from datumaro.plugins.datumaro_format.converter import DatumaroConverter
-from datumaro.util.test_utils import TestDir, item_to_str
 from datumaro.util.mask_tools import generate_colormap
+from datumaro.util.image import Image
+from datumaro.util.test_utils import TestDir, item_to_str
 
 
 class DatumaroConverterTest(TestCase):
@@ -48,7 +49,7 @@ class DatumaroConverterTest(TestCase):
                 DatasetItem(id=42, subset='test'),
 
                 DatasetItem(id=42),
-                DatasetItem(id=43),
+                DatasetItem(id=43, image=Image(size=(2, 4))),
             ])
 
         def categories(self):

--- a/datumaro/tests/test_datumaro_format.py
+++ b/datumaro/tests/test_datumaro_format.py
@@ -49,7 +49,7 @@ class DatumaroConverterTest(TestCase):
                 DatasetItem(id=42, subset='test'),
 
                 DatasetItem(id=42),
-                DatasetItem(id=43, image=Image(size=(2, 4))),
+                DatasetItem(id=43, image=Image(path='1/b/c.qq', size=(2, 4))),
             ])
 
         def categories(self):

--- a/datumaro/tests/test_image.py
+++ b/datumaro/tests/test_image.py
@@ -8,7 +8,7 @@ import datumaro.util.image as image_module
 from datumaro.util.test_utils import TestDir
 
 
-class ImageTest(TestCase):
+class ImageOperationsTest(TestCase):
     def setUp(self):
         self.default_backend = image_module._IMAGE_BACKEND
 

--- a/datumaro/tests/test_image_dir_format.py
+++ b/datumaro/tests/test_image_dir_format.py
@@ -1,12 +1,11 @@
 import numpy as np
-import os.path as osp
 
 from unittest import TestCase
 
 from datumaro.components.project import Project
 from datumaro.components.extractor import Extractor, DatasetItem
+from datumaro.plugins.image_dir import ImageDirConverter
 from datumaro.util.test_utils import TestDir, compare_datasets
-from datumaro.util.image import save_image
 
 
 class ImageDirFormatTest(TestCase):
@@ -21,9 +20,7 @@ class ImageDirFormatTest(TestCase):
         with TestDir() as test_dir:
             source_dataset = self.TestExtractor()
 
-            for item in source_dataset:
-                save_image(osp.join(test_dir, '%s.jpg' % item.id),
-                    item.image.data)
+            ImageDirConverter()(source_dataset, save_dir=test_dir)
 
             project = Project.import_from(test_dir, 'image_dir')
             parsed_dataset = project.make_dataset()

--- a/datumaro/tests/test_image_dir_format.py
+++ b/datumaro/tests/test_image_dir_format.py
@@ -22,7 +22,8 @@ class ImageDirFormatTest(TestCase):
             source_dataset = self.TestExtractor()
 
             for item in source_dataset:
-                save_image(osp.join(test_dir, '%s.jpg' % item.id), item.image)
+                save_image(osp.join(test_dir, '%s.jpg' % item.id),
+                    item.image.data)
 
             project = Project.import_from(test_dir, 'image_dir')
             parsed_dataset = project.make_dataset()

--- a/datumaro/tests/test_images.py
+++ b/datumaro/tests/test_images.py
@@ -47,10 +47,10 @@ class ImageCacheTest(TestCase):
 
 class ImageTest(TestCase):
     def test_lazy_image_shape(self):
-        loader = lambda _: np.ones((5, 6, 7))
+        data = np.ones((5, 6, 7))
 
-        image_lazy = Image(loader=loader, size=(2, 4))
-        image_eager = Image(loader=loader)
+        image_lazy = Image(data=data, size=(2, 4))
+        image_eager = Image(data=data)
 
         self.assertEqual((2, 4), image_lazy.size)
         self.assertEqual((5, 6), image_eager.size)
@@ -66,10 +66,10 @@ class ImageTest(TestCase):
                 { 'data': image },
                 { 'data': image, 'path': path },
                 { 'data': image, 'path': path, 'size': (2, 4) },
+                { 'data': image, 'path': path, 'loader': load_image, 'size': (2, 4) },
                 { 'path': path },
                 { 'path': path, 'loader': load_image },
                 { 'path': path, 'size': (2, 4) },
-                { 'size': (2, 4) },
             ]:
                 img = Image(**args)
                 # pylint: disable=pointless-statement

--- a/datumaro/tests/test_images.py
+++ b/datumaro/tests/test_images.py
@@ -1,11 +1,10 @@
 import numpy as np
 import os.path as osp
-from PIL import Image
 
 from unittest import TestCase
 
 from datumaro.util.test_utils import TestDir
-from datumaro.util.image import lazy_image
+from datumaro.util.image import lazy_image, load_image, save_image, Image
 from datumaro.util.image_cache import ImageCache
 
 
@@ -13,10 +12,8 @@ class LazyImageTest(TestCase):
     def test_cache_works(self):
         with TestDir() as test_dir:
             image = np.ones((100, 100, 3), dtype=np.uint8)
-            image = Image.fromarray(image).convert('RGB')
-
             image_path = osp.join(test_dir, 'image.jpg')
-            image.save(image_path)
+            save_image(image_path, image)
 
             caching_loader = lazy_image(image_path, cache=None)
             self.assertTrue(caching_loader() is caching_loader())
@@ -47,3 +44,36 @@ class ImageCacheTest(TestCase):
         ImageCache.get_instance().clear()
         self.assertTrue(loader() is loader())
         self.assertEqual(ImageCache.get_instance().size(), 1)
+
+class ImageTest(TestCase):
+    def test_lazy_image_shape(self):
+        loader = lambda _: np.ones((5, 6, 7))
+
+        image_lazy = Image(loader=loader, size=(2, 4))
+        image_eager = Image(loader=loader)
+
+        self.assertEqual((2, 4), image_lazy.size)
+        self.assertEqual((5, 6), image_eager.size)
+
+    @staticmethod
+    def test_ctors():
+        with TestDir() as test_dir:
+            path = osp.join(test_dir, 'path.png')
+            image = np.ones([2, 4, 3])
+            save_image(path, image)
+
+            for args in [
+                { 'data': image },
+                { 'data': image, 'path': path },
+                { 'data': image, 'path': path, 'size': (2, 4) },
+                { 'path': path },
+                { 'path': path, 'loader': load_image },
+                { 'path': path, 'size': (2, 4) },
+                { 'size': (2, 4) },
+            ]:
+                img = Image(**args)
+                # pylint: disable=pointless-statement
+                if img.has_data:
+                    img.data
+                img.size
+                # pylint: enable=pointless-statement

--- a/datumaro/tests/test_masks.py
+++ b/datumaro/tests/test_masks.py
@@ -68,6 +68,25 @@ class PolygonConversionsTest(TestCase):
             self.assertTrue(np.array_equal(e_mask, c_mask),
                 '#%s: %s\n%s\n' % (i, e_mask, c_mask))
 
+    def test_mask_to_rle(self):
+        source_mask = np.array([
+            [0, 1, 1, 1, 0, 1, 1, 1, 1, 0],
+            [0, 0, 1, 1, 0, 1, 0, 1, 0, 0],
+            [0, 0, 0, 1, 0, 1, 1, 0, 0, 0],
+            [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+        ])
+
+        rle_uncompressed = mask_tools.mask_to_rle(source_mask)
+
+        from pycocotools import mask as mask_utils
+        resulting_mask = mask_utils.frPyObjects(
+            rle_uncompressed, *rle_uncompressed['size'])
+        resulting_mask = mask_utils.decode(resulting_mask)
+
+        self.assertTrue(np.array_equal(source_mask, resulting_mask),
+            '%s\n%s\n' % (source_mask, resulting_mask))
+
 class ColormapOperationsTest(TestCase):
     def test_can_paint_mask(self):
         mask = np.zeros((1, 3), dtype=np.uint8)

--- a/datumaro/tests/test_project.py
+++ b/datumaro/tests/test_project.py
@@ -11,10 +11,11 @@ from datumaro.components.converter import Converter
 from datumaro.components.extractor import (Extractor, DatasetItem,
     Label, Mask, Points, Polygon, PolyLine, Bbox, Caption,
 )
+from datumaro.util.image import Image
 from datumaro.components.config import Config, DefaultConfig, SchemaBuilder
 from datumaro.components.dataset_filter import \
     XPathDatasetFilter, XPathAnnotationsFilter, DatasetItemEncoder
-from datumaro.util.test_utils import TestDir
+from datumaro.util.test_utils import TestDir, compare_datasets
 
 
 class ProjectTest(TestCase):
@@ -135,12 +136,12 @@ class ProjectTest(TestCase):
         class TestExtractor(Extractor):
             def __iter__(self):
                 for i in range(5):
-                    yield DatasetItem(id=i, subset='train', image=i)
+                    yield DatasetItem(id=i, subset='train', image=np.array([i]))
 
         class TestLauncher(Launcher):
             def launch(self, inputs):
                 for i, inp in enumerate(inputs):
-                    yield [ Label(attributes={'idx': i, 'data': inp}) ]
+                    yield [ Label(attributes={'idx': i, 'data': inp.item()}) ]
 
         model_name = 'model'
         launcher_name = 'custom_launcher'
@@ -165,19 +166,18 @@ class ProjectTest(TestCase):
         class TestExtractorSrc(Extractor):
             def __iter__(self):
                 for i in range(2):
-                    yield DatasetItem(id=i, subset='train', image=i,
-                        annotations=[ Label(i) ])
+                    yield DatasetItem(id=i, image=np.ones([2, 2, 3]) * i,
+                        annotations=[Label(i)])
 
         class TestLauncher(Launcher):
             def launch(self, inputs):
                 for inp in inputs:
-                    yield [ Label(inp) ]
+                    yield [ Label(inp[0, 0, 0]) ]
 
         class TestConverter(Converter):
             def __call__(self, extractor, save_dir):
                 for item in extractor:
                     with open(osp.join(save_dir, '%s.txt' % item.id), 'w') as f:
-                        f.write(str(item.subset) + '\n')
                         f.write(str(item.annotations[0].label) + '\n')
 
         class TestExtractorDst(Extractor):
@@ -189,11 +189,8 @@ class ProjectTest(TestCase):
                 for path in self.items:
                     with open(path, 'r') as f:
                         index = osp.splitext(osp.basename(path))[0]
-                        subset = f.readline().strip()
                         label = int(f.readline().strip())
-                        assert subset == 'train'
-                        yield DatasetItem(id=index, subset=subset,
-                            annotations=[ Label(label) ])
+                        yield DatasetItem(id=index, annotations=[Label(label)])
 
         model_name = 'model'
         launcher_name = 'custom_launcher'
@@ -476,6 +473,11 @@ class ExtractorTest(TestCase):
                     DatasetItem(id=2, subset='train'),
 
                     DatasetItem(id=3, subset='test'),
+                    DatasetItem(id=4, subset='test'),
+
+                    DatasetItem(id=1),
+                    DatasetItem(id=2),
+                    DatasetItem(id=3),
                 ])
 
         extractor_name = 'ext1'
@@ -485,8 +487,29 @@ class ExtractorTest(TestCase):
             'url': 'path',
             'format': extractor_name,
         })
-        project.set_subsets(['train'])
 
         dataset = project.make_dataset()
 
-        self.assertEqual(3, len(dataset))
+        compare_datasets(self, CustomExtractor(), dataset)
+
+class DatasetItemTest(TestCase):
+    def test_ctor_requires_id(self):
+        has_error = False
+        try:
+            # pylint: disable=no-value-for-parameter
+            DatasetItem()
+            # pylint: enable=no-value-for-parameter
+        except TypeError:
+            has_error = True
+
+        self.assertTrue(has_error)
+
+    @staticmethod
+    def test_ctors_with_image():
+        for args in [
+            { 'id': 0, 'image': None },
+            { 'id': 0, 'image': np.array([1, 2, 3]) },
+            { 'id': 0, 'image': lambda f: np.array([1, 2, 3]) },
+            { 'id': 0, 'image': Image(data=np.array([1, 2, 3])) },
+        ]:
+            DatasetItem(**args)

--- a/datumaro/tests/test_project.py
+++ b/datumaro/tests/test_project.py
@@ -499,7 +499,7 @@ class DatasetItemTest(TestCase):
             # pylint: disable=no-value-for-parameter
             DatasetItem()
             # pylint: enable=no-value-for-parameter
-        except TypeError:
+        except AssertionError:
             has_error = True
 
         self.assertTrue(has_error)
@@ -508,6 +508,7 @@ class DatasetItemTest(TestCase):
     def test_ctors_with_image():
         for args in [
             { 'id': 0, 'image': None },
+            { 'id': 0, 'image': 'path.jpg' },
             { 'id': 0, 'image': np.array([1, 2, 3]) },
             { 'id': 0, 'image': lambda f: np.array([1, 2, 3]) },
             { 'id': 0, 'image': Image(data=np.array([1, 2, 3])) },

--- a/datumaro/tests/test_tfrecord_format.py
+++ b/datumaro/tests/test_tfrecord_format.py
@@ -34,16 +34,16 @@ class TfrecordConverterTest(TestCase):
                     DatasetItem(id=1, subset='train',
                         image=np.ones((16, 16, 3)),
                         annotations=[
-                            Bbox(0, 4, 4, 8, label=2, id=0),
-                            Bbox(0, 4, 4, 4, label=3, id=1),
-                            Bbox(2, 4, 4, 4, id=2),
+                            Bbox(0, 4, 4, 8, label=2),
+                            Bbox(0, 4, 4, 4, label=3),
+                            Bbox(2, 4, 4, 4),
                         ]
                     ),
 
                     DatasetItem(id=2, subset='val',
                         image=np.ones((8, 8, 3)),
                         annotations=[
-                            Bbox(1, 2, 4, 2, label=3, id=0),
+                            Bbox(1, 2, 4, 2, label=3),
                         ]
                     ),
 
@@ -72,15 +72,15 @@ class TfrecordConverterTest(TestCase):
                     DatasetItem(id=1,
                         image=np.ones((16, 16, 3)),
                         annotations=[
-                            Bbox(2, 1, 4, 4, label=2, id=0),
-                            Bbox(4, 2, 8, 4, label=3, id=1),
+                            Bbox(2, 1, 4, 4, label=2),
+                            Bbox(4, 2, 8, 4, label=3),
                         ]
                     ),
 
                     DatasetItem(id=2,
                         image=np.ones((8, 8, 3)) * 2,
                         annotations=[
-                            Bbox(4, 4, 4, 4, label=3, id=0),
+                            Bbox(4, 4, 4, 4, label=3),
                         ]
                     ),
 
@@ -106,7 +106,7 @@ class TfrecordConverterTest(TestCase):
         class TestExtractor(Extractor):
             def __iter__(self):
                 return iter([
-                    DatasetItem(id=1, image=Image(size=(10, 15))),
+                    DatasetItem(id=1, image=Image(path='1/q.e', size=(10, 15))),
                 ])
 
             def categories(self):

--- a/datumaro/tests/test_tfrecord_format.py
+++ b/datumaro/tests/test_tfrecord_format.py
@@ -8,6 +8,7 @@ from datumaro.components.extractor import (Extractor, DatasetItem,
 from datumaro.plugins.tf_detection_api_format.importer import TfDetectionApiImporter
 from datumaro.plugins.tf_detection_api_format.extractor import TfDetectionApiExtractor
 from datumaro.plugins.tf_detection_api_format.converter import TfDetectionApiConverter
+from datumaro.util.image import Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -100,6 +101,20 @@ class TfrecordConverterTest(TestCase):
             self._test_save_and_load(
                 TestExtractor(), TfDetectionApiConverter(save_images=True),
                 test_dir)
+
+    def test_can_save_dataset_with_image_info(self):
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, image=Image(size=(10, 15))),
+                ])
+
+            def categories(self):
+                return { AnnotationType.label: LabelCategories() }
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(TestExtractor(),
+                TfDetectionApiConverter(), test_dir)
 
     def test_labelmap_parsing(self):
         text = """

--- a/datumaro/tests/test_transforms.py
+++ b/datumaro/tests/test_transforms.py
@@ -244,3 +244,20 @@ class TransformsTest(TestCase):
         actual = transforms.ShapesToBoxes(SrcExtractor())
         compare_datasets(self, DstExtractor(), actual)
 
+    def test_id_from_image(self):
+        class SrcExtractor(Extractor):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, image='path.jpg'),
+                    DatasetItem(id=2),
+                ])
+
+        class DstExtractor(Extractor):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id='path', image='path.jpg'),
+                    DatasetItem(id=2),
+                ])
+
+        actual = transforms.IdFromImageName(SrcExtractor())
+        compare_datasets(self, DstExtractor(), actual)

--- a/datumaro/tests/test_voc_format.py
+++ b/datumaro/tests/test_voc_format.py
@@ -27,7 +27,7 @@ from datumaro.plugins.voc_format.converter import (
 )
 from datumaro.plugins.voc_format.importer import VocImporter
 from datumaro.components.project import Project
-from datumaro.util.image import save_image
+from datumaro.util.image import save_image, Image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -171,13 +171,11 @@ def generate_dummy_voc(path):
     return subsets
 
 class TestExtractorBase(Extractor):
-    _categories = VOC.make_voc_categories()
-
     def _label(self, voc_label):
         return self.categories()[AnnotationType.label].find(voc_label)[0]
 
     def categories(self):
-        return self._categories
+        return VOC.make_voc_categories()
 
 class VocExtractorTest(TestCase):
     def test_can_load_voc_cls(self):
@@ -693,6 +691,17 @@ class VocConverterTest(TestCase):
             self._test_save_and_load(
                 SrcExtractor(), VocConverter(label_map=label_map),
                 test_dir, target_dataset=DstExtractor())
+
+    def test_can_save_dataset_with_image_info(self):
+        class TestExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, image=Image(size=(10, 15))),
+                ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(TestExtractor(),
+                VocConverter(label_map='voc'), test_dir)
 
 class VocImportTest(TestCase):
     def test_can_import(self):

--- a/datumaro/tests/test_voc_format.py
+++ b/datumaro/tests/test_voc_format.py
@@ -696,7 +696,7 @@ class VocConverterTest(TestCase):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):
                 return iter([
-                    DatasetItem(id=1, image=Image(size=(10, 15))),
+                    DatasetItem(id=1, image=Image(path='1.jpg', size=(10, 15))),
                 ])
 
         with TestDir() as test_dir:

--- a/datumaro/tests/test_yolo_format.py
+++ b/datumaro/tests/test_yolo_format.py
@@ -7,7 +7,6 @@ from datumaro.components.extractor import (Extractor, DatasetItem,
     AnnotationType, Bbox, LabelCategories,
 )
 from datumaro.plugins.yolo_format.importer import YoloImporter
-from datumaro.plugins.yolo_format.format import YoloPath
 from datumaro.plugins.yolo_format.converter import YoloConverter
 from datumaro.util.image import Image, save_image
 from datumaro.util.test_utils import TestDir, compare_datasets

--- a/datumaro/tests/test_yolo_format.py
+++ b/datumaro/tests/test_yolo_format.py
@@ -59,7 +59,7 @@ class YoloFormatTest(TestCase):
             def __iter__(self):
                 return iter([
                     DatasetItem(id=1, subset='train',
-                        image=Image(size=(10, 15)),
+                        image=Image(path='1.jpg', size=(10, 15)),
                         annotations=[
                             Bbox(0, 2, 4, 2, label=2),
                             Bbox(3, 3, 2, 3, label=4),
@@ -82,5 +82,35 @@ class YoloFormatTest(TestCase):
             save_image(osp.join(test_dir, 'obj_train_data', '1.jpg'),
                 np.ones((10, 15, 3))) # put the image for dataset
             parsed_dataset = YoloImporter()(test_dir).make_dataset()
+
+            compare_datasets(self, source_dataset, parsed_dataset)
+
+    def test_can_load_dataset_with_exact_image_info(self):
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, subset='train',
+                        image=Image(path='1.jpg', size=(10, 15)),
+                        annotations=[
+                            Bbox(0, 2, 4, 2, label=2),
+                            Bbox(3, 3, 2, 3, label=4),
+                        ]),
+                ])
+
+            def categories(self):
+                label_categories = LabelCategories()
+                for i in range(10):
+                    label_categories.add('label_' + str(i))
+                return {
+                    AnnotationType.label: label_categories,
+                }
+
+        with TestDir() as test_dir:
+            source_dataset = TestExtractor()
+
+            YoloConverter()(source_dataset, test_dir)
+
+            parsed_dataset = YoloImporter()(test_dir,
+                image_info={'1': (10, 15)}).make_dataset()
 
             compare_datasets(self, source_dataset, parsed_dataset)

--- a/datumaro/tests/test_yolo_format.py
+++ b/datumaro/tests/test_yolo_format.py
@@ -1,4 +1,5 @@
 import numpy as np
+import os.path as osp
 
 from unittest import TestCase
 
@@ -6,7 +7,9 @@ from datumaro.components.extractor import (Extractor, DatasetItem,
     AnnotationType, Bbox, LabelCategories,
 )
 from datumaro.plugins.yolo_format.importer import YoloImporter
+from datumaro.plugins.yolo_format.format import YoloPath
 from datumaro.plugins.yolo_format.converter import YoloConverter
+from datumaro.util.image import Image, save_image
 from datumaro.util.test_utils import TestDir, compare_datasets
 
 
@@ -48,6 +51,37 @@ class YoloFormatTest(TestCase):
             source_dataset = TestExtractor()
 
             YoloConverter(save_images=True)(source_dataset, test_dir)
+            parsed_dataset = YoloImporter()(test_dir).make_dataset()
+
+            compare_datasets(self, source_dataset, parsed_dataset)
+
+    def test_can_save_dataset_with_image_info(self):
+        class TestExtractor(Extractor):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, subset='train',
+                        image=Image(size=(10, 15)),
+                        annotations=[
+                            Bbox(0, 2, 4, 2, label=2),
+                            Bbox(3, 3, 2, 3, label=4),
+                        ]),
+                ])
+
+            def categories(self):
+                label_categories = LabelCategories()
+                for i in range(10):
+                    label_categories.add('label_' + str(i))
+                return {
+                    AnnotationType.label: label_categories,
+                }
+
+        with TestDir() as test_dir:
+            source_dataset = TestExtractor()
+
+            YoloConverter()(source_dataset, test_dir)
+
+            save_image(osp.join(test_dir, 'obj_train_data', '1.jpg'),
+                np.ones((10, 15, 3))) # put the image for dataset
             parsed_dataset = YoloImporter()(test_dir).make_dataset()
 
             compare_datasets(self, source_dataset, parsed_dataset)


### PR DESCRIPTION
Added:
- `Image` class, which has `path` and `size` as metainfo
- `ImageDir` converter, which saves images to a directory
- `IdFromImageName` transform, which allows to merge CVAT and COCO datasets with all others (allows to match items)
- Added additional image metainfo file support for YOLO format, which allows to load such a dataset when no images present
- Updated CVAT/Datumaro bindings that it was possible to export and *import* tasks
- `Inference` and `DatasetFilter` are now `Transforms`

Fixed:
- Transforms requiring image info now can be chained