### PR TITLE
Some debian package manager tweaks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,7 +15,7 @@ Next steps should work on clear Ubuntu 18.04.
 - Install necessary dependencies:
 
 ```sh
-$ sudo apt update && apt install -y nodejs npm curl redis-server python3-dev python3-pip python3-venv libldap2-dev libsasl2-dev
+$ sudo apt-get update && apt-get --no-install-recommends install -y nodejs npm curl redis-server python3-dev python3-pip python3-venv libldap2-dev libsasl2-dev
 ```
 
 -   Install [Visual Studio Code](https://code.visualstudio.com/docs/setup/linux#_debian-and-ubuntu-based-distributions)

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,12 +21,12 @@ ENV DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION}
 
 # Install necessary apt packages
 RUN apt-get update && \
-    apt-get install -yq \
+    apt-get --no-install-recommends install -yq \
         software-properties-common && \
     add-apt-repository ppa:mc3man/xerus-media -y && \
     add-apt-repository ppa:mc3man/gstffmpeg-keep -y && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -yq \
         apache2 \
         apache2-dev \
         libapache2-mod-xsendfile \
@@ -44,7 +44,7 @@ RUN apt-get update && \
         poppler-utils \
         curl && \
     curl https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && \
-    apt-get install -y git-lfs && git lfs install && \
+    apt-get --no-install-recommends install -y git-lfs && git lfs install && \
     if [ -z ${socks_proxy} ]; then \
         echo export "GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30\"" >> ${HOME}/.bashrc; \
     else \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,7 @@ RUN apt-get update && \
     add-apt-repository ppa:mc3man/gstffmpeg-keep -y && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -yq \
-        apache2 \   
+        apache2 \
         apache2-dev \
         apt-utils \
         build-essential \

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,8 +27,10 @@ RUN apt-get update && \
     add-apt-repository ppa:mc3man/gstffmpeg-keep -y && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -yq \
-        apache2 \
+        apache2 \   
         apache2-dev \
+        apt-utils \
+        build-essential \
         libapache2-mod-xsendfile \
         supervisor \
         ffmpeg \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -8,8 +8,11 @@ RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &
     curl https://deb.nodesource.com/setup_9.x | bash - && \
     apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -yq \
+        apt-utils \
+        build-essential \
         google-chrome-stable \
-        nodejs && \
+        nodejs \
+        python3-dev && \
     rm -rf /var/lib/apt/lists/*;
 
 RUN python3 -m pip install --no-cache-dir -r /tmp/requirements/${DJANGO_CONFIGURATION}.txt

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -7,7 +7,7 @@ RUN curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - &
     echo 'deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main' | tee /etc/apt/sources.list.d/google-chrome.list && \
     curl https://deb.nodesource.com/setup_9.x | bash - && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -yq \
+    DEBIAN_FRONTEND=noninteractive apt-get --no-install-recommends install -yq \
         google-chrome-stable \
         nodejs && \
     rm -rf /var/lib/apt/lists/*;

--- a/components/cuda/README.md
+++ b/components/cuda/README.md
@@ -13,10 +13,10 @@
 sudo add-apt-repository ppa:graphics-drivers/ppa
 sudo apt-get update
 sudo apt-cache search nvidia-*   # find latest nvidia driver
-sudo apt-get install nvidia-*    # install the nvidia driver
-sudo apt-get install mesa-common-dev
-sudo apt-get install freeglut3-dev
-sudo apt-get install nvidia-modprobe
+sudo apt-get --no-install-recommends install nvidia-*    # install the nvidia driver
+sudo apt-get --no-install-recommends install mesa-common-dev
+sudo apt-get --no-install-recommends install freeglut3-dev
+sudo apt-get --no-install-recommends install nvidia-modprobe
 ```
 
 #### Reboot your PC and verify installation by `nvidia-smi` command.

--- a/components/openvino/install.sh
+++ b/components/openvino/install.sh
@@ -22,7 +22,7 @@ cd /tmp/components/openvino
 tar -xzf `ls | grep "openvino_toolkit"`
 cd `ls -d */ | grep "openvino_toolkit"`
 
-apt-get update && apt-get install -y sudo cpio && \
+apt-get update && apt-get --no-install-recommends install -y sudo cpio && \
  if [ -f "install_cv_sdk_dependencies.sh" ]; then ./install_cv_sdk_dependencies.sh; \
  else ./install_openvino_dependencies.sh; fi && SUDO_FORCE_REMOVE=yes apt-get remove -y sudo
 

--- a/cvat/apps/documentation/installation.md
+++ b/cvat/apps/documentation/installation.md
@@ -27,7 +27,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
 
     ```sh
     sudo apt-get update
-    sudo apt-get install -y \
+    sudo apt-get --no-install-recommends install -y \
       apt-transport-https \
       ca-certificates \
       curl \
@@ -39,7 +39,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
       $(lsb_release -cs) \
       stable"
     sudo apt-get update
-    sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+    sudo apt-get --no-install-recommends install -y docker-ce docker-ce-cli containerd.io
     ```
 
 -   Perform [post-installation steps](https://docs.docker.com/install/linux/linux-postinstall/)
@@ -57,7 +57,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
     defining and running multi-container docker applications.
 
     ```bash
-    sudo apt-get install -y python3-pip
+    sudo apt-get --no-install-recommends install -y python3-pip
     sudo python3 -m pip install docker-compose
     ```
 
@@ -65,7 +65,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
     [GitHub repository](https://github.com/opencv/cvat).
 
     ```bash
-    sudo apt-get install -y git
+    sudo apt-get --no-install-recommends install -y git
     git clone https://github.com/opencv/cvat
     cd cvat
     ```
@@ -103,7 +103,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
     curl https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
     sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
     sudo apt-get update
-    sudo apt-get install -y google-chrome-stable
+    sudo apt-get --no-install-recommends install -y google-chrome-stable
     ```
 
 -   Open the installed Google Chrome browser and go to [localhost:8080](http://localhost:8080).


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages . 

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .