### PR TITLE
Add attributes in VOC format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - ClamAV antivirus integration (<https://github.com/opencv/cvat/pull/1712>)
 - Supported import and export or single boxes in MOT format (https://github.com/opencv/cvat/pull/1764)
 - [Datumaro] Added `stats` command, which shows some dataset statistics like image mean and std (https://github.com/opencv/cvat/pull/1734)
-- Add option to upload annotations upon task creation on CLI 
+- Add option to upload annotations upon task creation on CLI
 - Polygon and polylines interpolation (<https://github.com/opencv/cvat/pull/1571>)
 - Ability to redraw shape from scratch (Shift + N) for an activated shape (<https://github.com/opencv/cvat/pull/1571>)
 - Highlights for the first point of a polygon/polyline and direction (<https://github.com/opencv/cvat/pull/1571>)
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update https install manual. Makes it easier and more robust. Includes automatic renewing of lets encrypt certificates.
 - Implemented import and export of annotations with relative image paths (<https://github.com/opencv/cvat/pull/1463>)
 - Using only single click to start editing or remove a point (<https://github.com/opencv/cvat/pull/1571>)
+- Added support for attributes in VOC XML format (https://github.com/opencv/cvat/pull/1792)
 
 ### Deprecated
 -

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 import datumaro.components.extractor as datumaro
 from cvat.apps.engine.frame_provider import FrameProvider
-from cvat.apps.engine.models import AttributeType, ShapeType
+from cvat.apps.engine.models import AttributeType, ShapeType, AttributeSpec
 from datumaro.util import cast
 from datumaro.util.image import Image
 
@@ -49,7 +49,8 @@ class TaskData:
             (db_label.id, db_label) for db_label in db_labels)
 
         self._attribute_mapping = {db_label.id: {
-            'mutable': {}, 'immutable': {}} for db_label in db_labels}
+            'mutable': {}, 'immutable': {}, 'spec': {}}
+            for db_label in db_labels}
 
         for db_label in db_labels:
             for db_attribute in db_label.attributespec_set.all():
@@ -57,6 +58,7 @@ class TaskData:
                     self._attribute_mapping[db_label.id]['mutable'][db_attribute.id] = db_attribute.name
                 else:
                     self._attribute_mapping[db_label.id]['immutable'][db_attribute.id] = db_attribute.name
+                self._attribute_mapping[db_label.id]['spec'][db_attribute.id] = db_attribute
 
         self._attribute_mapping_merged = {}
         for label_id, attr_mapping in self._attribute_mapping.items():
@@ -317,10 +319,28 @@ class TaskData:
         return _tag
 
     def _import_attribute(self, label_id, attribute):
-        return {
-            'spec_id': self._get_attribute_id(label_id, attribute.name),
-            'value': attribute.value,
-        }
+        spec_id = self._get_attribute_id(label_id, attribute.name)
+        value = attribute.value
+
+        if spec_id:
+            spec = self._attribute_mapping[label_id]['spec'][spec_id]
+
+            try:
+                if spec.input_type == AttributeType.NUMBER:
+                    pass # no extra processing required
+                elif spec.input_type == AttributeType.CHECKBOX:
+                    if isinstance(value, str):
+                        value = value.lower()
+                        assert value in {'true', 'false'}
+                    elif isinstance(value, (bool, int, float)):
+                        value = 'true' if value else 'false'
+                    else:
+                        raise ValueError("Unexpected attribute value")
+            except Exception as e:
+                raise Exception("Failed to convert attribute '%s'='%s': %s" %
+                    (self._get_label_name(label_id), value, e))
+
+        return { 'spec_id': spec_id, 'value': value }
 
     def _import_shape(self, shape):
         _shape = shape._asdict()

--- a/cvat/apps/dataset_manager/bindings.py
+++ b/cvat/apps/dataset_manager/bindings.py
@@ -11,7 +11,7 @@ from django.utils import timezone
 
 import datumaro.components.extractor as datumaro
 from cvat.apps.engine.frame_provider import FrameProvider
-from cvat.apps.engine.models import AttributeType, ShapeType, AttributeSpec
+from cvat.apps.engine.models import AttributeType, ShapeType
 from datumaro.util import cast
 from datumaro.util.image import Image
 

--- a/cvat/apps/engine/tests/_test_rest_api.py
+++ b/cvat/apps/engine/tests/_test_rest_api.py
@@ -1988,7 +1988,7 @@ class JobAnnotationAPITestCase(APITestCase):
                             "name": "parked",
                             "mutable": True,
                             "input_type": "checkbox",
-                            "default_value": False
+                            "default_value": "false"
                         },
                     ]
                 },

--- a/datumaro/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/datumaro/plugins/voc_format/converter.py
@@ -207,9 +207,8 @@ class _Converter:
                         ET.SubElement(obj_elem, 'name').text = obj_label
 
                         if 'pose' in attr:
-                            pose = _convert_attr('pose', attr,
-                                lambda v: VocPose[v], VocPose.Unspecified)
-                            ET.SubElement(obj_elem, 'pose').text = pose.name
+                            ET.SubElement(obj_elem, 'pose').text = \
+                                str(attr['pose'])
 
                         if 'truncated' in attr:
                             truncated = _convert_attr('truncated', attr, int, 0)

--- a/datumaro/datumaro/plugins/voc_format/converter.py
+++ b/datumaro/datumaro/plugins/voc_format/converter.py
@@ -53,7 +53,8 @@ LabelmapType = Enum('LabelmapType', ['voc', 'source', 'guess'])
 
 class _Converter:
     def __init__(self, extractor, save_dir,
-            tasks=None, apply_colormap=True, save_images=False, label_map=None):
+            tasks=None, apply_colormap=True, save_images=False, label_map=None,
+            allow_attributes=True):
         assert tasks is None or isinstance(tasks, (VocTask, list, set))
         if tasks is None:
             tasks = set(VocTask)
@@ -66,6 +67,7 @@ class _Converter:
         self._extractor = extractor
         self._save_dir = save_dir
         self._apply_colormap = apply_colormap
+        self._allow_attributes = allow_attributes
         self._save_images = save_images
 
         self._load_categories(label_map)
@@ -251,6 +253,21 @@ class _Converter:
                             objects_with_actions[new_obj_id][action] = present
                         if len(actions_elem) != 0:
                             obj_elem.append(actions_elem)
+
+                        if self._allow_attributes:
+                            native_attrs = {'difficult', 'pose',
+                                'truncated', 'occluded' }
+                            native_attrs.update(label_actions)
+
+                            attrs_elem = ET.Element('attributes')
+                            for k, v in attr.items():
+                                if k in native_attrs:
+                                    continue
+                                attr_elem = ET.SubElement(attrs_elem, 'attribute')
+                                ET.SubElement(attr_elem, 'name').text = str(k)
+                                ET.SubElement(attr_elem, 'value').text = str(v)
+                            if len(attrs_elem):
+                                obj_elem.append(attrs_elem)
 
                     if self._tasks & {None,
                             VocTask.detection,
@@ -565,15 +582,17 @@ class VocConverter(Converter, CliPlugin):
         parser.add_argument('--label-map', type=cls._get_labelmap, default=None,
             help="Labelmap file path or one of %s" % \
                 ', '.join(t.name for t in LabelmapType))
+        parser.add_argument('--allow-attributes',
+            type=str_to_bool, default=True,
+            help="Allow export of attributes (default: %(default)s)")
         parser.add_argument('--tasks', type=cls._split_tasks_string,
-            default=None,
             help="VOC task filter, comma-separated list of {%s} "
-                "(default: all)" % ', '.join([t.name for t in VocTask]))
+                "(default: all)" % ', '.join(t.name for t in VocTask))
 
         return parser
 
     def __init__(self, tasks=None, save_images=False,
-            apply_colormap=False, label_map=None):
+            apply_colormap=False, label_map=None, allow_attributes=True):
         super().__init__()
 
         self._options = {
@@ -581,6 +600,7 @@ class VocConverter(Converter, CliPlugin):
             'save_images': save_images,
             'apply_colormap': apply_colormap,
             'label_map': label_map,
+            'allow_attributes': allow_attributes,
         }
 
     def __call__(self, extractor, save_dir):

--- a/datumaro/datumaro/plugins/voc_format/extractor.py
+++ b/datumaro/datumaro/plugins/voc_format/extractor.py
@@ -198,6 +198,12 @@ class _VocXmlExtractor(_VocExtractor):
                 item_annotations.append(Bbox(*part_bbox, label=part_label_id,
                     group=group))
 
+            attributes_elem = object_elem.find('attributes')
+            if attributes_elem is not None:
+                for attr_elem in attributes_elem.iter('attribute'):
+                    attributes[attr_elem.find('name').text] = \
+                        attr_elem.find('value').text
+
             if self._task is VocTask.person_layout and not has_parts:
                 continue
             if self._task is VocTask.action_classification and not actions:

--- a/datumaro/tests/test_voc_format.py
+++ b/datumaro/tests/test_voc_format.py
@@ -395,8 +395,8 @@ class VocConverterTest(TestCase):
 
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),
-                VocActionConverter(label_map='voc'), test_dir,
-                target_dataset=DstExtractor())
+                VocActionConverter(label_map='voc', allow_attributes=False),
+                test_dir, target_dataset=DstExtractor())
 
     def test_can_save_dataset_with_no_subsets(self):
         class TestExtractor(TestExtractorBase):
@@ -679,3 +679,34 @@ class VocConverterTest(TestCase):
         with TestDir() as test_dir:
             self._test_save_and_load(TestExtractor(),
                 VocConverter(label_map='voc', save_images=True), test_dir)
+
+    def test_can_save_attributes(self):
+        class TestExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id='a', annotations=[
+                        Bbox(2, 3, 4, 5, label=2,
+                            attributes={ 'occluded': True, 'x': 1, 'y': '2' }
+                        ),
+                    ]),
+                ])
+
+        class DstExtractor(TestExtractorBase):
+            def __iter__(self):
+                return iter([
+                    DatasetItem(id='a', annotations=[
+                        Bbox(2, 3, 4, 5, label=2, id=1, group=1,
+                            attributes={
+                                'truncated': False,
+                                'difficult': False,
+                                'occluded': True,
+                                'x': '1', 'y': '2', # can only read strings
+                            }
+                        ),
+                    ]),
+                ])
+
+        with TestDir() as test_dir:
+            self._test_save_and_load(TestExtractor(),
+                VocDetectionConverter(label_map='voc'), test_dir,
+                target_dataset=DstExtractor())


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Closes #1518 

Allows any values in `pose` object attribute.
Allows to read and write annotation attributes in `attributes` element of VOC XML annotations.

Exporting is enabled by default and can be disabled with `--allow-attributes=False` CLI option of Datumaro export.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
