### PR TITLE
[Datumaro] Fix attributes with spaces in names

### DIFF
--- a/datumaro/datumaro/components/dataset_filter.py
+++ b/datumaro/datumaro/components/dataset_filter.py
@@ -48,7 +48,7 @@ class DatasetItemEncoder:
         ET.SubElement(ann_elem, 'type').text = str(annotation.type.name)
 
         for k, v in annotation.attributes.items():
-            ET.SubElement(ann_elem, k).text = str(v)
+            ET.SubElement(ann_elem, k.replace(' ', '-')).text = str(v)
 
         ET.SubElement(ann_elem, 'group').text = str(annotation.group)
 


### PR DESCRIPTION
Fixes dataset filtering for items having attributes with spaces in names by replacing spaces with `-`.