### PR TITLE
[Datumaro] Fix frame matching in video annotations import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Fixed
--
+- Frame name matching for video annotations import -
+  allowed `frame_XXXXXX[.ext]` format ([#1274](https://github.com/opencv/cvat/pull/1274))
 
 ### Security
 -

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -177,6 +177,8 @@ class CvatTaskExtractor(CvatAnnotationsExtractor):
 
 
 def match_frame(item, cvat_task_anno):
+    is_video = cvat_task_anno.meta['task']['mode'] == 'interpolation'
+
     frame_number = None
     if frame_number is None:
         try:
@@ -193,6 +195,8 @@ def match_frame(item, cvat_task_anno):
             frame_number = int(item.id)
         except Exception:
             pass
+    if frame_number is None and is_video and item.id.startswith('frame_'):
+        frame_number = int(item.id[len('frame_'):])
     if not frame_number in cvat_task_anno.frame_info:
         raise Exception("Could not match item id: '%s' with any task frame" %
             item.id)

--- a/datumaro/datumaro/plugins/yolo_format/extractor.py
+++ b/datumaro/datumaro/plugins/yolo_format/extractor.py
@@ -90,7 +90,9 @@ class YoloExtractor(SourceExtractor):
             subset = YoloExtractor.Subset(subset_name, self)
             with open(list_path, 'r') as f:
                 subset.items = OrderedDict(
-                    (osp.splitext(osp.basename(p))[0], p.strip()) for p in f)
+                    (osp.splitext(osp.basename(p.strip()))[0], p.strip())
+                    for p in f
+                )
 
             for item_id, image_path in subset.items.items():
                 image_path = self._make_local_path(image_path)


### PR DESCRIPTION
Add extra frame matching way for videos: frames can be named `frame_XXXXXX[.ext]`. This should be revised when #1007 is merged.
Fixed YOLO image id reading for provided image meta list.