### PR TITLE
[Datumaro] Change alignment in mask parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Task/Job buttons has no "Open in new tab" option (<https://github.com/opencv/cvat/pull/1419>)
 - Delete point context menu option has no shortcut hint (<https://github.com/opencv/cvat/pull/1416>)
 - Fixed issue with unnecessary tag activation in cvat-canvas (<https://github.com/opencv/cvat/issues/1540>)
+- Fixed an issue with large number of instances in instance mask (https://github.com/opencv/cvat/issues/1539)
 
 ### Security
 -

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -310,7 +310,7 @@ class CompiledMask:
     def instance_count(self):
         return int(self.instance_mask.max())
 
-    def get_instance_labels(self, class_count=None):
+    def get_instance_labels(self):
         class_shift = 16
         m = (self.class_mask.astype(np.uint32) << class_shift) \
             + self.instance_mask.astype(np.uint32)

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -270,7 +270,7 @@ class CompiledMask:
         if instance_ids is not None:
             assert len(instance_ids) == len(instance_masks)
         else:
-            instance_ids = [1 + i for i in range(len(instance_masks))]
+            instance_ids = range(1, len(instance_masks) + 1)
 
         if instance_labels is not None:
             assert len(instance_labels) == len(instance_masks)

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -311,14 +311,12 @@ class CompiledMask:
         return int(self.instance_mask.max())
 
     def get_instance_labels(self, class_count=None):
-        if class_count is None:
-            class_count = np.max(self.class_mask) + 1
-
-        m = self.class_mask * class_count + self.instance_mask
-        m = m.astype(int)
+        class_shift = 16
+        m = (self.class_mask.astype(np.uint32) << class_shift) \
+            + self.instance_mask.astype(np.uint32)
         keys = np.unique(m)
-        instance_labels = {k % class_count: k // class_count
-            for k in keys if k % class_count != 0
+        instance_labels = {k & ((1 << class_shift) - 1): k >> class_shift
+            for k in keys if k & ((1 << class_shift) - 1) != 0
         }
         return instance_labels
 

--- a/datumaro/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/datumaro/plugins/voc_format/extractor.py
@@ -251,8 +251,7 @@ class VocSegmentationExtractor(_VocExtractor):
 
             if class_mask is not None:
                 label_cat = self._categories[AnnotationType.label]
-                instance_labels = compiled_mask.get_instance_labels(
-                    class_count=len(label_cat.items))
+                instance_labels = compiled_mask.get_instance_labels()
             else:
                 instance_labels = {i: None
                     for i in range(compiled_mask.instance_count)}

--- a/datumaro/tests/test_masks.py
+++ b/datumaro/tests/test_masks.py
@@ -3,6 +3,7 @@ import numpy as np
 from unittest import TestCase
 
 import datumaro.util.mask_tools as mask_tools
+from datumaro.components.extractor import CompiledMask
 
 
 class PolygonConversionsTest(TestCase):
@@ -184,3 +185,13 @@ class ColormapOperationsTest(TestCase):
 
         self.assertTrue(np.array_equal(expected, actual),
             '%s\nvs.\n%s' % (expected, actual))
+
+    def test_can_decode_compiled_mask(self):
+        class_idx = 1000
+        instance_idx = 10000
+        mask = np.array([1])
+        compiled_mask = CompiledMask(mask * class_idx, mask * instance_idx)
+
+        labels = compiled_mask.get_instance_labels()
+
+        self.assertEqual({instance_idx: class_idx}, labels)

--- a/datumaro/tests/test_voc_format.py
+++ b/datumaro/tests/test_voc_format.py
@@ -448,6 +448,41 @@ class VocConverterTest(TestCase):
                 VocSegmentationConverter(label_map='voc'), test_dir,
                 target_dataset=DstExtractor())
 
+    def test_can_save_voc_segm_with_many_instances(self):
+        def bit(x, y, shape):
+            mask = np.zeros(shape)
+            mask[y, x] = 1
+            return mask
+
+        class TestExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, subset='a', annotations=[
+                        Mask(image=bit(x, y, shape=[10, 10]),
+                            label=self._label(VOC.VocLabel(3).name),
+                            z_order=10 * y + x + 1
+                        )
+                        for y in range(10) for x in range(10)
+                    ]),
+                ])
+
+        class DstExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id=1, subset='a', annotations=[
+                        Mask(image=bit(x, y, shape=[10, 10]),
+                            label=self._label(VOC.VocLabel(3).name),
+                            group=10 * y + x + 1
+                        )
+                        for y in range(10) for x in range(10)
+                    ]),
+                ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(TestExtractor(),
+                VocSegmentationConverter(label_map='voc'), test_dir,
+                target_dataset=DstExtractor())
+
     def test_can_save_voc_layout(self):
         class TestExtractor(TestExtractorBase):
             def __iter__(self):

--- a/datumaro/tests/test_voc_format.py
+++ b/datumaro/tests/test_voc_format.py
@@ -247,11 +247,7 @@ class VocExtractorTest(TestCase):
                                 label=self._label(VOC.VocLabel(2).name),
                                 group=1,
                             ),
-                        ] + [
-                            Mask(image=np.ones([5, 10]),
-                                label=self._label(VOC.VocLabel(3).name),
-                            ),
-                        ] * 100
+                        ]
                     ),
                 ])
 

--- a/datumaro/tests/test_voc_format.py
+++ b/datumaro/tests/test_voc_format.py
@@ -247,7 +247,11 @@ class VocExtractorTest(TestCase):
                                 label=self._label(VOC.VocLabel(2).name),
                                 group=1,
                             ),
-                        ]
+                        ] + [
+                            Mask(image=np.ones([5, 10]),
+                                label=self._label(VOC.VocLabel(3).name),
+                            ),
+                        ] * 100
                     ),
                 ])
 


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

The problem is that in Datumaro there is more VOC labels than is used in VOC segmentation. The algorithm to decode masks did not expect that. The algorithm is changed to expect no more than 65k classes and 65k instances on a single image.

Fixes the problem with VOC dataset import in Datumaro described here: #1539 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Unit test.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
