### PR TITLE
React UI: Pinned option was added

### DIFF
--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -840,6 +840,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
             points: [...state.points],
             attributes: { ...state.attributes },
             zOrder: state.zOrder,
+            pinned: state.pinned,
         };
     }
 
@@ -873,6 +874,12 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 } else {
                     this.svgShapes[clientID].removeClass('cvat_canvas_shape_occluded');
                 }
+            }
+
+            if (drawnState.pinned !== state.pinned && this.activeElement.clientID !== null) {
+                const activeElement = { ...this.activeElement };
+                this.deactivate();
+                this.activate(activeElement);
             }
 
             if (state.points
@@ -1006,9 +1013,11 @@ export class CanvasViewImpl implements CanvasView, Listener {
 
             shape.removeClass('cvat_canvas_shape_activated');
 
-            (shape as any).off('dragstart');
-            (shape as any).off('dragend');
-            (shape as any).draggable(false);
+            if (!drawnState.pinned) {
+                (shape as any).off('dragstart');
+                (shape as any).off('dragend');
+                (shape as any).draggable(false);
+            }
 
             if (drawnState.shapeType !== 'points') {
                 this.selectize(false, shape);
@@ -1090,36 +1099,38 @@ export class CanvasViewImpl implements CanvasView, Listener {
             this.content.append(shape.node);
         }
 
-        (shape as any).draggable().on('dragstart', (): void => {
-            this.mode = Mode.DRAG;
-            if (text) {
-                text.addClass('cvat_canvas_hidden');
-            }
-        }).on('dragend', (e: CustomEvent): void => {
-            if (text) {
-                text.removeClass('cvat_canvas_hidden');
-                self.updateTextPosition(
-                    text,
-                    shape,
-                );
-            }
+        if (!state.pinned) {
+            (shape as any).draggable().on('dragstart', (): void => {
+                this.mode = Mode.DRAG;
+                if (text) {
+                    text.addClass('cvat_canvas_hidden');
+                }
+            }).on('dragend', (e: CustomEvent): void => {
+                if (text) {
+                    text.removeClass('cvat_canvas_hidden');
+                    self.updateTextPosition(
+                        text,
+                        shape,
+                    );
+                }
 
-            this.mode = Mode.IDLE;
+                this.mode = Mode.IDLE;
 
-            const p1 = e.detail.handler.startPoints.point;
-            const p2 = e.detail.p;
-            const delta = 1;
-            const { offset } = this.controller.geometry;
-            if (Math.sqrt(((p1.x - p2.x) ** 2) + ((p1.y - p2.y) ** 2)) >= delta) {
-                const points = pointsToArray(
-                    shape.attr('points') || `${shape.attr('x')},${shape.attr('y')} `
-                        + `${shape.attr('x') + shape.attr('width')},`
-                        + `${shape.attr('y') + shape.attr('height')}`,
-                ).map((x: number): number => x - offset);
+                const p1 = e.detail.handler.startPoints.point;
+                const p2 = e.detail.p;
+                const delta = 1;
+                const { offset } = this.controller.geometry;
+                if (Math.sqrt(((p1.x - p2.x) ** 2) + ((p1.y - p2.y) ** 2)) >= delta) {
+                    const points = pointsToArray(
+                        shape.attr('points') || `${shape.attr('x')},${shape.attr('y')} `
+                            + `${shape.attr('x') + shape.attr('width')},`
+                            + `${shape.attr('y') + shape.attr('height')}`,
+                    ).map((x: number): number => x - offset);
 
-                this.onEditDone(state, points);
-            }
-        });
+                    this.onEditDone(state, points);
+                }
+            });
+        }
 
         if (state.shapeType !== 'points') {
             this.selectize(true, shape);

--- a/cvat-core/src/annotations-objects.js
+++ b/cvat-core/src/annotations-objects.js
@@ -269,9 +269,23 @@
 
             this.frameMeta = injection.frameMeta;
             this.hidden = false;
+            this.pinned = true;
 
             this.color = color;
             this.shapeType = null;
+        }
+
+        _savePinned(pinned) {
+            const undoPinned = this.pinned;
+            const redoPinned = pinned;
+
+            this.history.do(HistoryActions.CHANGED_PINNED, () => {
+                this.pinned = undoPinned;
+            }, () => {
+                this.pinned = redoPinned;
+            }, [this.clientID]);
+
+            this.pinned = pinned;
         }
 
         _validateStateBeforeSave(frame, data, updated) {
@@ -341,6 +355,10 @@
 
             if (updated.lock) {
                 checkObjectType('lock', data.lock, 'boolean', null);
+            }
+
+            if (updated.pinned) {
+                checkObjectType('pinned', data.pinned, 'boolean', null);
             }
 
             if (updated.color) {
@@ -439,6 +457,7 @@
                 color: this.color,
                 hidden: this.hidden,
                 updated: this.updated,
+                pinned: this.pinned,
                 frame,
             };
         }
@@ -519,6 +538,10 @@
 
             if (updated.lock) {
                 this._saveLock(data.lock);
+            }
+
+            if (updated.pinned) {
+                this._savePinned(data.pinned);
             }
 
             if (updated.color) {
@@ -631,6 +654,7 @@
                 hidden: this.hidden,
                 updated: this.updated,
                 label: this.label,
+                pinned: this.pinned,
                 keyframes: {
                     prev,
                     next,
@@ -971,6 +995,10 @@
                 this._saveLock(data.lock);
             }
 
+            if (updated.pinned) {
+                this._savePinned(data.pinned);
+            }
+
             if (updated.color) {
                 this._saveColor(data.color);
             }
@@ -1135,6 +1163,7 @@
         constructor(data, clientID, color, injection) {
             super(data, clientID, color, injection);
             this.shapeType = ObjectShape.RECTANGLE;
+            this.pinned = false;
             checkNumberOfPoints(this.shapeType, this.points);
         }
 
@@ -1302,6 +1331,7 @@
         constructor(data, clientID, color, injection) {
             super(data, clientID, color, injection);
             this.shapeType = ObjectShape.RECTANGLE;
+            this.pinned = false;
             for (const shape of Object.values(this.shapes)) {
                 checkNumberOfPoints(this.shapeType, shape.points);
             }

--- a/cvat-core/src/enums.js
+++ b/cvat-core/src/enums.js
@@ -196,6 +196,7 @@
         CHANGED_ZORDER: 'Changed z-order',
         CHANGED_KEYFRAME: 'Changed keyframe',
         CHANGED_LOCK: 'Changed lock',
+        CHANGED_PINNED: 'Changed pinned',
         CHANGED_COLOR: 'Changed color',
         CHANGED_HIDDEN: 'Changed hidden',
         MERGED_OBJECTS: 'Merged objects',

--- a/cvat-core/src/object-state.js
+++ b/cvat-core/src/object-state.js
@@ -19,10 +19,10 @@
         /**
             * @param {Object} serialized - is an dictionary which contains
             * initial information about an ObjectState;
-            * Necessary fields: objectType, shapeType, frame, updated
-            * Optional fields: points, group, zOrder, outside, occluded, hidden,
-            * attributes, lock, label, mode, color, keyframe, keyframes, clientID, serverID
-            * These fields can be set later via setters
+            * </br> Necessary fields: objectType, shapeType, frame, updated, group
+            * </br> Optional fields: keyframes, clientID, serverID
+            * </br> Optional fields which can be set later: points, zOrder, outside,
+            * occluded, hidden, attributes, lock, label, color, keyframe
         */
         constructor(serialized) {
             const data = {
@@ -34,12 +34,13 @@
                 occluded: null,
                 keyframe: null,
 
-                zOrder: undefined,
+                zOrder: null,
                 lock: null,
                 color: null,
                 hidden: null,
+                pinned: null,
+                keyframes: null,
                 group: serialized.group,
-                keyframes: serialized.keyframes,
                 updated: serialized.updated,
 
                 clientID: serialized.clientID,
@@ -63,6 +64,7 @@
                     this.keyframe = false;
 
                     this.zOrder = false;
+                    this.pinned = false;
                     this.lock = false;
                     this.color = false;
                     this.hidden = false;
@@ -202,7 +204,7 @@
                 zOrder: {
                     /**
                         * @name zOrder
-                        * @type {integer}
+                        * @type {integer | null}
                         * @memberof module:API.cvat.classes.ObjectState
                         * @instance
                     */
@@ -242,15 +244,16 @@
                     /**
                         * Object of keyframes { first, prev, next, last }
                         * @name keyframes
-                        * @type {object}
+                        * @type {object | null}
                         * @memberof module:API.cvat.classes.ObjectState
                         * @readonly
                         * @instance
                     */
                     get: () => {
-                        if (data.keyframes) {
+                        if (typeof (data.keyframes) === 'object') {
                             return { ...data.keyframes };
                         }
+
                         return null;
                     },
                 },
@@ -278,6 +281,25 @@
                     set: (lock) => {
                         data.updateFlags.lock = true;
                         data.lock = lock;
+                    },
+                },
+                pinned: {
+                    /**
+                        * @name pinned
+                        * @type {boolean | null}
+                        * @memberof module:API.cvat.classes.ObjectState
+                        * @instance
+                    */
+                    get: () => {
+                        if (typeof (data.pinned) === 'boolean') {
+                            return data.pinned;
+                        }
+
+                        return null;
+                    },
+                    set: (pinned) => {
+                        data.updateFlags.pinned = true;
+                        data.pinned = pinned;
                     },
                 },
                 updated: {
@@ -320,19 +342,33 @@
             }));
 
             this.label = serialized.label;
-            this.zOrder = serialized.zOrder;
-            this.outside = serialized.outside;
-            this.keyframe = serialized.keyframe;
-            this.occluded = serialized.occluded;
-            this.color = serialized.color;
             this.lock = serialized.lock;
-            this.hidden = serialized.hidden;
 
-            // It can be undefined in a constructor and it can be defined later
-            if (typeof (serialized.points) !== 'undefined') {
+            if (typeof (serialized.zOrder) === 'number') {
+                this.zOrder = serialized.zOrder;
+            }
+            if (typeof (serialized.occluded) === 'boolean') {
+                this.occluded = serialized.occluded;
+            }
+            if (typeof (serialized.outside) === 'boolean') {
+                this.outside = serialized.outside;
+            }
+            if (typeof (serialized.keyframe) === 'boolean') {
+                this.keyframe = serialized.keyframe;
+            }
+            if (typeof (serialized.pinned) === 'boolean') {
+                this.pinned = serialized.pinned;
+            }
+            if (typeof (serialized.hidden) === 'boolean') {
+                this.hidden = serialized.hidden;
+            }
+            if (typeof (serialized.color) === 'string') {
+                this.color = serialized.color;
+            }
+            if (Array.isArray(serialized.points)) {
                 this.points = serialized.points;
             }
-            if (typeof (serialized.attributes) !== 'undefined') {
+            if (typeof (serialized.attributes) === 'object') {
                 this.attributes = serialized.attributes;
             }
 

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -175,6 +175,7 @@ interface ItemButtonsComponentProps {
     occluded: boolean;
     outside: boolean | undefined;
     locked: boolean;
+    pinned: boolean;
     hidden: boolean;
     keyframe: boolean | undefined;
 
@@ -191,6 +192,8 @@ interface ItemButtonsComponentProps {
     unsetKeyframe(): void;
     lock(): void;
     unlock(): void;
+    pin(): void;
+    unpin(): void;
     hide(): void;
     show(): void;
 }
@@ -201,6 +204,7 @@ function ItemButtonsComponent(props: ItemButtonsComponentProps): JSX.Element {
         occluded,
         outside,
         locked,
+        pinned,
         hidden,
         keyframe,
 
@@ -217,6 +221,8 @@ function ItemButtonsComponent(props: ItemButtonsComponentProps): JSX.Element {
         unsetKeyframe,
         lock,
         unlock,
+        pin,
+        unpin,
         hide,
         show,
     } = props;
@@ -273,6 +279,11 @@ function ItemButtonsComponent(props: ItemButtonsComponentProps): JSX.Element {
                                 ? <Icon type='star' theme='filled' onClick={unsetKeyframe} />
                                 : <Icon type='star' onClick={setKeyframe} />}
                         </Col>
+                        <Col span={4}>
+                            { pinned
+                                ? <Icon type='pushpin' theme='filled' onClick={unpin} />
+                                : <Icon type='pushpin' onClick={pin} />}
+                        </Col>
                     </Row>
                 </Col>
             </Row>
@@ -283,20 +294,25 @@ function ItemButtonsComponent(props: ItemButtonsComponentProps): JSX.Element {
         <Row type='flex' align='middle' justify='space-around'>
             <Col span={20} style={{ textAlign: 'center' }}>
                 <Row type='flex' justify='space-around'>
-                    <Col span={8}>
+                    <Col span={6}>
                         { locked
                             ? <Icon type='lock' onClick={unlock} />
                             : <Icon type='unlock' onClick={lock} />}
                     </Col>
-                    <Col span={8}>
+                    <Col span={6}>
                         { occluded
                             ? <Icon type='team' onClick={unsetOccluded} />
                             : <Icon type='user' onClick={setOccluded} />}
                     </Col>
-                    <Col span={8}>
+                    <Col span={6}>
                         { hidden
                             ? <Icon type='eye-invisible' onClick={show} />
                             : <Icon type='eye' onClick={hide} />}
+                    </Col>
+                    <Col span={6}>
+                        { pinned
+                            ? <Icon type='pushpin' theme='filled' onClick={unpin} />
+                            : <Icon type='pushpin' onClick={pin} />}
                     </Col>
                 </Row>
             </Col>
@@ -540,6 +556,7 @@ interface Props {
     occluded: boolean;
     outside: boolean | undefined;
     locked: boolean;
+    pinned: boolean;
     hidden: boolean;
     keyframe: boolean | undefined;
     attrValues: Record<number, string>;
@@ -568,6 +585,8 @@ interface Props {
     unsetKeyframe(): void;
     lock(): void;
     unlock(): void;
+    pin(): void;
+    unpin(): void;
     hide(): void;
     show(): void;
     changeLabel(labelID: string): void;
@@ -578,6 +597,7 @@ interface Props {
 function objectItemsAreEqual(prevProps: Props, nextProps: Props): boolean {
     return nextProps.activated === prevProps.activated
         && nextProps.locked === prevProps.locked
+        && nextProps.pinned === prevProps.pinned
         && nextProps.occluded === prevProps.occluded
         && nextProps.outside === prevProps.outside
         && nextProps.hidden === prevProps.hidden
@@ -608,6 +628,7 @@ function ObjectItemComponent(props: Props): JSX.Element {
         occluded,
         outside,
         locked,
+        pinned,
         hidden,
         keyframe,
         attrValues,
@@ -637,6 +658,8 @@ function ObjectItemComponent(props: Props): JSX.Element {
         unsetKeyframe,
         lock,
         unlock,
+        pin,
+        unpin,
         hide,
         show,
         changeLabel,
@@ -677,6 +700,7 @@ function ObjectItemComponent(props: Props): JSX.Element {
                 occluded={occluded}
                 outside={outside}
                 locked={locked}
+                pinned={pinned}
                 hidden={hidden}
                 keyframe={keyframe}
                 navigateFirstKeyframe={navigateFirstKeyframe}
@@ -691,6 +715,8 @@ function ObjectItemComponent(props: Props): JSX.Element {
                 unsetKeyframe={unsetKeyframe}
                 lock={lock}
                 unlock={unlock}
+                pin={pin}
+                unpin={unpin}
                 hide={hide}
                 show={show}
             />

--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -178,6 +178,7 @@ const ItemTop = React.memo(ItemTopComponent);
 
 interface ItemButtonsComponentProps {
     objectType: ObjectType;
+    shapeType: ShapeType;
     occluded: boolean;
     outside: boolean | undefined;
     locked: boolean;
@@ -207,6 +208,7 @@ interface ItemButtonsComponentProps {
 function ItemButtonsComponent(props: ItemButtonsComponentProps): JSX.Element {
     const {
         objectType,
+        shapeType,
         occluded,
         outside,
         locked,
@@ -238,58 +240,62 @@ function ItemButtonsComponent(props: ItemButtonsComponentProps): JSX.Element {
             <Row type='flex' align='middle' justify='space-around'>
                 <Col span={20} style={{ textAlign: 'center' }}>
                     <Row type='flex' justify='space-around'>
-                        <Col span={6}>
+                        <Col>
                             { navigateFirstKeyframe
                                 ? <Icon component={FirstIcon} onClick={navigateFirstKeyframe} />
                                 : <Icon component={FirstIcon} style={{ opacity: 0.5, pointerEvents: 'none' }} />}
                         </Col>
-                        <Col span={6}>
+                        <Col>
                             { navigatePrevKeyframe
                                 ? <Icon component={PreviousIcon} onClick={navigatePrevKeyframe} />
                                 : <Icon component={PreviousIcon} style={{ opacity: 0.5, pointerEvents: 'none' }} />}
                         </Col>
-                        <Col span={6}>
+                        <Col>
                             { navigateNextKeyframe
                                 ? <Icon component={NextIcon} onClick={navigateNextKeyframe} />
                                 : <Icon component={NextIcon} style={{ opacity: 0.5, pointerEvents: 'none' }} />}
                         </Col>
-                        <Col span={6}>
+                        <Col>
                             { navigateLastKeyframe
                                 ? <Icon component={LastIcon} onClick={navigateLastKeyframe} />
                                 : <Icon component={LastIcon} style={{ opacity: 0.5, pointerEvents: 'none' }} />}
                         </Col>
                     </Row>
                     <Row type='flex' justify='space-around'>
-                        <Col span={4}>
+                        <Col>
                             { outside
                                 ? <Icon component={ObjectOutsideIcon} onClick={unsetOutside} />
                                 : <Icon type='select' onClick={setOutside} />}
                         </Col>
-                        <Col span={4}>
+                        <Col>
                             { locked
                                 ? <Icon type='lock' onClick={unlock} />
                                 : <Icon type='unlock' onClick={lock} />}
                         </Col>
-                        <Col span={4}>
+                        <Col>
                             { occluded
                                 ? <Icon type='team' onClick={unsetOccluded} />
                                 : <Icon type='user' onClick={setOccluded} />}
                         </Col>
-                        <Col span={4}>
+                        <Col>
                             { hidden
                                 ? <Icon type='eye-invisible' onClick={show} />
                                 : <Icon type='eye' onClick={hide} />}
                         </Col>
-                        <Col span={4}>
+                        <Col>
                             { keyframe
                                 ? <Icon type='star' theme='filled' onClick={unsetKeyframe} />
                                 : <Icon type='star' onClick={setKeyframe} />}
                         </Col>
-                        <Col span={4}>
-                            { pinned
-                                ? <Icon type='pushpin' theme='filled' onClick={unpin} />
-                                : <Icon type='pushpin' onClick={pin} />}
-                        </Col>
+                        {
+                            shapeType !== ShapeType.POINTS && (
+                                <Col>
+                                    { pinned
+                                        ? <Icon type='pushpin' theme='filled' onClick={unpin} />
+                                        : <Icon type='pushpin' onClick={pin} />}
+                                </Col>
+                            )
+                        }
                     </Row>
                 </Col>
             </Row>
@@ -300,26 +306,30 @@ function ItemButtonsComponent(props: ItemButtonsComponentProps): JSX.Element {
         <Row type='flex' align='middle' justify='space-around'>
             <Col span={20} style={{ textAlign: 'center' }}>
                 <Row type='flex' justify='space-around'>
-                    <Col span={6}>
+                    <Col>
                         { locked
                             ? <Icon type='lock' onClick={unlock} />
                             : <Icon type='unlock' onClick={lock} />}
                     </Col>
-                    <Col span={6}>
+                    <Col>
                         { occluded
                             ? <Icon type='team' onClick={unsetOccluded} />
                             : <Icon type='user' onClick={setOccluded} />}
                     </Col>
-                    <Col span={6}>
+                    <Col>
                         { hidden
                             ? <Icon type='eye-invisible' onClick={show} />
                             : <Icon type='eye' onClick={hide} />}
                     </Col>
-                    <Col span={6}>
-                        { pinned
-                            ? <Icon type='pushpin' theme='filled' onClick={unpin} />
-                            : <Icon type='pushpin' onClick={pin} />}
-                    </Col>
+                    {
+                        shapeType !== ShapeType.POINTS && (
+                            <Col>
+                                { pinned
+                                    ? <Icon type='pushpin' theme='filled' onClick={unpin} />
+                                    : <Icon type='pushpin' onClick={pin} />}
+                            </Col>
+                        )
+                    }
                 </Row>
             </Col>
         </Row>
@@ -727,6 +737,7 @@ function ObjectItemComponent(props: Props): JSX.Element {
                     toForeground={toForeground}
                 />
                 <ItemButtons
+                    shapeType={shapeType}
                     objectType={objectType}
                     occluded={occluded}
                     outside={outside}

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -277,6 +277,18 @@ class ObjectItemContainer extends React.PureComponent<Props> {
         this.commit();
     };
 
+    private pin = (): void => {
+        const { objectState } = this.props;
+        objectState.pinned = true;
+        this.commit();
+    };
+
+    private unpin = (): void => {
+        const { objectState } = this.props;
+        objectState.pinned = false;
+        this.commit();
+    };
+
     private show = (): void => {
         const { objectState } = this.props;
         objectState.hidden = false;
@@ -407,6 +419,7 @@ class ObjectItemContainer extends React.PureComponent<Props> {
                 occluded={objectState.occluded}
                 outside={objectState.outside}
                 locked={objectState.lock}
+                pinned={objectState.pinned}
                 hidden={objectState.hidden}
                 keyframe={objectState.keyframe}
                 attrValues={{ ...objectState.attributes }}
@@ -446,6 +459,8 @@ class ObjectItemContainer extends React.PureComponent<Props> {
                 unsetKeyframe={this.unsetKeyframe}
                 lock={this.lock}
                 unlock={this.unlock}
+                pin={this.pin}
+                unpin={this.unpin}
                 hide={this.hide}
                 show={this.show}
                 changeLabel={this.changeLabel}


### PR DESCRIPTION
* Enabled by default for all polyshapes
* Pinned shapes cannot be moved (resize, changing attributes, etc. work as usual)
* Undo/redo support

![Screenshot from 2020-02-26 18-11-41](https://user-images.githubusercontent.com/40690378/75358546-1bb67c80-58c4-11ea-8f0a-5815adf336c8.png)
