### PR TITLE
updated auto annotation runner to use new auto annotation api

### DIFF
--- a/cvat/apps/auto_annotation/inference.py
+++ b/cvat/apps/auto_annotation/inference.py
@@ -150,7 +150,7 @@ class InferenceAnnotationRunner:
                     continue
 
             db_label = self.labels_mapping[shape["label"]]
-            label_attr_spec = self.attribute_spec.get(db_label)
+            label_attr_spec = self.attribute_spec.get(db_label, dict())
             target_container.append({
                 "label_id": db_label,
                 "frame": shape["frame"],

--- a/utils/auto_annotation/run_model.py
+++ b/utils/auto_annotation/run_model.py
@@ -15,7 +15,7 @@ cvat_dir = os.path.join(work_dir, '..', '..')
 
 sys.path.insert(0, cvat_dir)
 
-from cvat.apps.auto_annotation.inference import run_inference_engine_annotation
+from cvat.apps.auto_annotation.inference import InferenceAnnotationRunner
 
 
 def _get_kwargs():
@@ -177,15 +177,14 @@ def main():
         test_image = np.ones((1024, 1980, 3), np.uint8) * 255
         image_data = [test_image,]
     attribute_spec = {}
+    runner = InferenceAnnotationRunner(image_data,
+                                       xml_file,
+                                       bin_file,
+                                       mapping,
+                                       attribute_spec,
+                                       py_file)
 
-    results = run_inference_engine_annotation(image_data,
-                                              xml_file,
-                                              bin_file,
-                                              mapping,
-                                              attribute_spec,
-                                              py_file,
-                                              restricted=restricted)
-
+    results, _ = runner.run(restricted=restricted)
 
     logging.warning('Inference didn\'t have any errors.')
     show_images = kwargs.get('show_images', False)


### PR DESCRIPTION
### Motivation and context
See: https://github.com/opencv/cvat/issues/1798
Note that the API was changed in 8a2efa4da33eba71d14e177e5b460e9c3a6530a8 to not continually add to a list. Users were reporting issues with large video files consuming all the RAM, so we went to a more iterative API.

### How has this been tested?
Sorry, I don't have an active CVAT installation. This was not tested. 

### Checklist
- [ x ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ x ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [x ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
