### PR TITLE
Use source label map for voc export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Changed
-- 
+- VOC task export now does not use official label map by default, but takes one
+  from the source task to avoid primary-class and class part name
+  clashing ([#1275](https://github.com/opencv/cvat/issues/1275))
 
 ### Deprecated
 -

--- a/cvat/apps/annotation/pascal_voc.py
+++ b/cvat/apps/annotation/pascal_voc.py
@@ -74,7 +74,7 @@ def dump(file_object, annotations):
     extractor = CvatAnnotationsExtractor('', annotations)
     extractor = extractor.transform(id_from_image)
     extractor = Dataset.from_extractors(extractor) # apply lazy transforms
-    converter = env.make_converter('voc')
+    converter = env.make_converter('voc', label_map='source')
     with TemporaryDirectory() as temp_dir:
         converter(extractor, save_dir=temp_dir)
         make_zip_archive(temp_dir, file_object)


### PR DESCRIPTION
Fixes #1275 

VOC export now does not use official label map by default, but takes one from the source task to avoid primary class and class part clashing.