### PR TITLE
Fixed task creation for videos with uneven dimensions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed an error when exporting a task with cuboids to any format except CVAT (<https://github.com/opencv/cvat/pull/1577>)
 - Synchronization with remote git repo (<https://github.com/opencv/cvat/pull/1582>)
 - A problem with mask to polygons conversion when polygons are too small (<https://github.com/opencv/cvat/pull/1581>)
+- Unable to upload video with uneven size (<https://github.com/opencv/cvat/pull/1594>)
 
 ### Security
 -

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation
+# Copyright (C) 2019-2020 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -304,10 +304,16 @@ class Mpeg4ChunkWriter(IChunkWriter):
         self._output_fps = 25
 
     @staticmethod
-    def _create_av_container(path, w, h, rate, pix_format, options):
+    def _create_av_container(path, w, h, rate, options):
+            # x264 requires width and height must be divisible by 2 for yuv420p
+            if h % 2:
+                h += 1
+            if w % 2:
+                w += 1
+
             container = av.open(path, 'w')
             video_stream = container.add_stream('libx264', rate=rate)
-            video_stream.pix_fmt = pix_format
+            video_stream.pix_fmt = "yuv420p"
             video_stream.width = w
             video_stream.height = h
             video_stream.options = options
@@ -320,14 +326,12 @@ class Mpeg4ChunkWriter(IChunkWriter):
 
         input_w = images[0][0].width
         input_h = images[0][0].height
-        pix_format = images[0][0].format.name
 
         output_container, output_v_stream = self._create_av_container(
             path=chunk_path,
             w=input_w,
             h=input_h,
             rate=self._output_fps,
-            pix_format=pix_format,
             options={
                 "crf": str(self._image_quality),
                 "preset": "ultrafast",
@@ -373,18 +377,11 @@ class Mpeg4CompressedChunkWriter(Mpeg4ChunkWriter):
         output_h = input_h // downscale_factor
         output_w = input_w // downscale_factor
 
-        # width and height must be divisible by 2
-        if output_h % 2:
-            output_h += 1
-        if output_w % 2:
-            output_w +=1
-
         output_container, output_v_stream = self._create_av_container(
             path=chunk_path,
             w=output_w,
             h=output_h,
             rate=self._output_fps,
-            pix_format='yuv420p',
             options={
                 'profile': 'baseline',
                 'coder': '0',


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->
resolve #1411 

<!-- Provide a general summary of your changes in the Title above -->
Fixed task creation for videos with uneven dimensions.

### Motivation and context
FFmpeg x264 implementation requires width and height must be divisible by 2 for yuv420p, but it's possible to get uneven dimensions for yuv420p format with other software - it's reason why we cannot use original pix_fmt. So, let's use yuv420p for original and compressed chunks and add padding if height or width are uneven.

### How has this been tested?
Manual testing

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
