### PR TITLE
session.annotations.put() returns indexes of added objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 -
 
 ### Changed
--
+- cvat-core: session.annotations.put() now returns identificators of added objects (<https://github.com/opencv/cvat/pull/1493>)
 
 ### Deprecated
 -

--- a/cvat-core/src/annotations-collection.js
+++ b/cvat-core/src/annotations-collection.js
@@ -806,6 +806,8 @@
                     object.removed = false;
                 });
             }, importedArray.map((object) => object.clientID), objectStates[0].frame);
+
+            return importedArray.map((value) => value.clientID);
         }
 
         select(objectStates, x, y) {

--- a/cvat-core/src/session.js
+++ b/cvat-core/src/session.js
@@ -280,7 +280,7 @@
                 * @method put
                 * @memberof Session.annotations
                 * @param {module:API.cvat.classes.ObjectState[]} data
-                * @returns {number[]} indexes of added objects
+                * @returns {number[]} identificators of added objects
                 * array of objects on the specific frame
                 * @throws {module:API.cvat.exceptions.PluginError}
                 * @throws {module:API.cvat.exceptions.DataError}

--- a/cvat-core/src/session.js
+++ b/cvat-core/src/session.js
@@ -280,6 +280,7 @@
                 * @method put
                 * @memberof Session.annotations
                 * @param {module:API.cvat.classes.ObjectState[]} data
+                * @returns {number[]} indexes of added objects
                 * array of objects on the specific frame
                 * @throws {module:API.cvat.exceptions.PluginError}
                 * @throws {module:API.cvat.exceptions.DataError}

--- a/cvat-core/tests/api/annotations.js
+++ b/cvat-core/tests/api/annotations.js
@@ -88,8 +88,10 @@ describe('Feature: put annotations', () => {
             zOrder: 0,
         });
 
-        await task.annotations.put([state]);
+        const indexes = await task.annotations.put([state]);
         annotations = await task.annotations.get(1);
+        expect(indexes).toBeInstanceOf(Array);
+        expect(indexes).toHaveLength(1);
         expect(annotations).toHaveLength(length + 1);
     });
 
@@ -108,7 +110,9 @@ describe('Feature: put annotations', () => {
             zOrder: 0,
         });
 
-        await job.annotations.put([state]);
+        const indexes = await job.annotations.put([state]);
+        expect(indexes).toBeInstanceOf(Array);
+        expect(indexes).toHaveLength(1);
         annotations = await job.annotations.get(5);
         expect(annotations).toHaveLength(length + 1);
     });
@@ -128,7 +132,9 @@ describe('Feature: put annotations', () => {
             zOrder: 0,
         });
 
-        await task.annotations.put([state]);
+        const indexes = await task.annotations.put([state]);
+        expect(indexes).toBeInstanceOf(Array);
+        expect(indexes).toHaveLength(1);
         annotations = await task.annotations.get(1);
         expect(annotations).toHaveLength(length + 1);
     });
@@ -148,7 +154,9 @@ describe('Feature: put annotations', () => {
             zOrder: 0,
         });
 
-        await job.annotations.put([state]);
+        const indexes = await job.annotations.put([state]);
+        expect(indexes).toBeInstanceOf(Array);
+        expect(indexes).toHaveLength(1);
         annotations = await job.annotations.get(5);
         expect(annotations).toHaveLength(length + 1);
     });


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
There aren't way to get information what objects have been just added with ```session.annotations.put()```. But sometimes we need this information to create some extra steps (for example, to automatically group them immediately after creating)

### How has this been tested?
Updated unit tests

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

Resolved #1486 
