### PR TITLE
[Datumaro] Allow empty COCO dataset export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- Annotation-less tasks now can be exported as empty datasets in COCO ([#1277](https://github.com/opencv/cvat/issues/1277))
 
 ### Security
 -

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -632,10 +632,13 @@ class CocoConverterTest(TestCase):
 
             def categories(self):
                 label_cat = LabelCategories()
+                point_cat = PointsCategories()
                 for label in range(10):
                     label_cat.add('label_' + str(label))
+                    point_cat.add(label)
                 return {
                     AnnotationType.label: label_cat,
+                    AnnotationType.points: point_cat,
                 }
 
         with TestDir() as test_dir:
@@ -651,4 +654,4 @@ class CocoConverterTest(TestCase):
 
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),
-                CocoConverter(), test_dir)
+                CocoConverter(tasks='image_info'), test_dir)


### PR DESCRIPTION
- Allows annotation-less projects to be exported as valid empty datasets in COCO

Fixes #1277 