### PR TITLE
Auto-generate labelmap during VOC import

### DIFF
--- a/cvat/apps/annotation/pascal_voc.py
+++ b/cvat/apps/annotation/pascal_voc.py
@@ -36,6 +36,14 @@ def load(file_object, annotations):
     with TemporaryDirectory() as tmp_dir:
         Archive(archive_file).extractall(tmp_dir)
 
+        # put label map from the task if not present
+        labelmap_file = osp.join(tmp_dir, 'labelmap.txt')
+        if not osp.isfile(labelmap_file):
+            labels = (label['name'] + ':::'
+                for _, label in annotations.meta['task']['labels'])
+            with open(labelmap_file, 'w') as f:
+                f.write('\n'.join(labels))
+
         # support flat archive layout
         anno_dir = osp.join(tmp_dir, 'Annotations')
         if not osp.isdir(anno_dir):

--- a/datumaro/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/datumaro/plugins/voc_format/extractor.py
@@ -155,7 +155,12 @@ class VocExtractor(SourceExtractor):
 
     def _get_label_id(self, label):
         label_id, _ = self._categories[AnnotationType.label].find(label)
-        assert label_id is not None
+        if label_id is None:
+            log.debug("Unknown label '%s'. Loaded labels: %s",
+                label,
+                ', '.join("'%s'" % s.name
+                    for s in self._categories[AnnotationType.label].items))
+            raise Exception("Unknown label '%s'" % label)
         return label_id
 
     @staticmethod


### PR DESCRIPTION
Auto generate `labelmap.txt` during import of VOC annotations from the task. Produce meaningful error in the case of foreign labels.