### PR TITLE
Match image by name (instead of id) on CVAT upload

### DIFF
--- a/cvat/apps/dataset_manager/formats/cvat.py
+++ b/cvat/apps/dataset_manager/formats/cvat.py
@@ -432,7 +432,7 @@ def load(file_object, annotations):
                 )
             elif el.tag == 'image':
                 image_is_opened = True
-                frame_id = int(el.attrib['id'])
+                frame_id = annotations.match_frame(el.attrib['name'])
             elif el.tag in supported_shapes and (track is not None or image_is_opened):
                 attributes = []
                 shape = {

--- a/cvat/apps/dataset_manager/formats/cvat.py
+++ b/cvat/apps/dataset_manager/formats/cvat.py
@@ -9,8 +9,10 @@ from collections import OrderedDict
 from glob import glob
 from tempfile import TemporaryDirectory
 
+from cvat.apps.dataset_manager.bindings import match_dm_item
 from cvat.apps.dataset_manager.util import make_zip_archive
 from cvat.apps.engine.frame_provider import FrameProvider
+from datumaro.components.extractor import DatasetItem
 from datumaro.util.image import save_image
 
 from .registry import exporter, importer
@@ -432,7 +434,7 @@ def load(file_object, annotations):
                 )
             elif el.tag == 'image':
                 image_is_opened = True
-                frame_id = annotations.match_frame(el.attrib['name'])
+                frame_id = match_dm_item(DatasetItem(id=el.attrib['id'], image=el.attrib['name']), annotations)
             elif el.tag in supported_shapes and (track is not None or image_is_opened):
                 attributes = []
                 shape = {


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, the cvat annotation import (upload) matches annotations to frames by id, so this works only on very specific cases like backups for the same task. When moving annotations between tasks, if the order doesn't match exactly or if there are more frames, or (in our case) if we generate cvat annotations for pre-annotation, nothing matched and it's useless.
This PR just uses the same matching as for coco files, so it works both for old use-cases like backup (if the ID matched, then the filenames will match) but also pre-annotation and others.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manually, uploaded some files.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
