### PR TITLE
Add hash to js bundle names

### DIFF
--- a/cvat-canvas/webpack.config.js
+++ b/cvat-canvas/webpack.config.js
@@ -60,10 +60,12 @@ const webConfig = {
     target: 'web',
     mode: 'production',
     devtool: 'source-map',
-    entry: './src/typescript/canvas.ts',
+    entry: {
+        'cvat-canvas': './src/typescript/canvas.ts',
+    },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'cvat-canvas.js',
+        filename: '[name].[contenthash].js',
         library: 'canvas',
         libraryTarget: 'window',
     },

--- a/cvat-core/webpack.config.js
+++ b/cvat-core/webpack.config.js
@@ -30,10 +30,12 @@ const webConfig = {
     target: 'web',
     mode: 'production',
     devtool: 'source-map',
-    entry: './src/api.js',
+    entry: {
+        'cvat-core': './src/api.js',
+    },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'cvat-core.min.js',
+        filename: '[name].[contenthash].min.js',
         library: 'cvat',
         libraryTarget: 'window',
     },
@@ -58,7 +60,7 @@ const webConfig = {
                 loader: 'worker-loader',
                 options: {
                     publicPath: '/static/engine/js/3rdparty/',
-                    name: '[name].js',
+                    name: '[name].[contenthash].js',
                 },
             },
         }, {
@@ -68,7 +70,7 @@ const webConfig = {
                 loader: 'worker-loader',
                 options: {
                     publicPath: '/static/engine/js/',
-                    name: '[name].js',
+                    name: '[name].[contenthash].js',
                 },
             },
         },

--- a/cvat-data/webpack.config.js
+++ b/cvat-data/webpack.config.js
@@ -9,10 +9,12 @@ const CopyPlugin = require('copy-webpack-plugin');
 const cvatData = {
     target: 'web',
     mode: 'production',
-    entry: './src/js/cvat-data.js',
+    entry: {
+        'cvat-data': './src/js/cvat-data.js',
+    },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'cvat-data.min.js',
+        filename: '[name].[contenthash].min.js',
         library: 'cvatData',
         libraryTarget: 'window',
     },
@@ -39,7 +41,7 @@ const cvatData = {
                     loader: 'worker-loader',
                     options: {
                         publicPath: '/',
-                        name: '[name].js',
+                        name: '[name].[contenthash].js',
                     },
                 },
             }, {
@@ -48,7 +50,7 @@ const cvatData = {
                     loader: 'worker-loader',
                     options: {
                         publicPath: '/3rdparty/',
-                        name: '3rdparty/[name].js',
+                        name: '3rdparty/[name].[contenthash].js',
                     },
                 },
             },

--- a/cvat-ui/src/index.html
+++ b/cvat-ui/src/index.html
@@ -15,6 +15,5 @@
 
     <body>
         <div id="root"></div>
-        <script src="/cvat-ui.min.js" type="text/javascript"></script>
     </body>
 </html>

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -14,10 +14,13 @@ module.exports = {
     target: 'web',
     mode: 'production',
     devtool: 'source-map',
-    entry: './src/index.tsx',
+    entry: {
+        'cvat-ui': './src/index.tsx',
+    },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'cvat-ui.min.js',
+        filename: '[name].[contenthash].min.js',
+        publicPath: '/',
     },
     devServer: {
         contentBase: path.join(__dirname, 'dist'),
@@ -79,7 +82,7 @@ module.exports = {
                 loader: 'worker-loader',
                 options: {
                     publicPath: '/',
-                    name: '3rdparty/[name].js',
+                    name: '3rdparty/[name].[contenthash].js',
                 },
             },
         }, {
@@ -89,7 +92,7 @@ module.exports = {
                 loader: 'worker-loader',
                 options: {
                     publicPath: '/',
-                    name: '[name].js',
+                    name: '[name].[contenthash].js',
                 },
             },
         },],
@@ -97,7 +100,7 @@ module.exports = {
     plugins: [
         new HtmlWebpackPlugin({
             template: "./src/index.html",
-            inject: false,
+            inject: 'body',
         }),
         new Dotenv({
             systemvars: true,


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Adding hash to the js bundle name should solve the problem with the browser cache after updating cvat-* component(s).
Resolve #1545 

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
Manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
