### PR TITLE
Fixed lags when working with shapes

### DIFF
--- a/cvat/apps/engine/static/engine/js/3rdparty.patch
+++ b/cvat/apps/engine/static/engine/js/3rdparty.patch
@@ -1,14 +1,15 @@
-From a2f542cc7ac4149fe14f42e194e44ef982d7fc28 Mon Sep 17 00:00:00 2001
+From 11bd98c7f1ecf5a57b0eb327e6e86fa1e6ca33d9 Mon Sep 17 00:00:00 2001
 From: Boris Sekachev <boris.sekachev@yandex.ru>
-Date: Wed, 27 Mar 2019 15:08:18 +0300
-Subject: [PATCH] upd
+Date: Tue, 25 Feb 2020 19:08:36 +0300
+Subject: [PATCH] Applied patch
 
 ---
  .../static/engine/js/3rdparty/svg.draggable.js  |  1 +
  .../static/engine/js/3rdparty/svg.draw.js       | 17 +++++++++++++++--
+ .../engine/static/engine/js/3rdparty/svg.js     |  2 +-
  .../static/engine/js/3rdparty/svg.resize.min.js |  2 +-
  .../static/engine/js/3rdparty/svg.select.js     |  5 ++++-
- 4 files changed, 21 insertions(+), 4 deletions(-)
+ 5 files changed, 22 insertions(+), 5 deletions(-)
 
 diff --git a/cvat/apps/engine/static/engine/js/3rdparty/svg.draggable.js b/cvat/apps/engine/static/engine/js/3rdparty/svg.draggable.js
 index d88abf5..aba474c 100644
@@ -77,6 +78,19 @@ index 68dbf2a..20a6917 100644
              }
          }
  
+diff --git a/cvat/apps/engine/static/engine/js/3rdparty/svg.js b/cvat/apps/engine/static/engine/js/3rdparty/svg.js
+index 72737da..c865ef8 100644
+--- a/cvat/apps/engine/static/engine/js/3rdparty/svg.js
++++ b/cvat/apps/engine/static/engine/js/3rdparty/svg.js
+@@ -3503,7 +3503,7 @@ SVG.off = function(node, event, listener) {
+       SVG.off(node, event)
+ 
+     delete SVG.listeners[index]
+-    delete SVG.handlerMap[index]
++    SVG.handlerMap.splice(index, 1)
+ 
+   }
+ }
 diff --git a/cvat/apps/engine/static/engine/js/3rdparty/svg.resize.min.js b/cvat/apps/engine/static/engine/js/3rdparty/svg.resize.min.js
 index 2dca34b..50ef3d3 100644
 --- a/cvat/apps/engine/static/engine/js/3rdparty/svg.resize.min.js


### PR DESCRIPTION
The key idea is to use ``splice`` instead of ``delete`` operator for the array.
If we use operator ``delete``, the method ``indexOf`` works much slower gradually. 

Related: #1141, #1182