### PR TITLE
Avoid hard-coding container names and use docker-compose…

### DIFF
--- a/components/analytics/docker-compose.analytics.yml
+++ b/components/analytics/docker-compose.analytics.yml
@@ -1,7 +1,6 @@
 version: '2.3'
 services:
   cvat_elasticsearch:
-    container_name: cvat_elasticsearch
     image: cvat_elasticsearch
     networks:
       default:
@@ -16,7 +15,6 @@ services:
     restart: always
 
   cvat_kibana:
-    container_name: cvat_kibana
     image: cvat_kibana
     networks:
       default:
@@ -30,7 +28,6 @@ services:
     restart: always
 
   cvat_kibana_setup:
-    container_name: cvat_kibana_setup
     image: cvat
     volumes: ['./components/analytics/kibana:/home/django/kibana:ro']
     depends_on: ['cvat']
@@ -42,7 +39,6 @@ services:
       no_proxy: elasticsearch,kibana,${no_proxy}
 
   cvat_logstash:
-    container_name: cvat_logstash
     image: cvat_logstash
     networks:
       default:

--- a/cvat/apps/documentation/faq.md
+++ b/cvat/apps/documentation/faq.md
@@ -20,13 +20,13 @@ docker-compose up -d
 ```
 
 Sometimes the update process takes a lot of time due to changes in the database schema and data.
-You can check the current status with `docker logs cvat`.
+You can check the current status with `docker-compose logs cvat`.
 Please do not terminate the migration and wait till the process is complete.
 
 ## Kibana app works, but no logs are displayed
 Make sure there aren't error messages from Elasticsearch:
 ```sh
-docker logs cvat_elasticsearch
+docker-compose logs cvat_elasticsearch
 ```
 If you see errors like this:
 ```sh

--- a/cvat/apps/documentation/installation.md
+++ b/cvat/apps/documentation/installation.md
@@ -98,7 +98,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
     below:
 
     ```sh
-    docker exec -it cvat bash -ic 'python3 ~/manage.py createsuperuser'
+    docker-compose exec cvat bash -ic 'python3 ~/manage.py createsuperuser'
     ```
     Choose login and password for your admin account. For more information
     please read [Django documentation](https://docs.djangoproject.com/en/2.2/ref/django-admin/#createsuperuser).
@@ -163,7 +163,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
     below:
 
     ```sh
-    winpty docker exec -it cvat bash -ic 'python3 ~/manage.py createsuperuser'
+    winpty docker-compose exec cvat bash -ic 'python3 ~/manage.py createsuperuser'
     ```
     Choose login and password for your admin account. For more information
     please read [Django documentation](https://docs.djangoproject.com/en/2.2/ref/django-admin/#createsuperuser).
@@ -228,7 +228,7 @@ server. Proxy is an advanced topic and it is not covered by the guide.
     below:
 
     ```sh
-    docker exec -it cvat bash -ic 'python3 ~/manage.py createsuperuser'
+    docker-compose exec cvat bash -ic 'python3 ~/manage.py createsuperuser'
     ```
     Choose login and password for your admin account. For more information
     please read [Django documentation](https://docs.djangoproject.com/en/2.2/ref/django-admin/#createsuperuser).
@@ -434,7 +434,7 @@ Let’s Encrypt provides rate limits to ensure fair usage by as many people as p
 ~/.acme.sh/acme.sh --issue --staging -d my-cvat-server.org -w $HOME/cvat/letsencrypt-webroot --debug
 ```
 
-> Debug note: nginx server logs for cvat_proxy are not saved in container. You shall see it at docker host by with: `docker logs cvat_proxy`.
+> Debug note: nginx server logs for cvat_proxy are not saved in container. You shall see it at docker host by with: `docker-compose logs cvat_proxy`.
 
 If certificates is issued a successful we should test a renew:
 
@@ -459,7 +459,7 @@ rm -r /root/.acme.sh/my-cvat-server.org
 Down the cvat_proxy container for setup https with issued certificates.
 
 ```bash
-docker stop cvat_proxy
+docker-compose stop cvat_proxy
 ```
 
 **Reconfigure nginx for use certificates.**
@@ -547,5 +547,5 @@ server {
 Start cvat_proxy container with https enabled.
 
 ```
-docker start cvat_proxy
+docker-compose start cvat_proxy
 ```

--- a/cvat/apps/documentation/user_guide.md
+++ b/cvat/apps/documentation/user_guide.md
@@ -66,7 +66,7 @@ computer vision tasks developed by our team.
     [Django administration panel](http://localhost:8080/admin) to assign correct
     groups to the user. Please use the command below to create an admin account:
 
-    ``docker exec -it cvat bash -ic '/usr/bin/python3 ~/manage.py createsuperuser'``
+    ``docker-compose exec cvat bash -ic '/usr/bin/python3 ~/manage.py createsuperuser'``
 
 -   If you want to create a non-admin account, you can do that using the link below
     on the login page. Don't forget to modify permissions for the new user in the

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,6 @@ version: "2.3"
 
 services:
   cvat_db:
-    container_name: cvat_db
     image: postgres:10-alpine
     networks:
       default:
@@ -22,7 +21,6 @@ services:
       - cvat_db:/var/lib/postgresql/data
 
   cvat_redis:
-    container_name: cvat_redis
     image: redis:4.0-alpine
     networks:
       default:
@@ -31,7 +29,6 @@ services:
     restart: always
 
   cvat:
-    container_name: cvat
     image: cvat
     restart: always
     depends_on:
@@ -63,7 +60,6 @@ services:
       - cvat_models:/home/django/models
 
   cvat_ui:
-    container_name: cvat_ui
     restart: always
     build:
       context: .
@@ -82,7 +78,6 @@ services:
       - cvat
 
   cvat_proxy:
-    container_name: cvat_proxy
     image: nginx:stable-alpine
     restart: always
     depends_on:

--- a/ssh/README.md
+++ b/ssh/README.md
@@ -4,7 +4,7 @@ If you have any problems with a git repository cloning inside the CVAT:
   * Make sure that SSH keys have been added to the CVAT container:
 
 ```bash
-docker exec -it cvat bash -ic 'ls .ssh'
+docker-compose exec cvat bash -ic 'ls .ssh'
 ```
 
   * If you need a proxy for connecting to the Internet, specify the socks_proxy variable before build the container. For example:
@@ -16,7 +16,7 @@ socks_proxy=proxy-example.com:1080 docker-compose build
   * Try to clone a repository via SSH directly in the container by the command:
 
 ```bash
-docker exec -it cvat bash -ic 'cd /tmp -r && git clone <ssh_repository_url>'
+docker-compose exec cvat bash -ic 'cd /tmp -r && git clone <ssh_repository_url>'
 ```
 
   * Finally try to clone it on your local machine and if it's successful, contact with us via [Gitter chat](https://gitter.im/opencv-cvat) or [Github issues](https://github.com/opencv/cvat/issues).

--- a/utils/auto_annotation/README.md
+++ b/utils/auto_annotation/README.md
@@ -14,8 +14,8 @@ $ python /path/to/run_model.py --model-name mymodel --task-id 4
 
 If you're running in docker, this can be useful way to debug your model.
 
-``` shell
-$ docker exec -it cvat bash -ic 'python3 ~/cvat/apps/auto_annotation/run_model.py --model-name my-model --task-id 4
+```shell
+$ docker-compose exec cvat bash -ic 'python3 ~/cvat/apps/auto_annotation/run_model.py --model-name my-model --task-id 4
 ```
 
 If you are developing an auto annotation model or you can't get something uploaded into the server, 


### PR DESCRIPTION
… instead of docker

<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
We can't run multiple cvat on the same host because the container names are hardcoded (and clashes with the already running containers). Omitting `container_names` allows to use the default ones which are the name of the service, prefixed by the project name ([--project-name](https://docs.docker.com/compose/reference/overview/) which is by default the directory name) so eg. `cvat` becomes `cvat_cvat_1` if we cloned the repo to `cvat/` (the `_1` is because it's suffixed to allow multiple containers of the same image).
So now we just have to clone to another directory, change the 8080 port, and it works because everything is prefixed. Small change: it's better to use `docker-compose something` because it will find the containers of the current project, instead of having to prefix the names manually (ie. use `docker-compose exec cvat bash` instead of `docker exec -it cvat_cvat_1 bash`). I updated the documentation.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Currently running 3 cvats on the same host without issues.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
