### PR TITLE
[Datumaro] Avoid tf deprecation warning

### DIFF
--- a/datumaro/datumaro/util/tf_util.py
+++ b/datumaro/datumaro/util/tf_util.py
@@ -26,12 +26,15 @@ def import_tf():
         pass
 
     # Enable eager execution in early versions to unlock dataset operations
+    eager_enabled = False
     try:
         tf.compat.v1.enable_eager_execution()
+        eager_enabled = True
     except AttributeError:
         pass
     try:
-        tf.enable_eager_execution()
+        if not eager_enabled:
+            tf.enable_eager_execution()
     except AttributeError:
         pass
 


### PR DESCRIPTION
Fixes:
- TF `eager execution` warning is now avoided 