### PR TITLE
Increase preview size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added option to display shape text always
 
 ### Changed
--
+- Increase preview size of a task till 256, 256 on the server
 
 ### Deprecated
 -

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -52,11 +52,12 @@ class IMediaReader(ABC):
 
     @staticmethod
     def _get_preview(obj):
+        PREVIEW_SIZE = (256, 256)
         if isinstance(obj, io.IOBase):
             preview = Image.open(obj)
         else:
             preview = obj
-        preview.thumbnail((128, 128))
+        preview.thumbnail(PREVIEW_SIZE)
 
         return preview.convert('RGB')
 


### PR DESCRIPTION
Previous preview size was not optimal and led to a blurred image due to too small size.

Previous tasks will not be fixed by new ones should have a better preview size.
