### PR TITLE
[CVAT-UI] Better labels validation and fixed React warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Shortcut to change color of an activated shape in new UI (Enter) (<https://github.com/opencv/cvat/pull/1683>)
 - Shortcut to switch split mode (<https://github.com/opencv/cvat/pull/1683>)
 - Built-in search for labels when create an object or change a label (<https://github.com/opencv/cvat/pull/1683>)
+- Better validation of labels and attributes in raw viewer (<https://github.com/opencv/cvat/pull/1727>)
 
 ### Changed
 - Removed information about e-mail from the basic user information (<https://github.com/opencv/cvat/pull/1627>)
@@ -32,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Wrong rexex for account name validation (<https://github.com/opencv/cvat/pull/1667>)
 - Wrong description on register view for the username field (<https://github.com/opencv/cvat/pull/1667>)
 - Wrong resolution for resizing a shape (<https://github.com/opencv/cvat/pull/1667>)
+- React warning because of not unique keys in labels viewer (<https://github.com/opencv/cvat/pull/1727>)
+
 
 ### Security
 - SQL injection in Django `CVE-2020-9402` (<https://github.com/opencv/cvat/pull/1657>)

--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/labels-editor/common.ts
+++ b/cvat-ui/src/components/labels-editor/common.ts
@@ -18,6 +18,59 @@ export interface Label {
 
 let id = 0;
 
+function validateParsedAttribute(attr: Attribute): void {
+    if (typeof (attr.name) !== 'string') {
+        throw new Error(`Type of attribute name must be a string. Got value ${attr.name}`);
+    }
+
+    if (!['number', 'undefined'].includes(typeof (attr.id))) {
+        throw new Error(`Attribute: "${attr.name}". `
+        + `Type of attribute id must be a number or undefined. Got value ${attr.id}`);
+    }
+
+    if (!['checkbox', 'number', 'text', 'radio', 'select'].includes((attr.input_type || '').toLowerCase())) {
+        throw new Error(`Attribute: "${attr.name}". `
+        + `Unknown input type: ${attr.input_type}`);
+    }
+
+    if (typeof (attr.mutable) !== 'boolean') {
+        throw new Error(`Attribute: "${attr.name}". `
+        + `Mutable flag must be a boolean value. Got value ${attr.mutable}`);
+    }
+
+    if (!Array.isArray(attr.values)) {
+        throw new Error(`Attribute: "${attr.name}". `
+        + `Attribute values must be an array. Got type ${typeof (attr.values)}`);
+    }
+
+    for (const value of attr.values) {
+        if (typeof (value) !== 'string') {
+            throw new Error(`Attribute: "${attr.name}". `
+            + `Each value must be a string. Got value ${value}`);
+        }
+    }
+}
+
+export function validateParsedLabel(label: Label): void {
+    if (typeof (label.name) !== 'string') {
+        throw new Error(`Type of label name must be a string. Got value ${label.name}`);
+    }
+
+    if (!['number', 'undefined'].includes(typeof (label.id))) {
+        throw new Error(`Label "${label.name}". `
+        + `Type of label id must be only a number or undefined. Got value ${label.id}`);
+    }
+
+    if (!Array.isArray(label.attributes)) {
+        throw new Error(`Label "${label.name}". `
+        + `attributes must be an array. Got type ${typeof (label.attributes)}`);
+    }
+
+    for (const attr of label.attributes) {
+        validateParsedAttribute(attr);
+    }
+}
+
 export function idGenerator(): number {
     return --id;
 }

--- a/cvat-ui/src/components/labels-editor/raw-viewer.tsx
+++ b/cvat-ui/src/components/labels-editor/raw-viewer.tsx
@@ -9,7 +9,12 @@ import Button from 'antd/lib/button';
 import Tooltip from 'antd/lib/tooltip';
 import Form, { FormComponentProps } from 'antd/lib/form/Form';
 
-import { Label, Attribute, validateParsedLabel } from './common';
+import {
+    Label,
+    Attribute,
+    validateParsedLabel,
+    idGenerator,
+} from './common';
 
 type Props = FormComponentProps & {
     labels: Label[];
@@ -47,7 +52,14 @@ class RawViewer extends React.PureComponent<Props> {
         e.preventDefault();
         form.validateFields((error, values): void => {
             if (!error) {
-                onSubmit(JSON.parse(values.labels));
+                const parsed = JSON.parse(values.labels);
+                for (const label of parsed) {
+                    label.id = idGenerator();
+                    for (const attr of label.attributes) {
+                        attr.id = idGenerator();
+                    }
+                }
+                onSubmit(parsed);
             }
         });
     };

--- a/cvat-ui/src/components/labels-editor/raw-viewer.tsx
+++ b/cvat-ui/src/components/labels-editor/raw-viewer.tsx
@@ -9,10 +9,7 @@ import Button from 'antd/lib/button';
 import Tooltip from 'antd/lib/tooltip';
 import Form, { FormComponentProps } from 'antd/lib/form/Form';
 
-import {
-    Label,
-    Attribute,
-} from './common';
+import { Label, Attribute, validateParsedLabel } from './common';
 
 type Props = FormComponentProps & {
     labels: Label[];
@@ -22,7 +19,18 @@ type Props = FormComponentProps & {
 class RawViewer extends React.PureComponent<Props> {
     private validateLabels = (_: any, value: string, callback: any): void => {
         try {
-            JSON.parse(value);
+            const parsed = JSON.parse(value);
+            if (!Array.isArray(parsed)) {
+                callback('Field is expected to be a JSON array');
+            }
+
+            for (const label of parsed) {
+                try {
+                    validateParsedLabel(label);
+                } catch (error) {
+                    callback(error.toString());
+                }
+            }
         } catch (error) {
             callback(error.toString());
         }

--- a/cvat-ui/src/components/labels-editor/raw-viewer.tsx
+++ b/cvat-ui/src/components/labels-editor/raw-viewer.tsx
@@ -54,9 +54,9 @@ class RawViewer extends React.PureComponent<Props> {
             if (!error) {
                 const parsed = JSON.parse(values.labels);
                 for (const label of parsed) {
-                    label.id = idGenerator();
+                    label.id = label.id || idGenerator();
                     for (const attr of label.attributes) {
-                        attr.id = idGenerator();
+                        attr.id = attr.id || idGenerator();
                     }
                 }
                 onSubmit(parsed);


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
When use raw representation of labels, some errors aren't validated. It confuses our users. What's more there is a warning in React related with unique keys. This PR fixes these issues.

### How has this been tested?
Manual testing

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```

Resolve #1498