### PR TITLE
React UI: Batch of fixes

### DIFF
--- a/cvat-canvas/README.md
+++ b/cvat-canvas/README.md
@@ -37,10 +37,15 @@ Canvas itself handles:
         CLOCKWISE90,
     }
 
+    enum RectDrawingMethod {
+        CLASSIC = 'By 2 points',
+        EXTREME_POINTS = 'By 4 points'
+    }
+
     interface DrawData {
         enabled: boolean;
         shapeType?: string;
-        rectDrawingMethod?: string;
+        rectDrawingMethod?: RectDrawingMethod;
         numberOfPoints?: number;
         initialState?: any;
         crosshair?: boolean;
@@ -147,6 +152,7 @@ Standard JS events are used.
         enabled: true,
         shapeType: 'rectangle',
         crosshair: true,
+        rectDrawingMethod: window.Canvas.RectDrawingMethod.CLASSIC,
     });
 ```
 

--- a/cvat-canvas/src/typescript/canvas.ts
+++ b/cvat-canvas/src/typescript/canvas.ts
@@ -10,6 +10,7 @@ import {
     GroupData,
     CanvasModel,
     CanvasModelImpl,
+    RectDrawingMethod,
 } from './canvasModel';
 
 import {
@@ -141,4 +142,5 @@ export {
     CanvasImpl as Canvas,
     Rotation,
     CanvasVersion,
+    RectDrawingMethod,
 };

--- a/cvat-canvas/src/typescript/canvasModel.ts
+++ b/cvat-canvas/src/typescript/canvasModel.ts
@@ -4,7 +4,6 @@
 
 import { MasterImpl } from './master';
 
-
 export interface Size {
     width: number;
     height: number;
@@ -36,10 +35,15 @@ export interface ActiveElement {
     attributeID: number | null;
 }
 
+export enum RectDrawingMethod {
+    CLASSIC = 'By 2 points',
+    EXTREME_POINTS = 'By 4 points'
+}
+
 export interface DrawData {
     enabled: boolean;
     shapeType?: string;
-    rectDrawingMethod?: string;
+    rectDrawingMethod?: RectDrawingMethod;
     numberOfPoints?: number;
     initialState?: any;
     crosshair?: boolean;

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -552,7 +552,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
         this.grid.setAttribute('version', '2');
         this.gridPath.setAttribute('d', 'M 1000 0 L 0 0 0 1000');
         this.gridPath.setAttribute('fill', 'none');
-        this.gridPath.setAttribute('stroke-width', '1.5');
+        this.gridPath.setAttribute('stroke-width', `${consts.BASE_GRID_WIDTH}`);
+        this.gridPath.setAttribute('opacity', 'inherit');
         this.gridPattern.setAttribute('id', 'cvat_canvas_grid_pattern');
         this.gridPattern.setAttribute('width', '100');
         this.gridPattern.setAttribute('height', '100');

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -626,7 +626,9 @@ export class CanvasViewImpl implements CanvasView, Listener {
 
         this.content.addEventListener('mousedown', (event): void => {
             if ([1, 2].includes(event.which)) {
-                self.controller.enableDrag(event.clientX, event.clientY);
+                if (![Mode.ZOOM_CANVAS, Mode.GROUP].includes(this.mode) || event.which === 2) {
+                    self.controller.enableDrag(event.clientX, event.clientY);
+                }
                 event.preventDefault();
             }
         });
@@ -1072,7 +1074,6 @@ export class CanvasViewImpl implements CanvasView, Listener {
         this.activeElement = { ...activeElement };
         const shape = this.svgShapes[clientID];
         let text = this.svgTexts[clientID];
-        // Draw text if it's hidden by default
         if (!text) {
             text = this.addText(state);
             this.svgTexts[state.clientID] = text;

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -125,6 +125,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 },
             });
 
+            this.drawnStates[state.clientID].points = points;
             this.canvas.dispatchEvent(event);
         } else {
             const event: CustomEvent = new CustomEvent('canvas.canceled', {

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -1060,22 +1060,17 @@ export class CanvasViewImpl implements CanvasView, Listener {
         const [state] = this.controller.objects
             .filter((_state: any): boolean => _state.clientID === clientID);
 
-        if (!state) {
-            return;
-        }
-
-        if (state.shapeType === 'points') {
+        if (state && state.shapeType === 'points') {
             this.svgShapes[clientID].remember('_selectHandler').nested
                 .style('pointer-events', state.lock ? 'none' : '');
         }
 
-        if (state.hidden || state.lock) {
+        if (!state || state.hidden || state.outside) {
             return;
         }
 
         this.activeElement = { ...activeElement };
         const shape = this.svgShapes[clientID];
-        shape.addClass('cvat_canvas_shape_activated');
         let text = this.svgTexts[clientID];
         // Draw text if it's hidden by default
         if (!text) {
@@ -1087,7 +1082,11 @@ export class CanvasViewImpl implements CanvasView, Listener {
             );
         }
 
-        const self = this;
+        if (state.lock) {
+            return;
+        }
+
+        shape.addClass('cvat_canvas_shape_activated');
         if (state.shapeType === 'points') {
             this.content.append(this.svgShapes[clientID]
                 .remember('_selectHandler').nested.node);
@@ -1103,7 +1102,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
         }).on('dragend', (e: CustomEvent): void => {
             if (text) {
                 text.removeClass('cvat_canvas_hidden');
-                self.updateTextPosition(
+                this.updateTextPosition(
                     text,
                     shape,
                 );
@@ -1153,7 +1152,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
 
             if (text) {
                 text.removeClass('cvat_canvas_hidden');
-                self.updateTextPosition(
+                this.updateTextPosition(
                     text,
                     shape,
                 );

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -106,11 +106,10 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 this.geometry,
             );
         } else {
+            this.mode = Mode.IDLE;
             this.controller.draw({
                 enabled: false,
             });
-
-            this.mode = Mode.IDLE;
         }
     }
 
@@ -763,13 +762,16 @@ export class CanvasViewImpl implements CanvasView, Listener {
             }
         } else if (reason === UpdateReasons.DRAW) {
             const data: DrawData = this.controller.drawData;
-            if (data.enabled) {
+            if (data.enabled && this.mode === Mode.IDLE) {
                 this.canvas.style.cursor = 'crosshair';
                 this.mode = Mode.DRAW;
+                this.drawHandler.draw(data, this.geometry);
             } else {
                 this.canvas.style.cursor = '';
+                if (this.mode !== Mode.IDLE) {
+                    this.drawHandler.draw(data, this.geometry);
+                }
             }
-            this.drawHandler.draw(data, this.geometry);
         } else if (reason === UpdateReasons.MERGE) {
             const data: MergeData = this.controller.mergeData;
             if (data.enabled) {

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -125,7 +125,6 @@ export class CanvasViewImpl implements CanvasView, Listener {
                 },
             });
 
-            this.drawnStates[state.clientID].points = points;
             this.canvas.dispatchEvent(event);
         } else {
             const event: CustomEvent = new CustomEvent('canvas.canceled', {
@@ -1124,6 +1123,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         + `${shape.attr('y') + shape.attr('height')}`,
                 ).map((x: number): number => x - offset);
 
+                this.drawnStates[state.clientID].points = points;
                 this.onEditDone(state, points);
             }
         });
@@ -1172,6 +1172,7 @@ export class CanvasViewImpl implements CanvasView, Listener {
                         + `${shape.attr('y') + shape.attr('height')}`,
                 ).map((x: number): number => x - offset);
 
+                this.drawnStates[state.clientID].points = points;
                 this.onEditDone(state, points);
             }
         });

--- a/cvat-canvas/src/typescript/consts.ts
+++ b/cvat-canvas/src/typescript/consts.ts
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: MIT
 
 const BASE_STROKE_WIDTH = 1.75;
-const BASE_GRID_WIDTH = 1;
+const BASE_GRID_WIDTH = 2;
 const BASE_POINT_SIZE = 5;
 const TEXT_MARGIN = 10;
 const AREA_THRESHOLD = 9;

--- a/cvat-canvas/src/typescript/drawHandler.ts
+++ b/cvat-canvas/src/typescript/drawHandler.ts
@@ -216,9 +216,6 @@ export class DrawHandlerImpl implements DrawHandler {
                 if (numberOfPoints > 0) {
                     numberOfPoints -= 1;
                 }
-            }).on('drawdone', (): void => {
-                // close drawing mode without drawing rect
-                this.cancel();
             });
 
         this.drawPolyshape();

--- a/cvat-canvas/src/typescript/drawHandler.ts
+++ b/cvat-canvas/src/typescript/drawHandler.ts
@@ -10,6 +10,7 @@ import './svg.patch';
 import {
     DrawData,
     Geometry,
+    RectDrawingMethod,
 } from './canvasModel';
 
 import {
@@ -160,7 +161,7 @@ export class DrawHandlerImpl implements DrawHandler {
                 const { drawInstance } = this;
                 this.drawInstance = null;
                 if (this.drawData.shapeType === 'rectangle'
-                    && this.drawData.rectDrawingMethod !== 'by_four_points') {
+                    && this.drawData.rectDrawingMethod !== RectDrawingMethod.EXTREME_POINTS) {
                     drawInstance.draw('cancel');
                 } else {
                     drawInstance.draw('done');
@@ -206,10 +207,10 @@ export class DrawHandlerImpl implements DrawHandler {
             .addClass('cvat_canvas_shape_drawing').attr({
                 'stroke-width': 0,
                 opacity: 0,
-            }).on('drawstart', () => {
+            }).on('drawstart', (): void => {
                 // init numberOfPoints as one on drawstart
                 numberOfPoints = 1;
-            }).on('drawpoint', (e: CustomEvent) => {
+            }).on('drawpoint', (e: CustomEvent): void => {
                 // increase numberOfPoints by one on drawpoint
                 numberOfPoints += 1;
 
@@ -227,11 +228,11 @@ export class DrawHandlerImpl implements DrawHandler {
                         this.onDrawDone(null);
                     }
                 }
-            }).on('undopoint', () => {
+            }).on('undopoint', (): void => {
                 if (numberOfPoints > 0) {
                     numberOfPoints -= 1;
                 }
-            }).off('drawdone').on('drawdone', () => {
+            }).on('drawdone', (): void => {
                 // close drawing mode without drawing rect
                 this.onDrawDone(null);
             });
@@ -578,7 +579,7 @@ export class DrawHandlerImpl implements DrawHandler {
             this.setupPasteEvents();
         } else {
             if (this.drawData.shapeType === 'rectangle') {
-                if (this.drawData.rectDrawingMethod === 'by_four_points') {
+                if (this.drawData.rectDrawingMethod === RectDrawingMethod.EXTREME_POINTS) {
                     // draw box by extreme clicking
                     this.drawBoxBy4Points();
                 } else {

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -20,6 +20,7 @@ import {
 } from 'reducers/interfaces';
 
 import getCore from 'cvat-core';
+import { RectDrawingMethod } from 'cvat-canvas';
 import { getCVATStore } from 'cvat-store';
 
 const cvat = getCore();
@@ -807,7 +808,7 @@ export function drawShape(
     labelID: number,
     objectType: ObjectType,
     points?: number,
-    rectDrawingMethod?: string,
+    rectDrawingMethod?: RectDrawingMethod,
 ): AnyAction {
     let activeControl = ActiveControl.DRAW_RECTANGLE;
     if (shapeType === ShapeType.POLYGON) {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/canvas-wrapper.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/canvas-wrapper.tsx
@@ -100,10 +100,6 @@ export default class CanvasWrapperComponent extends React.PureComponent<Props> {
             colorBy,
             selectedOpacity,
             blackBorders,
-            grid,
-            gridSize,
-            gridColor,
-            gridOpacity,
             frameData,
             annotations,
             canvasInstance,
@@ -122,34 +118,12 @@ export default class CanvasWrapperComponent extends React.PureComponent<Props> {
             }
         }
 
-        if (prevProps.grid !== grid) {
-            const gridElement = window.document.getElementById('cvat_canvas_grid');
-            if (gridElement) {
-                gridElement.style.display = grid ? 'block' : 'none';
-            }
-        }
-
-        if (prevProps.gridSize !== gridSize) {
-            canvasInstance.grid(gridSize, gridSize);
-        }
-
-        if (prevProps.gridColor !== gridColor) {
-            const gridPattern = window.document.getElementById('cvat_canvas_grid_pattern');
-            if (gridPattern) {
-                gridPattern.style.stroke = gridColor.toLowerCase();
-            }
-        }
-
-        if (prevProps.gridOpacity !== gridOpacity) {
-            const gridPattern = window.document.getElementById('cvat_canvas_grid_pattern');
-            if (gridPattern) {
-                gridPattern.style.opacity = `${gridOpacity / 100}`;
-            }
-        }
-
         if (prevProps.activatedStateID !== null
             && prevProps.activatedStateID !== activatedStateID) {
             canvasInstance.activate(null);
+        }
+
+        if (activatedStateID) {
             const el = window.document.getElementById(`cvat_canvas_shape_${prevProps.activatedStateID}`);
             if (el) {
                 (el as any).instance.fill({ opacity: opacity / 100 });
@@ -160,15 +134,15 @@ export default class CanvasWrapperComponent extends React.PureComponent<Props> {
             this.updateCanvas();
         }
 
-        if (prevProps.opacity !== opacity || prevProps.blackBorders !== blackBorders
-            || prevProps.selectedOpacity !== selectedOpacity || prevProps.colorBy !== colorBy) {
-            this.updateShapesView();
-        }
-
         if (prevProps.frame !== frameData.number && resetZoom) {
             canvasInstance.html().addEventListener('canvas.setup', () => {
                 canvasInstance.fit();
             }, { once: true });
+        }
+
+        if (prevProps.opacity !== opacity || prevProps.blackBorders !== blackBorders
+            || prevProps.selectedOpacity !== selectedOpacity || prevProps.colorBy !== colorBy) {
+            this.updateShapesView();
         }
 
         if (prevProps.curZLayer !== curZLayer) {

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -139,6 +139,7 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
                 <Col span={12}>
                     <Button
                         onClick={onDrawTrack}
+                        disabled={shapeType !== ShapeType.RECTANGLE}
                     >
                         Track
                     </Button>

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -16,10 +16,8 @@ import {
 import { RadioChangeEvent } from 'antd/lib/radio';
 import Text from 'antd/lib/typography/Text';
 
-import {
-    ShapeType,
-    RectDrawingMethod,
-} from 'reducers/interfaces';
+import { RectDrawingMethod } from 'cvat-canvas';
+import { ShapeType } from 'reducers/interfaces';
 
 interface Props {
     shapeType: ShapeType;
@@ -42,6 +40,7 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
         minimumPoints,
         selectedLabeID,
         numberOfPoints,
+        rectDrawingMethod,
         onDrawTrack,
         onDrawShape,
         onChangeLabel,
@@ -92,17 +91,17 @@ function DrawShapePopoverComponent(props: Props): JSX.Element {
                             <Col>
                                 <Radio.Group
                                     style={{ display: 'flex' }}
-                                    defaultValue={RectDrawingMethod.BY_TWO_POINTS}
+                                    value={rectDrawingMethod}
                                     onChange={onChangeRectDrawingMethod}
                                 >
                                     <Radio
-                                        value={RectDrawingMethod.BY_TWO_POINTS}
+                                        value={RectDrawingMethod.CLASSIC}
                                         style={{ width: 'auto' }}
                                     >
                                         By 2 Points
                                     </Radio>
                                     <Radio
-                                        value={RectDrawingMethod.BY_FOUR_POINTS}
+                                        value={RectDrawingMethod.EXTREME_POINTS}
                                         style={{ width: 'auto' }}
                                     >
                                         By 4 Points

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -21,9 +21,9 @@ import { ShapeType } from 'reducers/interfaces';
 
 interface Props {
     shapeType: ShapeType;
-    rectDrawingMethod: RectDrawingMethod;
     labels: any[];
     minimumPoints: number;
+    rectDrawingMethod?: RectDrawingMethod;
     numberOfPoints?: number;
     selectedLabeID: number;
     onChangeLabel(value: string): void;

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -10,13 +10,12 @@ import {
     CombinedState,
     ShapeType,
     ObjectType,
-    RectDrawingMethod,
 } from 'reducers/interfaces';
 
 import {
     drawShape,
 } from 'actions/annotation-actions';
-import { Canvas } from 'cvat-canvas';
+import { Canvas, RectDrawingMethod } from 'cvat-canvas';
 import DrawShapePopoverComponent from 'components/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover';
 
 interface OwnProps {
@@ -29,7 +28,7 @@ interface DispatchToProps {
         labelID: number,
         objectType: ObjectType,
         points?: number,
-        rectDrawingMethod?: string,
+        rectDrawingMethod?: RectDrawingMethod,
     ): void;
 }
 
@@ -46,7 +45,7 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
             labelID: number,
             objectType: ObjectType,
             points?: number,
-            rectDrawingMethod?: string,
+            rectDrawingMethod?: RectDrawingMethod,
         ): void {
             dispatch(drawShape(shapeType, labelID, objectType, points, rectDrawingMethod));
         },
@@ -75,7 +74,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
 type Props = StateToProps & DispatchToProps;
 
 interface State {
-    rectDrawingMethod?: string;
+    rectDrawingMethod: RectDrawingMethod;
     numberOfPoints?: number;
     selectedLabelID: number;
 }
@@ -85,13 +84,14 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
     constructor(props: Props) {
         super(props);
 
+        const { shapeType } = props;
         const defaultLabelID = props.labels[0].id;
-        const defaultRectDrawingMethod = RectDrawingMethod.BY_TWO_POINTS;
+        const defaultRectDrawingMethod = RectDrawingMethod.CLASSIC;
         this.state = {
             selectedLabelID: defaultLabelID,
+            rectDrawingMethod: defaultRectDrawingMethod,
         };
 
-        const { shapeType } = props;
         if (shapeType === ShapeType.POLYGON) {
             this.minimumPoints = 3;
         }
@@ -100,9 +100,6 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         }
         if (shapeType === ShapeType.POINTS) {
             this.minimumPoints = 1;
-        }
-        if (shapeType === ShapeType.RECTANGLE) {
-            this.state.rectDrawingMethod = defaultRectDrawingMethod;
         }
     }
 
@@ -166,6 +163,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
 
     public render(): JSX.Element {
         const {
+            rectDrawingMethod,
             selectedLabelID,
             numberOfPoints,
         } = this.state;
@@ -182,6 +180,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
                 minimumPoints={this.minimumPoints}
                 selectedLabeID={selectedLabelID}
                 numberOfPoints={numberOfPoints}
+                rectDrawingMethod={rectDrawingMethod}
                 onChangeLabel={this.onChangeLabel}
                 onChangePoints={this.onChangePoints}
                 onChangeRectDrawingMethod={this.onChangeRectDrawingMethod}

--- a/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx
@@ -74,7 +74,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
 type Props = StateToProps & DispatchToProps;
 
 interface State {
-    rectDrawingMethod: RectDrawingMethod;
+    rectDrawingMethod?: RectDrawingMethod;
     numberOfPoints?: number;
     selectedLabelID: number;
 }
@@ -89,7 +89,8 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         const defaultRectDrawingMethod = RectDrawingMethod.CLASSIC;
         this.state = {
             selectedLabelID: defaultLabelID,
-            rectDrawingMethod: defaultRectDrawingMethod,
+            rectDrawingMethod: shapeType === ShapeType.RECTANGLE
+                ? defaultRectDrawingMethod : undefined,
         };
 
         if (shapeType === ShapeType.POLYGON) {
@@ -126,7 +127,7 @@ class DrawShapePopoverContainer extends React.PureComponent<Props, State> {
         });
 
         onDrawStart(shapeType, selectedLabelID,
-            objectType, numberOfPoints);
+            objectType, numberOfPoints, rectDrawingMethod);
     }
 
     private onChangeRectDrawingMethod = (event: RadioChangeEvent): void => {

--- a/cvat-ui/src/cvat-canvas.ts
+++ b/cvat-ui/src/cvat-canvas.ts
@@ -6,10 +6,12 @@ import {
     Canvas,
     Rotation,
     CanvasVersion,
+    RectDrawingMethod,
 } from '../../cvat-canvas/src/typescript/canvas';
 
 export {
     Canvas,
     Rotation,
     CanvasVersion,
+    RectDrawingMethod,
 };

--- a/cvat-ui/src/reducers/interfaces.ts
+++ b/cvat-ui/src/reducers/interfaces.ts
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import { Canvas } from 'cvat-canvas';
+import { Canvas, RectDrawingMethod } from 'cvat-canvas';
 
 export type StringObject = {
     [index: string]: string;
@@ -249,11 +249,6 @@ export enum ActiveControl {
     GROUP = 'group',
     SPLIT = 'split',
     EDIT = 'edit',
-}
-
-export enum RectDrawingMethod {
-    BY_TWO_POINTS = 'by_two_points',
-    BY_FOUR_POINTS = 'by_four_points'
 }
 
 export enum ShapeType {

--- a/cvat-ui/src/reducers/settings-reducer.ts
+++ b/cvat-ui/src/reducers/settings-reducer.ts
@@ -34,7 +34,7 @@ const defaultState: SettingsState = {
         grid: false,
         gridSize: 100,
         gridColor: GridColor.White,
-        gridOpacity: 0,
+        gridOpacity: 100,
         brightnessLevel: 100,
         contrastLevel: 100,
         saturationLevel: 100,

--- a/cvat-ui/src/reducers/settings-reducer.ts
+++ b/cvat-ui/src/reducers/settings-reducer.ts
@@ -4,6 +4,7 @@
 
 import { AnyAction } from 'redux';
 import { SettingsActionTypes } from 'actions/settings-actions';
+import { AnnotationActionTypes } from 'actions/annotation-actions';
 
 import {
     SettingsState,
@@ -210,6 +211,17 @@ export default (state = defaultState, action: AnyAction): SettingsState => {
                 workspace: {
                     ...state.workspace,
                     showAllInterpolationTracks: action.payload.showAllInterpolationTracks,
+                },
+            };
+        }
+        case AnnotationActionTypes.GET_JOB_SUCCESS: {
+            const { job } = action.payload;
+
+            return {
+                ...state,
+                player: {
+                    ...state.player,
+                    resetZoom: job && job.task.mode === 'annotation',
                 },
             };
         }


### PR DESCRIPTION
Fix: issues with drawing (corner cases)
Fix: grid opacity doesn't work
Fix: putting shape out of canvas works wrong
Fix: reset zoom for images by default
Fix: selecting in grouping mode
Fix: selecting in panzoom mode
Fix: text for locked shapes aren't displayed
Fix: outside shapes can be activated
Fix: issues with code in ``cvat-ui/src/containers/annotation-page/standard-workspace/controls-side-bar/draw-shape-popover.tsx``
Fix: Disable tracks for polygons, polyshapes and points (because it isn't supported by server and algorithms can be changed in the future)