### PR TITLE
[Datumaro] Reducing nesting of tests

### DIFF
--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -74,6 +74,19 @@ class LabelCategories(Categories):
 
     @classmethod
     def from_iterable(cls, iterable):
+        """Generation of LabelCategories from iterable object
+
+        Args:
+            iterable ([type]): This iterable object can be:
+            1)simple str - will generate one Category with str as name
+            2)list of str - will interpreted as list of Category names
+            3)list of positional argumetns - will generate Categories
+            with this arguments
+
+
+        Returns:
+            LabelCategories: LabelCategories object
+        """
         temp_categories = cls()
 
         if isinstance(iterable, str):
@@ -498,6 +511,18 @@ class PointsCategories(Categories):
 
     @classmethod
     def from_iterable(cls, iterable):
+        """Generation of PointsCategories from iterable object
+
+        Args:
+            iterable ([type]): This iterable object can be:
+            1)simple int - will generate one Category with int as label
+            2)list of int - will interpreted as list of Category labels
+            3)list of positional argumetns - will generate Categories
+            with this arguments
+
+        Returns:
+            PointsCategories: PointsCategories object
+        """
         temp_categories = cls()
 
         if isinstance(iterable, int):

--- a/datumaro/datumaro/components/extractor.py
+++ b/datumaro/datumaro/components/extractor.py
@@ -72,6 +72,20 @@ class Categories:
 class LabelCategories(Categories):
     Category = namedtuple('Category', ['name', 'parent', 'attributes'])
 
+    @classmethod
+    def from_iterable(cls, iterable):
+        temp_categories = cls()
+
+        if isinstance(iterable, str):
+            iterable = [[iterable]]
+
+        for category in iterable:
+            if isinstance(category, str):
+                category = [category]
+            temp_categories.add(*category)
+
+        return temp_categories
+
     def __init__(self, items=None, attributes=None):
         super().__init__(attributes=attributes)
 
@@ -481,6 +495,19 @@ class Bbox(_Shape):
 
 class PointsCategories(Categories):
     Category = namedtuple('Category', ['labels', 'joints'])
+
+    @classmethod
+    def from_iterable(cls, iterable):
+        temp_categories = cls()
+
+        if isinstance(iterable, int):
+            iterable = [[iterable]]
+
+        for category in iterable:
+            if isinstance(category, int):
+                category = [category]
+            temp_categories.add(*category)
+        return temp_categories
 
     def __init__(self, items=None, attributes=None):
         super().__init__(attributes=attributes)

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -327,33 +327,17 @@ class Dataset(Extractor):
             Dataset: Dataset object
         """
 
-        # Configuration of categories
         if not categories:
             categories = {}
 
-        # Get Dataset with specified categories
-        dataset = Dataset(categories=categories)
+        class tmpExtractor(Extractor):
+            def __iter__(self):
+                return iter(iterable)
 
-        #Get iterator
-        it = iter(iterable)
+            def categories(self):
+                return categories
 
-        # Merging items
-        subsets = defaultdict(lambda: Subset(dataset))
-
-        for item in it:
-                existing_item = subsets[item.subset].items.get(item.id)
-                if existing_item is not None:
-                    path = existing_item.path
-                    if item.path != path:
-                        path = None
-                    item = cls._merge_items(existing_item, item, path=path)
-
-                subsets[item.subset].items[item.id] = item
-
-        # Set obtained items to dataset
-        dataset._subsets = dict(subsets)
-
-        return dataset
+        return cls.from_extractors(tmpExtractor())
 
     @classmethod
     def from_extractors(cls, *sources):

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -18,7 +18,8 @@ import sys
 from datumaro.components.config import Config, DEFAULT_FORMAT
 from datumaro.components.config_model import (Model, Source,
     PROJECT_DEFAULT_CONFIG, PROJECT_SCHEMA)
-from datumaro.components.extractor import Extractor, LabelCategories
+from datumaro.components.extractor import Extractor, LabelCategories,\
+    AnnotationType
 from datumaro.components.launcher import ModelTransform
 from datumaro.components.dataset_filter import \
     XPathDatasetFilter, XPathAnnotationsFilter
@@ -321,14 +322,16 @@ class Dataset(Extractor):
 
         Args:
             iterable: Iterable object contains DatasetItems
-            categories (dict, optional): Dict of categories of datasets. Defaults to {}.
+            categories (dict, optional): You can pass dict of categories or
+            you can pass list of names. It'll interpreted as list of names of
+            LabelCategories. Defaults to {}.
 
         Returns:
             Dataset: Dataset object
         """
 
         if isinstance(categories, list):
-            categories = LabelCategories.from_iterable(categories)
+            categories = {AnnotationType.label : LabelCategories.from_iterable(categories)}
 
         if not categories:
             categories = {}

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -316,6 +316,41 @@ class Subset(Extractor):
 
 class Dataset(Extractor):
     @classmethod
+    def from_iterable(cls, iterable, categories={}):
+        """Generation of Dataset from iterable object
+
+        Args:
+            iterable: Iterable object contains DatasetItems
+            categories (dict, optional): Dict of categories of datasets. Defaults to {}.
+
+        Returns:
+            Dataset: Dataset object
+        """
+        # Get Dataset with specified categories
+        dataset = Dataset(categories=categories)
+
+        #Get iterator
+        it = iter(iterable)
+
+        # Merging items
+        subsets = defaultdict(lambda: Subset(dataset))
+
+        for item in it:
+                existing_item = subsets[item.subset].items.get(item.id)
+                if existing_item is not None:
+                    path = existing_item.path
+                    if item.path != path:
+                        path = None
+                    item = cls._merge_items(existing_item, item, path=path)
+
+                subsets[item.subset].items[item.id] = item
+
+        # Set obtained items to dataset
+        dataset._subsets = dict(subsets)
+
+        return dataset
+
+    @classmethod
     def from_extractors(cls, *sources):
         # merge categories
         # TODO: implement properly with merging and annotations remapping

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -18,7 +18,7 @@ import sys
 from datumaro.components.config import Config, DEFAULT_FORMAT
 from datumaro.components.config_model import (Model, Source,
     PROJECT_DEFAULT_CONFIG, PROJECT_SCHEMA)
-from datumaro.components.extractor import Extractor
+from datumaro.components.extractor import Extractor, LabelCategories
 from datumaro.components.launcher import ModelTransform
 from datumaro.components.dataset_filter import \
     XPathDatasetFilter, XPathAnnotationsFilter
@@ -326,6 +326,9 @@ class Dataset(Extractor):
         Returns:
             Dataset: Dataset object
         """
+
+        if isinstance(categories, list):
+            categories = LabelCategories.from_iterable(categories)
 
         if not categories:
             categories = {}

--- a/datumaro/datumaro/components/project.py
+++ b/datumaro/datumaro/components/project.py
@@ -316,7 +316,7 @@ class Subset(Extractor):
 
 class Dataset(Extractor):
     @classmethod
-    def from_iterable(cls, iterable, categories={}):
+    def from_iterable(cls, iterable, categories=None):
         """Generation of Dataset from iterable object
 
         Args:
@@ -326,6 +326,11 @@ class Dataset(Extractor):
         Returns:
             Dataset: Dataset object
         """
+
+        # Configuration of categories
+        if not categories:
+            categories = {}
+
         # Get Dataset with specified categories
         dataset = Dataset(categories=categories)
 

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -27,21 +27,21 @@ class CocoImporterTest(TestCase):
     def test_can_import(self):
 
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id='000000000001', image=np.ones((10, 5, 3)),
-                        subset='val', attributes={'id': 1},
-                        annotations=[
-                            Polygon([0, 0, 1, 0, 1, 2, 0, 2], label=0,
-                                id=1, group=1, attributes={'is_crowd': False}),
-                            Mask(np.array(
-                                [[1, 0, 0, 1, 0]] * 5 +
-                                [[1, 1, 1, 1, 0]] * 5
-                                ), label=0,
-                                id=2, group=2, attributes={'is_crowd': True}),
-                        ]
-                    )
-                ], categories={
-                    AnnotationType.label : LabelCategories.from_iterable('TEST'),
-                })
+            DatasetItem(id='000000000001', image=np.ones((10, 5, 3)),
+                subset='val', attributes={'id': 1},
+                annotations=[
+                    Polygon([0, 0, 1, 0, 1, 2, 0, 2], label=0,
+                        id=1, group=1, attributes={'is_crowd': False}),
+                    Mask(np.array(
+                        [[1, 0, 0, 1, 0]] * 5 +
+                        [[1, 1, 1, 1, 0]] * 5
+                        ), label=0,
+                        id=2, group=2, attributes={'is_crowd': True}),
+                ]
+            ),
+        ], categories={
+                        AnnotationType.label : LabelCategories.from_iterable('TEST'),
+                    })
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'coco') \
             .make_dataset()
@@ -67,21 +67,21 @@ class CocoConverterTest(TestCase):
 
     def test_can_save_and_load_captions(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        annotations=[
-                            Caption('hello', id=1, group=1),
-                            Caption('world', id=2, group=2),
-                        ], attributes={'id': 1}),
-                    DatasetItem(id=2, subset='train',
-                        annotations=[
-                            Caption('test', id=3, group=3),
-                        ], attributes={'id': 2}),
+            DatasetItem(id=1, subset='train',
+                annotations=[
+                    Caption('hello', id=1, group=1),
+                    Caption('world', id=2, group=2),
+                ], attributes={'id': 1}),
+            DatasetItem(id=2, subset='train',
+                annotations=[
+                    Caption('test', id=3, group=3),
+                ], attributes={'id': 2}),
 
-                    DatasetItem(id=3, subset='val',
-                        annotations=[
-                            Caption('word', id=1, group=1),
-                        ], attributes={'id': 1}),
-                    ])
+            DatasetItem(id=3, subset='val',
+                annotations=[
+                    Caption('word', id=1, group=1),
+                ], attributes={'id': 1}),
+            ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -89,84 +89,84 @@ class CocoConverterTest(TestCase):
 
     def test_can_save_and_load_instances(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train', image=np.ones((4, 4, 3)),
-                        annotations=[
-                            # Bbox + single polygon
-                            Bbox(0, 1, 2, 2,
-                                label=2, group=1, id=1,
-                                attributes={ 'is_crowd': False }),
-                            Polygon([0, 1, 2, 1, 2, 3, 0, 3],
-                                attributes={ 'is_crowd': False },
-                                label=2, group=1, id=1),
-                        ], attributes={'id': 1}),
-                    DatasetItem(id=2, subset='train', image=np.ones((4, 4, 3)),
-                        annotations=[
-                            # Mask + bbox
-                            Mask(np.array([
-                                    [0, 1, 0, 0],
-                                    [0, 1, 0, 0],
-                                    [0, 1, 1, 1],
-                                    [0, 0, 0, 0]],
-                                ),
-                                attributes={ 'is_crowd': True },
-                                label=4, group=3, id=3),
-                            Bbox(1, 0, 2, 2, label=4, group=3, id=3,
-                                attributes={ 'is_crowd': True }),
-                        ], attributes={'id': 2}),
+            DatasetItem(id=1, subset='train', image=np.ones((4, 4, 3)),
+                annotations=[
+                    # Bbox + single polygon
+                    Bbox(0, 1, 2, 2,
+                        label=2, group=1, id=1,
+                        attributes={ 'is_crowd': False }),
+                    Polygon([0, 1, 2, 1, 2, 3, 0, 3],
+                        attributes={ 'is_crowd': False },
+                        label=2, group=1, id=1),
+                ], attributes={'id': 1}),
+            DatasetItem(id=2, subset='train', image=np.ones((4, 4, 3)),
+                annotations=[
+                    # Mask + bbox
+                    Mask(np.array([
+                            [0, 1, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 1, 1, 1],
+                            [0, 0, 0, 0]],
+                        ),
+                        attributes={ 'is_crowd': True },
+                        label=4, group=3, id=3),
+                    Bbox(1, 0, 2, 2, label=4, group=3, id=3,
+                        attributes={ 'is_crowd': True }),
+                ], attributes={'id': 2}),
 
-                    DatasetItem(id=3, subset='val', image=np.ones((4, 4, 3)),
-                        annotations=[
-                            # Bbox + mask
-                            Bbox(0, 1, 2, 2, label=4, group=3, id=3,
-                                attributes={ 'is_crowd': True }),
-                            Mask(np.array([
-                                    [0, 0, 0, 0],
-                                    [1, 1, 1, 0],
-                                    [1, 1, 0, 0],
-                                    [0, 0, 0, 0]],
-                                ),
-                                attributes={ 'is_crowd': True },
-                                label=4, group=3, id=3),
-                        ], attributes={'id': 1}),
-                    ], categories={
-                        AnnotationType.label: LabelCategories.from_iterable(
-                            str(i) for i in range(10)),
-                    })
+            DatasetItem(id=3, subset='val', image=np.ones((4, 4, 3)),
+                annotations=[
+                    # Bbox + mask
+                    Bbox(0, 1, 2, 2, label=4, group=3, id=3,
+                        attributes={ 'is_crowd': True }),
+                    Mask(np.array([
+                            [0, 0, 0, 0],
+                            [1, 1, 1, 0],
+                            [1, 1, 0, 0],
+                            [0, 0, 0, 0]],
+                        ),
+                        attributes={ 'is_crowd': True },
+                        label=4, group=3, id=3),
+                ], attributes={'id': 1}),
+            ], categories={
+                AnnotationType.label: LabelCategories.from_iterable(
+                    str(i) for i in range(10)),
+            })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train', image=np.ones((4, 4, 3)),
-                        annotations=[
-                            Polygon([0, 1, 2, 1, 2, 3, 0, 3],
-                                attributes={ 'is_crowd': False },
-                                label=2, group=1, id=1),
-                        ], attributes={'id': 1}),
-                    DatasetItem(id=2, subset='train', image=np.ones((4, 4, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 1, 0, 0],
-                                    [0, 1, 0, 0],
-                                    [0, 1, 1, 1],
-                                    [0, 0, 0, 0]],
-                                ),
-                                attributes={ 'is_crowd': True },
-                                label=4, group=3, id=3),
-                        ], attributes={'id': 2}),
+            DatasetItem(id=1, subset='train', image=np.ones((4, 4, 3)),
+                annotations=[
+                    Polygon([0, 1, 2, 1, 2, 3, 0, 3],
+                        attributes={ 'is_crowd': False },
+                        label=2, group=1, id=1),
+                ], attributes={'id': 1}),
+            DatasetItem(id=2, subset='train', image=np.ones((4, 4, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 1, 0, 0],
+                            [0, 1, 0, 0],
+                            [0, 1, 1, 1],
+                            [0, 0, 0, 0]],
+                        ),
+                        attributes={ 'is_crowd': True },
+                        label=4, group=3, id=3),
+                ], attributes={'id': 2}),
 
-                    DatasetItem(id=3, subset='val', image=np.ones((4, 4, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 0, 0],
-                                    [1, 1, 1, 0],
-                                    [1, 1, 0, 0],
-                                    [0, 0, 0, 0]],
-                                ),
-                                attributes={ 'is_crowd': True },
-                                label=4, group=3, id=3),
-                        ], attributes={'id': 1})
-                    ], categories={
-                        AnnotationType.label: LabelCategories.from_iterable(
-                            str(i) for i in range(10)),
-                })
+            DatasetItem(id=3, subset='val', image=np.ones((4, 4, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 0, 0],
+                            [1, 1, 1, 0],
+                            [1, 1, 0, 0],
+                            [0, 0, 0, 0]],
+                        ),
+                        attributes={ 'is_crowd': True },
+                        label=4, group=3, id=3),
+                ], attributes={'id': 1})
+            ], categories={
+                AnnotationType.label: LabelCategories.from_iterable(
+                    str(i) for i in range(10)),
+            })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -175,39 +175,39 @@ class CocoConverterTest(TestCase):
 
     def test_can_merge_polygons_on_loading(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((6, 10, 3)),
-                        annotations=[
-                            Polygon([0, 0, 4, 0, 4, 4],
-                                label=3, id=4, group=4),
-                            Polygon([5, 0, 9, 0, 5, 5],
-                                label=3, id=4, group=4),
-                        ]
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, image=np.zeros((6, 10, 3)),
+                annotations=[
+                    Polygon([0, 0, 4, 0, 4, 4],
+                        label=3, id=4, group=4),
+                    Polygon([5, 0, 9, 0, 5, 5],
+                        label=3, id=4, group=4),
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+        })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((6, 10, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                [0, 1, 1, 1, 0, 1, 1, 1, 1, 0],
-                                [0, 0, 1, 1, 0, 1, 1, 1, 0, 0],
-                                [0, 0, 0, 1, 0, 1, 1, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
-                                # only internal fragment (without the border),
-                                # but not everywhere...
-                            ),
-                            label=3, id=4, group=4,
-                            attributes={ 'is_crowd': False }),
-                        ], attributes={'id': 1}
+            DatasetItem(id=1, image=np.zeros((6, 10, 3)),
+                annotations=[
+                    Mask(np.array([
+                        [0, 1, 1, 1, 0, 1, 1, 1, 1, 0],
+                        [0, 0, 1, 1, 0, 1, 1, 1, 0, 0],
+                        [0, 0, 0, 1, 0, 1, 1, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                        # only internal fragment (without the border),
+                        # but not everywhere...
                     ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+                    label=3, id=4, group=4,
+                    attributes={ 'is_crowd': False }),
+                ], attributes={'id': 1}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -217,47 +217,47 @@ class CocoConverterTest(TestCase):
 
     def test_can_crop_covered_segments(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 1, 1, 1],
-                                    [0, 0, 1, 1, 1],
-                                    [1, 1, 0, 1, 1],
-                                    [1, 1, 1, 0, 0],
-                                    [1, 1, 1, 0, 0]],
-                                ),
-                                label=2, id=1, z_order=0),
-                            Polygon([1, 1, 4, 1, 4, 4, 1, 4],
-                                label=1, id=2, z_order=1),
-                        ]
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 1, 1, 1],
+                            [0, 0, 1, 1, 1],
+                            [1, 1, 0, 1, 1],
+                            [1, 1, 1, 0, 0],
+                            [1, 1, 1, 0, 0]],
+                        ),
+                        label=2, id=1, z_order=0),
+                    Polygon([1, 1, 4, 1, 4, 4, 1, 4],
+                        label=1, id=2, z_order=1),
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 1, 1, 1],
-                                    [0, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 0],
-                                    [1, 1, 1, 0, 0]],
-                                ),
-                                attributes={ 'is_crowd': True },
-                                label=2, id=1, group=1),
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 1, 1, 1],
+                            [0, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 0],
+                            [1, 1, 1, 0, 0]],
+                        ),
+                        attributes={ 'is_crowd': True },
+                        label=2, id=1, group=1),
 
-                            Polygon([1, 1, 4, 1, 4, 4, 1, 4],
-                                label=1, id=2, group=2,
-                                attributes={ 'is_crowd': False }),
-                        ], attributes={'id': 1}
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+                    Polygon([1, 1, 4, 1, 4, 4, 1, 4],
+                        label=1, id=2, group=2,
+                        attributes={ 'is_crowd': False }),
+                ], attributes={'id': 1}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -266,40 +266,40 @@ class CocoConverterTest(TestCase):
 
     def test_can_convert_polygons_to_mask(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((6, 10, 3)),
-                        annotations=[
-                            Polygon([0, 0, 4, 0, 4, 4],
-                                label=3, id=4, group=4),
-                            Polygon([5, 0, 9, 0, 5, 5],
-                                label=3, id=4, group=4),
-                        ]
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, image=np.zeros((6, 10, 3)),
+                annotations=[
+                    Polygon([0, 0, 4, 0, 4, 4],
+                        label=3, id=4, group=4),
+                    Polygon([5, 0, 9, 0, 5, 5],
+                        label=3, id=4, group=4),
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((6, 10, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 1, 1, 1, 0, 1, 1, 1, 1, 0],
-                                    [0, 0, 1, 1, 0, 1, 1, 1, 0, 0],
-                                    [0, 0, 0, 1, 0, 1, 1, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
-                                    # only internal fragment (without the border),
-                                    # but not everywhere...
-                                ),
-                                attributes={ 'is_crowd': True },
-                                label=3, id=4, group=4),
-                        ], attributes={'id': 1}
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, image=np.zeros((6, 10, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 1, 1, 1, 0, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]],
+                            # only internal fragment (without the border),
+                            # but not everywhere...
+                        ),
+                        attributes={ 'is_crowd': True },
+                        label=3, id=4, group=4),
+                ], attributes={'id': 1}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -308,40 +308,40 @@ class CocoConverterTest(TestCase):
 
     def test_can_convert_masks_to_polygons(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 10, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 1, 1, 1, 0, 1, 1, 1, 1, 0],
-                                    [0, 0, 1, 1, 0, 1, 1, 1, 0, 0],
-                                    [0, 0, 0, 1, 0, 1, 1, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                ]),
-                                label=3, id=4, group=4),
-                        ]
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, image=np.zeros((5, 10, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 1, 1, 1, 0, 1, 1, 1, 1, 0],
+                            [0, 0, 1, 1, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 1, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        ]),
+                        label=3, id=4, group=4),
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 10, 3)),
-                        annotations=[
-                            Polygon(
-                                [3.0, 2.5, 1.0, 0.0, 3.5, 0.0, 3.0, 2.5],
-                                label=3, id=4, group=4,
-                                attributes={ 'is_crowd': False }),
-                            Polygon(
-                                [5.0, 3.5, 4.5, 0.0, 8.0, 0.0, 5.0, 3.5],
-                                label=3, id=4, group=4,
-                                attributes={ 'is_crowd': False }),
-                        ], attributes={'id': 1}
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, image=np.zeros((5, 10, 3)),
+                annotations=[
+                    Polygon(
+                        [3.0, 2.5, 1.0, 0.0, 3.5, 0.0, 3.0, 2.5],
+                        label=3, id=4, group=4,
+                        attributes={ 'is_crowd': False }),
+                    Polygon(
+                        [5.0, 3.5, 4.5, 0.0, 8.0, 0.0, 5.0, 3.5],
+                        label=3, id=4, group=4,
+                        attributes={ 'is_crowd': False }),
+                ], attributes={'id': 1}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -350,32 +350,31 @@ class CocoConverterTest(TestCase):
 
     def test_can_save_and_load_images(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train', attributes={'id': 1}),
-                    DatasetItem(id=2, subset='train', attributes={'id': 2}),
+            DatasetItem(id=1, subset='train', attributes={'id': 1}),
+            DatasetItem(id=2, subset='train', attributes={'id': 2}),
 
-                    DatasetItem(id=2, subset='val', attributes={'id': 2}),
-                    DatasetItem(id=3, subset='val', attributes={'id': 3}),
-                    DatasetItem(id=4, subset='val', attributes={'id': 4}),
+            DatasetItem(id=2, subset='val', attributes={'id': 2}),
+            DatasetItem(id=3, subset='val', attributes={'id': 3}),
+            DatasetItem(id=4, subset='val', attributes={'id': 4}),
 
-                    DatasetItem(id=5, subset='test', attributes={'id': 1}),
-                ])
+            DatasetItem(id=5, subset='test', attributes={'id': 1}),
+        ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
                 CocoImageInfoConverter(), test_dir)
 
     def test_can_save_and_load_labels(self):
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
-                    DatasetItem(id=1, subset='train',
-                        annotations=[
-                            Label(4, id=1, group=1),
-                            Label(9, id=2, group=2),
-                        ], attributes={'id': 1}),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-                })
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id=1, subset='train',
+                annotations=[
+                    Label(4, id=1, group=1),
+                    Label(9, id=2, group=2),
+                ], attributes={'id': 1}),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -384,73 +383,73 @@ class CocoConverterTest(TestCase):
     def test_can_save_and_load_keypoints(self):
 
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train', image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            # Full instance annotations: polygon + keypoints
-                            Points([0, 0, 0, 2, 4, 1], [0, 1, 2],
-                                label=3, group=1, id=1),
-                            Polygon([0, 0, 4, 0, 4, 4],
-                                label=3, group=1, id=1),
+            DatasetItem(id=1, subset='train', image=np.zeros((5, 5, 3)),
+                annotations=[
+                    # Full instance annotations: polygon + keypoints
+                    Points([0, 0, 0, 2, 4, 1], [0, 1, 2],
+                        label=3, group=1, id=1),
+                    Polygon([0, 0, 4, 0, 4, 4],
+                        label=3, group=1, id=1),
 
-                            # Full instance annotations: bbox + keypoints
-                            Points([1, 2, 3, 4, 2, 3], group=2, id=2),
-                            Bbox(1, 2, 2, 2, group=2, id=2),
+                    # Full instance annotations: bbox + keypoints
+                    Points([1, 2, 3, 4, 2, 3], group=2, id=2),
+                    Bbox(1, 2, 2, 2, group=2, id=2),
 
-                            # Solitary keypoints
-                            Points([1, 2, 0, 2, 4, 1], label=5, id=3),
+                    # Solitary keypoints
+                    Points([1, 2, 0, 2, 4, 1], label=5, id=3),
 
-                            # Some other solitary annotations (bug #1387)
-                            Polygon([0, 0, 4, 0, 4, 4], label=3, id=4),
+                    # Some other solitary annotations (bug #1387)
+                    Polygon([0, 0, 4, 0, 4, 4], label=3, id=4),
 
-                            # Solitary keypoints with no label
-                            Points([0, 0, 1, 2, 3, 4], [0, 1, 2], id=5),
-                        ]),
-                    ], categories={
-                            AnnotationType.label: LabelCategories.from_iterable(
-                                str(i) for i in range(10)),
-                            AnnotationType.points: PointsCategories.from_iterable(
-                                (i, None, [[0, 1], [1, 2]]) for i in range(10)
-                            ),
-                    })
+                    # Solitary keypoints with no label
+                    Points([0, 0, 1, 2, 3, 4], [0, 1, 2], id=5),
+                ]),
+            ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
+                    AnnotationType.points: PointsCategories.from_iterable(
+                        (i, None, [[0, 1], [1, 2]]) for i in range(10)
+                    ),
+            })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train', image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Points([0, 0, 0, 2, 4, 1], [0, 1, 2],
-                                label=3, group=1, id=1,
-                                attributes={'is_crowd': False}),
-                            Polygon([0, 0, 4, 0, 4, 4],
-                                label=3, group=1, id=1,
-                                attributes={'is_crowd': False}),
+            DatasetItem(id=1, subset='train', image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Points([0, 0, 0, 2, 4, 1], [0, 1, 2],
+                        label=3, group=1, id=1,
+                        attributes={'is_crowd': False}),
+                    Polygon([0, 0, 4, 0, 4, 4],
+                        label=3, group=1, id=1,
+                        attributes={'is_crowd': False}),
 
-                            Points([1, 2, 3, 4, 2, 3],
-                                group=2, id=2,
-                                attributes={'is_crowd': False}),
-                            Polygon([1, 2, 3, 2, 3, 4, 1, 4],
-                                group=2, id=2,
-                                attributes={'is_crowd': False}),
+                    Points([1, 2, 3, 4, 2, 3],
+                        group=2, id=2,
+                        attributes={'is_crowd': False}),
+                    Polygon([1, 2, 3, 2, 3, 4, 1, 4],
+                        group=2, id=2,
+                        attributes={'is_crowd': False}),
 
-                            Points([1, 2, 0, 2, 4, 1],
-                                label=5, group=3, id=3,
-                                attributes={'is_crowd': False}),
-                            Polygon([0, 1, 4, 1, 4, 2, 0, 2],
-                                label=5, group=3, id=3,
-                                attributes={'is_crowd': False}),
+                    Points([1, 2, 0, 2, 4, 1],
+                        label=5, group=3, id=3,
+                        attributes={'is_crowd': False}),
+                    Polygon([0, 1, 4, 1, 4, 2, 0, 2],
+                        label=5, group=3, id=3,
+                        attributes={'is_crowd': False}),
 
-                            Points([0, 0, 1, 2, 3, 4], [0, 1, 2],
-                                group=5, id=5,
-                                attributes={'is_crowd': False}),
-                            Polygon([1, 2, 3, 2, 3, 4, 1, 4],
-                                group=5, id=5,
-                                attributes={'is_crowd': False}),
-                        ], attributes={'id': 1}),
-                    ], categories={
-                            AnnotationType.label: LabelCategories.from_iterable(
-                                str(i) for i in range(10)),
-                            AnnotationType.points: PointsCategories.from_iterable(
-                                (i, None, [[0, 1], [1, 2]]) for i in range(10)
-                            ),
-                    })
+                    Points([0, 0, 1, 2, 3, 4], [0, 1, 2],
+                        group=5, id=5,
+                        attributes={'is_crowd': False}),
+                    Polygon([1, 2, 3, 2, 3, 4, 1, 4],
+                        group=5, id=5,
+                        attributes={'is_crowd': False}),
+                ], attributes={'id': 1}),
+            ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
+                    AnnotationType.points: PointsCategories.from_iterable(
+                        (i, None, [[0, 1], [1, 2]]) for i in range(10)
+                    ),
+            })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -459,10 +458,9 @@ class CocoConverterTest(TestCase):
 
     def test_can_save_dataset_with_no_subsets(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, attributes={'id': 1}),
-                    DatasetItem(id=2, attributes={'id': 2}),
-                ], categories={ AnnotationType.label: LabelCategories(), }
-            )
+            DatasetItem(id=1, attributes={'id': 1}),
+            DatasetItem(id=2, attributes={'id': 2}),
+        ], categories={ AnnotationType.label: LabelCategories(), })
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -470,9 +468,9 @@ class CocoConverterTest(TestCase):
 
     def test_can_save_dataset_with_image_info(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=Image(path='1.jpg', size=(10, 15)),
-                        attributes={'id': 1}),
-                ])
+            DatasetItem(id=1, image=Image(path='1.jpg', size=(10, 15)),
+                attributes={'id': 1}),
+        ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -480,24 +478,23 @@ class CocoConverterTest(TestCase):
 
     def test_relative_paths(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id='1', image=np.ones((4, 2, 3)),
-                        attributes={'id': 1}),
-                    DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3)),
-                        attributes={'id': 2}),
-                    DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3)),
-                        attributes={'id': 3}),
-                ])
+            DatasetItem(id='1', image=np.ones((4, 2, 3)),
+                attributes={'id': 1}),
+            DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3)),
+                attributes={'id': 2}),
+            DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3)),
+                attributes={'id': 3}),
+        ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
                 CocoConverter(tasks='image_info', save_images=True), test_dir)
 
     def test_preserve_coco_ids(self):
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
-                    DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
-                        attributes={'id': 40}),
-                ])
+        expected_dataset = Dataset.from_iterable([
+            DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
+                attributes={'id': 40}),
+        ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -505,14 +502,14 @@ class CocoConverterTest(TestCase):
 
     def test_annotation_attributes(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.ones((4, 2, 3)), annotations=[
-                        Polygon([0, 0, 4, 0, 4, 4], label=5, group=1, id=1,
-                            attributes={'is_crowd': False, 'x': 5, 'y': 'abc'}),
-                    ], attributes={'id': 1})
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        str(i) for i in range(10)),
-            })
+            DatasetItem(id=1, image=np.ones((4, 2, 3)), annotations=[
+                Polygon([0, 0, 4, 0, 4, 4], label=5, group=1, id=1,
+                    attributes={'is_crowd': False, 'x': 5, 'y': 'abc'}),
+            ], attributes={'id': 1})
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -39,7 +39,7 @@ class CocoImporterTest(TestCase):
                                 id=2, group=2, attributes={'is_crowd': True}),
                         ]
                     )]
-        
+
         # Creating categories
         label_cat = LabelCategories()
         label_cat.add('TEST')
@@ -88,7 +88,7 @@ class CocoConverterTest(TestCase):
                             Caption('word', id=1, group=1),
                         ], attributes={'id': 1}
                     )]
-        
+
         # Creating exemplary dataset
         exemplary_dataset = Dataset.from_iterable(items_list)
 
@@ -138,7 +138,7 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': True },
                                 label=4, group=3, id=3),
                         ], attributes={'id': 1})]
-        
+
         # Creating categories
         label_categories = LabelCategories()
         for i in range(10):
@@ -180,8 +180,8 @@ class CocoConverterTest(TestCase):
                                 label=4, group=3, id=3),
                         ], attributes={'id': 1})
                     ]
-        
-        
+
+
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
 
@@ -201,7 +201,7 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ]
                     )]
-        
+
         # Creating categories
         label_categories = LabelCategories()
         for i in range(10):
@@ -229,7 +229,7 @@ class CocoConverterTest(TestCase):
                             attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
                     )]
-        
+
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
 
@@ -256,7 +256,7 @@ class CocoConverterTest(TestCase):
                                 label=1, id=2, z_order=1),
                         ]
                     )]
-        
+
         # Creating categories
         label_categories = LabelCategories()
         for i in range(10):
@@ -285,7 +285,7 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
                     )]
-        
+
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
 
@@ -305,7 +305,7 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ]
                     )]
-        
+
         # Creating categories
         label_categories = LabelCategories()
         for i in range(10):
@@ -333,7 +333,7 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ], attributes={'id': 1}
                     )]
-        
+
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
 
@@ -357,7 +357,7 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ]
                     )]
-        
+
         # Creating categories
         label_categories = LabelCategories()
         for i in range(10):
@@ -384,7 +384,7 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
                     )]
-        
+
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
 
@@ -405,7 +405,7 @@ class CocoConverterTest(TestCase):
 
                     DatasetItem(id=5, subset='test', attributes={'id': 1}),
                 ]
-        
+
         # Creating exemplary dataset
         exemplary_dataset = Dataset.from_iterable(items_list)
 
@@ -422,7 +422,7 @@ class CocoConverterTest(TestCase):
                             Label(9, id=2, group=2),
                         ], attributes={'id': 1}
                     )]
-        
+
         # Creating categories
         label_categories = LabelCategories()
         for i in range(10):
@@ -460,7 +460,7 @@ class CocoConverterTest(TestCase):
                             # Solitary keypoints with no label
                             Points([0, 0, 1, 2, 3, 4], [0, 1, 2], id=5),
                         ])]
-        
+
         # Creating categories
         label_categories = LabelCategories()
         points_categories = PointsCategories()
@@ -508,7 +508,7 @@ class CocoConverterTest(TestCase):
                                 attributes={'is_crowd': False}),
                         ], attributes={'id': 1})
                     ]
-        
+
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
 
@@ -523,7 +523,7 @@ class CocoConverterTest(TestCase):
                     DatasetItem(id=1, attributes={'id': 1}),
                     DatasetItem(id=2, attributes={'id': 2}),
                 ]
-        
+
         # Creating categories
         categories = { AnnotationType.label: LabelCategories() }
 

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -315,7 +315,8 @@ class CocoConverterTest(TestCase):
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
-                CocoInstancesConverter.convert, test_dir,
+                partial(CocoInstancesConverter.convert, segmentation_mode='polygons'),
+                test_dir,
                 target_dataset=target_dataset)
 
     def test_can_save_and_load_images(self):
@@ -424,13 +425,13 @@ class CocoConverterTest(TestCase):
                 target_dataset=target_dataset)
 
     def test_can_save_dataset_with_no_subsets(self):
-        expected_dataset = Dataset.from_iterable([
+        test_dataset = Dataset.from_iterable([
             DatasetItem(id=1, attributes={'id': 1}),
             DatasetItem(id=2, attributes={'id': 2}),
-        ], categories={ AnnotationType.label: LabelCategories(), })
+        ])
 
         with TestDir() as test_dir:
-            self._test_save_and_load(expected_dataset,
+            self._test_save_and_load(test_dataset,
                 CocoConverter.convert, test_dir)
 
     def test_can_save_dataset_with_image_info(self):

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -38,8 +38,7 @@ class CocoImporterTest(TestCase):
                                 ), label=0,
                                 id=2, group=2, attributes={'is_crowd': True}),
                         ]
-                    ),
-                ]
+                    )]
         
         # Creating categories
         label_cat = LabelCategories()
@@ -88,8 +87,7 @@ class CocoConverterTest(TestCase):
                         annotations=[
                             Caption('word', id=1, group=1),
                         ], attributes={'id': 1}
-                    ),
-                ]
+                    )]
         
         # Creating exemplary dataset
         exemplary_dataset = Dataset.from_iterable(items_list)
@@ -139,8 +137,7 @@ class CocoConverterTest(TestCase):
                                 ),
                                 attributes={ 'is_crowd': True },
                                 label=4, group=3, id=3),
-                        ], attributes={'id': 1}),
-                ]
+                        ], attributes={'id': 1})]
         
         # Creating categories
         label_categories = LabelCategories()
@@ -181,8 +178,8 @@ class CocoConverterTest(TestCase):
                                 ),
                                 attributes={ 'is_crowd': True },
                                 label=4, group=3, id=3),
-                        ], attributes={'id': 1}),
-                ]
+                        ], attributes={'id': 1})
+                    ]
         
         
         # Creating exemplary dataset
@@ -203,8 +200,7 @@ class CocoConverterTest(TestCase):
                             Polygon([5, 0, 9, 0, 5, 5],
                                 label=3, id=4, group=4),
                         ]
-                    ),
-                ]
+                    )]
         
         # Creating categories
         label_categories = LabelCategories()
@@ -232,8 +228,7 @@ class CocoConverterTest(TestCase):
                             label=3, id=4, group=4,
                             attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
-                    ),
-                ]
+                    )]
         
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
@@ -260,8 +255,7 @@ class CocoConverterTest(TestCase):
                             Polygon([1, 1, 4, 1, 4, 4, 1, 4],
                                 label=1, id=2, z_order=1),
                         ]
-                    ),
-                ]
+                    )]
         
         # Creating categories
         label_categories = LabelCategories()
@@ -290,8 +284,7 @@ class CocoConverterTest(TestCase):
                                 label=1, id=2, group=2,
                                 attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
-                    ),
-                ]
+                    )]
         
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
@@ -311,8 +304,7 @@ class CocoConverterTest(TestCase):
                             Polygon([5, 0, 9, 0, 5, 5],
                                 label=3, id=4, group=4),
                         ]
-                    ),
-                ]
+                    )]
         
         # Creating categories
         label_categories = LabelCategories()
@@ -340,8 +332,7 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': True },
                                 label=3, id=4, group=4),
                         ], attributes={'id': 1}
-                    ),
-                ]
+                    )]
         
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
@@ -365,8 +356,7 @@ class CocoConverterTest(TestCase):
                                 ]),
                                 label=3, id=4, group=4),
                         ]
-                    ),
-                ]
+                    )]
         
         # Creating categories
         label_categories = LabelCategories()
@@ -393,8 +383,7 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4,
                                 attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
-                    ),
-                ]
+                    )]
         
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)
@@ -432,8 +421,7 @@ class CocoConverterTest(TestCase):
                             Label(4, id=1, group=1),
                             Label(9, id=2, group=2),
                         ], attributes={'id': 1}
-                    ),
-                ]
+                    )]
         
         # Creating categories
         label_categories = LabelCategories()
@@ -471,8 +459,7 @@ class CocoConverterTest(TestCase):
 
                             # Solitary keypoints with no label
                             Points([0, 0, 1, 2, 3, 4], [0, 1, 2], id=5),
-                        ])
-                ]
+                        ])]
         
         # Creating categories
         label_categories = LabelCategories()
@@ -519,8 +506,8 @@ class CocoConverterTest(TestCase):
                             Polygon([1, 2, 3, 2, 3, 4, 1, 4],
                                 group=5, id=5,
                                 attributes={'is_crowd': False}),
-                        ], attributes={'id': 1}),
-                ]
+                        ], attributes={'id': 1})
+                    ]
         
         # Creating exemplary dataset
         dst_exemplary_dataset = Dataset.from_iterable(dst_items_list, categories)

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -129,7 +129,8 @@ class CocoConverterTest(TestCase):
                                 label=4, group=3, id=3),
                         ], attributes={'id': 1}),
                     ], categories={
-                        AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                        AnnotationType.label: LabelCategories.from_iterable(
+                            str(i) for i in range(10)),
                     })
 
         target_dataset = Dataset.from_iterable([
@@ -163,7 +164,8 @@ class CocoConverterTest(TestCase):
                                 label=4, group=3, id=3),
                         ], attributes={'id': 1})
                     ], categories={
-                        AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                        AnnotationType.label: LabelCategories.from_iterable(
+                            str(i) for i in range(10)),
                 })
 
         with TestDir() as test_dir:
@@ -203,7 +205,8 @@ class CocoConverterTest(TestCase):
                         ], attributes={'id': 1}
                     ),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         with TestDir() as test_dir:
@@ -229,7 +232,8 @@ class CocoConverterTest(TestCase):
                         ]
                     ),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         target_dataset = Dataset.from_iterable([
@@ -251,7 +255,8 @@ class CocoConverterTest(TestCase):
                         ], attributes={'id': 1}
                     ),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         with TestDir() as test_dir:
@@ -270,7 +275,8 @@ class CocoConverterTest(TestCase):
                         ]
                     ),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         target_dataset = Dataset.from_iterable([
@@ -291,7 +297,8 @@ class CocoConverterTest(TestCase):
                         ], attributes={'id': 1}
                     ),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         with TestDir() as test_dir:
@@ -314,7 +321,8 @@ class CocoConverterTest(TestCase):
                         ]
                     ),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         target_dataset = Dataset.from_iterable([
@@ -331,7 +339,8 @@ class CocoConverterTest(TestCase):
                         ], attributes={'id': 1}
                     ),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         with TestDir() as test_dir:
@@ -364,7 +373,8 @@ class CocoConverterTest(TestCase):
                             Label(9, id=2, group=2),
                         ], attributes={'id': 1}),
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
                 })
 
         with TestDir() as test_dir:
@@ -372,9 +382,6 @@ class CocoConverterTest(TestCase):
                 CocoLabelsConverter(), test_dir)
 
     def test_can_save_and_load_keypoints(self):
-        points_categories = PointsCategories()
-        for i in range(10):
-            points_categories.add(i, joints=[[0, 1], [1, 2]])
 
         source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', image=np.zeros((5, 5, 3)),
@@ -399,8 +406,11 @@ class CocoConverterTest(TestCase):
                             Points([0, 0, 1, 2, 3, 4], [0, 1, 2], id=5),
                         ]),
                     ], categories={
-                            AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
-                            AnnotationType.points: points_categories,
+                            AnnotationType.label: LabelCategories.from_iterable(
+                                str(i) for i in range(10)),
+                            AnnotationType.points: PointsCategories.from_iterable(
+                                (i, None, [[0, 1], [1, 2]]) for i in range(10)
+                            ),
                     })
 
         target_dataset = Dataset.from_iterable([
@@ -435,8 +445,11 @@ class CocoConverterTest(TestCase):
                                 attributes={'is_crowd': False}),
                         ], attributes={'id': 1}),
                     ], categories={
-                            AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
-                            AnnotationType.points: points_categories,
+                            AnnotationType.label: LabelCategories.from_iterable(
+                                str(i) for i in range(10)),
+                            AnnotationType.points: PointsCategories.from_iterable(
+                                (i, None, [[0, 1], [1, 2]]) for i in range(10)
+                            ),
                     })
 
         with TestDir() as test_dir:
@@ -497,7 +510,8 @@ class CocoConverterTest(TestCase):
                             attributes={'is_crowd': False, 'x': 5, 'y': 'abc'}),
                     ], attributes={'id': 1})
                 ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        str(i) for i in range(10)),
             })
 
         with TestDir() as test_dir:

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -39,9 +39,7 @@ class CocoImporterTest(TestCase):
                         id=2, group=2, attributes={'is_crowd': True}),
                 ]
             ),
-        ], categories={
-                        AnnotationType.label : LabelCategories.from_iterable('TEST'),
-                    })
+        ], categories=['TEST',])
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'coco') \
             .make_dataset()
@@ -128,10 +126,7 @@ class CocoConverterTest(TestCase):
                         attributes={ 'is_crowd': True },
                         label=4, group=3, id=3),
                 ], attributes={'id': 1}),
-            ], categories={
-                AnnotationType.label: LabelCategories.from_iterable(
-                    str(i) for i in range(10)),
-            })
+            ], categories=[str(i) for i in range(10)])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id=1, subset='train', image=np.ones((4, 4, 3)),
@@ -163,10 +158,7 @@ class CocoConverterTest(TestCase):
                         attributes={ 'is_crowd': True },
                         label=4, group=3, id=3),
                 ], attributes={'id': 1})
-            ], categories={
-                AnnotationType.label: LabelCategories.from_iterable(
-                    str(i) for i in range(10)),
-            })
+            ], categories=[str(i) for i in range(10)])
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -183,9 +175,7 @@ class CocoConverterTest(TestCase):
                         label=3, id=4, group=4),
                 ]
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id=1, image=np.zeros((6, 10, 3)),
@@ -204,10 +194,7 @@ class CocoConverterTest(TestCase):
                     attributes={ 'is_crowd': False }),
                 ], attributes={'id': 1}
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -231,10 +218,7 @@ class CocoConverterTest(TestCase):
                         label=1, id=2, z_order=1),
                 ]
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id=1, image=np.zeros((5, 5, 3)),
@@ -254,10 +238,7 @@ class CocoConverterTest(TestCase):
                         attributes={ 'is_crowd': False }),
                 ], attributes={'id': 1}
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -274,10 +255,7 @@ class CocoConverterTest(TestCase):
                         label=3, id=4, group=4),
                 ]
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id=1, image=np.zeros((6, 10, 3)),
@@ -296,10 +274,7 @@ class CocoConverterTest(TestCase):
                         label=3, id=4, group=4),
                 ], attributes={'id': 1}
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -320,10 +295,7 @@ class CocoConverterTest(TestCase):
                         label=3, id=4, group=4),
                 ]
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id=1, image=np.zeros((5, 10, 3)),
@@ -338,10 +310,7 @@ class CocoConverterTest(TestCase):
                         attributes={ 'is_crowd': False }),
                 ], attributes={'id': 1}
             ),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -371,10 +340,7 @@ class CocoConverterTest(TestCase):
                     Label(4, id=1, group=1),
                     Label(9, id=2, group=2),
                 ], attributes={'id': 1}),
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
@@ -506,10 +472,7 @@ class CocoConverterTest(TestCase):
                 Polygon([0, 0, 4, 0, 4, 4], label=5, group=1, id=1,
                     attributes={'is_crowd': False, 'x': 5, 'y': 'abc'}),
             ], attributes={'id': 1})
-        ], categories={
-            AnnotationType.label: LabelCategories.from_iterable(
-                str(i) for i in range(10)),
-        })
+        ], categories=[str(i) for i in range(10)])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -25,11 +25,8 @@ DUMMY_DATASET_DIR = osp.join(osp.dirname(__file__), 'assets', 'coco_dataset')
 
 class CocoImporterTest(TestCase):
     def test_can_import(self):
-        label_cat = LabelCategories()
-        label_cat.add('TEST')
 
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id='000000000001', image=np.ones((10, 5, 3)),
                         subset='val', attributes={'id': 1},
                         annotations=[
@@ -42,8 +39,9 @@ class CocoImporterTest(TestCase):
                                 id=2, group=2, attributes={'is_crowd': True}),
                         ]
                     )
-                ], categories={ AnnotationType.label : label_cat, }
-            )
+                ], categories={
+                    AnnotationType.label : LabelCategories.from_iterable('TEST'),
+                })
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'coco') \
             .make_dataset()
@@ -68,8 +66,7 @@ class CocoConverterTest(TestCase):
         compare_datasets(self, expected=target_dataset, actual=parsed_dataset)
 
     def test_can_save_and_load_captions(self):
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train',
                         annotations=[
                             Caption('hello', id=1, group=1),
@@ -91,12 +88,7 @@ class CocoConverterTest(TestCase):
                 CocoCaptionsConverter(), test_dir)
 
     def test_can_save_and_load_instances(self):
-        label_categories = LabelCategories()
-        for i in range(10):
-            label_categories.add(str(i))
-
-        source_dataset = Dataset.from_iterable(
-                iterable=[
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', image=np.ones((4, 4, 3)),
                         annotations=[
                             # Bbox + single polygon
@@ -136,11 +128,11 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': True },
                                 label=4, group=3, id=3),
                         ], attributes={'id': 1}),
-                    ], categories={ AnnotationType.label: label_categories, }
-                )
+                    ], categories={
+                        AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                    })
 
-        target_dataset = Dataset.from_iterable(
-                iterable=[
+        target_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', image=np.ones((4, 4, 3)),
                         annotations=[
                             Polygon([0, 1, 2, 1, 2, 3, 0, 3],
@@ -170,8 +162,9 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': True },
                                 label=4, group=3, id=3),
                         ], attributes={'id': 1})
-                    ], categories={ AnnotationType.label: label_categories, }
-                )
+                    ], categories={
+                        AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -179,12 +172,7 @@ class CocoConverterTest(TestCase):
                 target_dataset=target_dataset)
 
     def test_can_merge_polygons_on_loading(self):
-        label_categories = LabelCategories()
-        for i in range(10):
-            label_categories.add(str(i))
-
-        source_dataset = Dataset.from_iterable(
-                iterable=[
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((6, 10, 3)),
                         annotations=[
                             Polygon([0, 0, 4, 0, 4, 4],
@@ -193,11 +181,11 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ]
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
-        target_dataset = Dataset.from_iterable(
-                iterable=[
+        target_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((6, 10, 3)),
                         annotations=[
                             Mask(np.array([
@@ -214,8 +202,9 @@ class CocoConverterTest(TestCase):
                             attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -224,12 +213,7 @@ class CocoConverterTest(TestCase):
                 target_dataset=target_dataset)
 
     def test_can_crop_covered_segments(self):
-        label_categories = LabelCategories()
-        for i in range(10):
-            label_categories.add(str(i))
-
-        source_dataset = Dataset.from_iterable(
-                iterable=[
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((5, 5, 3)),
                         annotations=[
                             Mask(np.array([
@@ -244,11 +228,11 @@ class CocoConverterTest(TestCase):
                                 label=1, id=2, z_order=1),
                         ]
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
-        target_dataset = Dataset.from_iterable(
-                iterable=[
+        target_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((5, 5, 3)),
                         annotations=[
                             Mask(np.array([
@@ -266,8 +250,9 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -275,12 +260,7 @@ class CocoConverterTest(TestCase):
                 target_dataset=target_dataset)
 
     def test_can_convert_polygons_to_mask(self):
-        label_categories = LabelCategories()
-        for i in range(10):
-            label_categories.add(str(i))
-
-        source_dataset = Dataset.from_iterable(
-                iterable=[
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((6, 10, 3)),
                         annotations=[
                             Polygon([0, 0, 4, 0, 4, 4],
@@ -289,11 +269,11 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ]
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
-        target_dataset = Dataset.from_iterable(
-                iterable=[
+        target_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((6, 10, 3)),
                         annotations=[
                             Mask(np.array([
@@ -310,8 +290,9 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ], attributes={'id': 1}
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -319,12 +300,7 @@ class CocoConverterTest(TestCase):
                 target_dataset=target_dataset)
 
     def test_can_convert_masks_to_polygons(self):
-        label_categories = LabelCategories()
-        for i in range(10):
-            label_categories.add(str(i))
-
-        source_dataset = Dataset.from_iterable(
-                iterable=[
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((5, 10, 3)),
                         annotations=[
                             Mask(np.array([
@@ -337,11 +313,11 @@ class CocoConverterTest(TestCase):
                                 label=3, id=4, group=4),
                         ]
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
-        target_dataset = Dataset.from_iterable(
-                iterable=[
+        target_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.zeros((5, 10, 3)),
                         annotations=[
                             Polygon(
@@ -354,8 +330,9 @@ class CocoConverterTest(TestCase):
                                 attributes={ 'is_crowd': False }),
                         ], attributes={'id': 1}
                     ),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -363,8 +340,7 @@ class CocoConverterTest(TestCase):
                 target_dataset=target_dataset)
 
     def test_can_save_and_load_images(self):
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', attributes={'id': 1}),
                     DatasetItem(id=2, subset='train', attributes={'id': 2}),
 
@@ -380,10 +356,6 @@ class CocoConverterTest(TestCase):
                 CocoImageInfoConverter(), test_dir)
 
     def test_can_save_and_load_labels(self):
-        label_categories = LabelCategories()
-        for i in range(10):
-            label_categories.add(str(i))
-
         expected_dataset = Dataset.from_iterable(
                 iterable=[
                     DatasetItem(id=1, subset='train',
@@ -391,22 +363,20 @@ class CocoConverterTest(TestCase):
                             Label(4, id=1, group=1),
                             Label(9, id=2, group=2),
                         ], attributes={'id': 1}),
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,
                 CocoLabelsConverter(), test_dir)
 
     def test_can_save_and_load_keypoints(self):
-        label_categories = LabelCategories()
         points_categories = PointsCategories()
         for i in range(10):
-            label_categories.add(str(i))
             points_categories.add(i, joints=[[0, 1], [1, 2]])
 
-        source_dataset = Dataset.from_iterable(
-                iterable=[
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', image=np.zeros((5, 5, 3)),
                         annotations=[
                             # Full instance annotations: polygon + keypoints
@@ -429,12 +399,11 @@ class CocoConverterTest(TestCase):
                             Points([0, 0, 1, 2, 3, 4], [0, 1, 2], id=5),
                         ]),
                     ], categories={
-                            AnnotationType.label: label_categories,
+                            AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
                             AnnotationType.points: points_categories,
                     })
 
-        target_dataset = Dataset.from_iterable(
-                iterable=[
+        target_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', image=np.zeros((5, 5, 3)),
                         annotations=[
                             Points([0, 0, 0, 2, 4, 1], [0, 1, 2],
@@ -466,7 +435,7 @@ class CocoConverterTest(TestCase):
                                 attributes={'is_crowd': False}),
                         ], attributes={'id': 1}),
                     ], categories={
-                            AnnotationType.label: label_categories,
+                            AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
                             AnnotationType.points: points_categories,
                     })
 
@@ -476,8 +445,7 @@ class CocoConverterTest(TestCase):
                 target_dataset=target_dataset)
 
     def test_can_save_dataset_with_no_subsets(self):
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, attributes={'id': 1}),
                     DatasetItem(id=2, attributes={'id': 2}),
                 ], categories={ AnnotationType.label: LabelCategories(), }
@@ -488,8 +456,7 @@ class CocoConverterTest(TestCase):
                 CocoConverter(), test_dir)
 
     def test_can_save_dataset_with_image_info(self):
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=Image(path='1.jpg', size=(10, 15)),
                         attributes={'id': 1}),
                 ])
@@ -499,8 +466,7 @@ class CocoConverterTest(TestCase):
                 CocoConverter(tasks='image_info'), test_dir)
 
     def test_relative_paths(self):
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id='1', image=np.ones((4, 2, 3)),
                         attributes={'id': 1}),
                     DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3)),
@@ -525,18 +491,14 @@ class CocoConverterTest(TestCase):
                 CocoConverter(tasks='image_info', save_images=True), test_dir)
 
     def test_annotation_attributes(self):
-        label_categories = LabelCategories()
-        for i in range(10):
-            label_categories.add(str(i))
-
-        expected_dataset = Dataset.from_iterable(
-                iterable=[
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, image=np.ones((4, 2, 3)), annotations=[
                         Polygon([0, 0, 4, 0, 4, 4], label=5, group=1, id=1,
                             attributes={'is_crowd': False, 'x': 5, 'y': 'abc'}),
                     ], attributes={'id': 1})
-                ], categories={ AnnotationType.label: label_categories, }
-            )
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(str(i) for i in range(10)),
+            })
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,

--- a/datumaro/tests/test_coco_format.py
+++ b/datumaro/tests/test_coco_format.py
@@ -44,7 +44,7 @@ class CocoImporterTest(TestCase):
         label_cat = LabelCategories()
         label_cat.add('TEST')
         categories = { AnnotationType.label : label_cat}
-        
+
         # Creating exemplary dataset
         exemplary_dataset = Dataset.from_iterable(items_list, categories)
 
@@ -144,7 +144,7 @@ class CocoConverterTest(TestCase):
         for i in range(10):
             label_categories.add(str(i))
         categories = { AnnotationType.label: label_categories }
-        
+
         # Creating exemplary dataset
         src_exemplary_dataset = Dataset.from_iterable(src_items_list, categories)
 
@@ -207,7 +207,7 @@ class CocoConverterTest(TestCase):
         for i in range(10):
             label_categories.add(str(i))
         categories = { AnnotationType.label: label_categories }
-        
+
         # Creating exemplary dataset
         src_exemplary_dataset = Dataset.from_iterable(src_items_list, categories)
 

--- a/datumaro/tests/test_cvat_format.py
+++ b/datumaro/tests/test_cvat_format.py
@@ -28,31 +28,31 @@ class CvatImporterTest(TestCase):
 
     def test_can_load_image(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id='img0', subset='train',
-                        image=np.ones((8, 8, 3)),
-                        annotations=[
-                            Bbox(0, 2, 4, 2, label=0, z_order=1,
-                                attributes={
-                                    'occluded': True,
-                                    'a1': True, 'a2': 'v3'
-                                }),
-                            PolyLine([1, 2, 3, 4, 5, 6, 7, 8],
-                                attributes={'occluded': False}),
-                        ], attributes={'frame': 0}),
-                    DatasetItem(id='img1', subset='train',
-                        image=np.ones((10, 10, 3)),
-                        annotations=[
-                            Polygon([1, 2, 3, 4, 6, 5], z_order=1,
-                                attributes={'occluded': False}),
-                            Points([1, 2, 3, 4, 5, 6], label=1, z_order=2,
-                                attributes={'occluded': False}),
-                        ], attributes={'frame': 1}),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable([
-                        ['label1', '', {'a1', 'a2'}],
-                        ['label2'],
-                    ])
-                })
+            DatasetItem(id='img0', subset='train',
+                image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=0, z_order=1,
+                        attributes={
+                            'occluded': True,
+                            'a1': True, 'a2': 'v3'
+                        }),
+                    PolyLine([1, 2, 3, 4, 5, 6, 7, 8],
+                        attributes={'occluded': False}),
+                ], attributes={'frame': 0}),
+            DatasetItem(id='img1', subset='train',
+                image=np.ones((10, 10, 3)),
+                annotations=[
+                    Polygon([1, 2, 3, 4, 6, 5], z_order=1,
+                        attributes={'occluded': False}),
+                    Points([1, 2, 3, 4, 5, 6], label=1, z_order=2,
+                        attributes={'occluded': False}),
+                ], attributes={'frame': 1}),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable([
+                ['label1', '', {'a1', 'a2'}],
+                ['label2'],
+            ])
+        })
 
         parsed_dataset = CvatImporter()(DUMMY_IMAGE_DATASET_DIR).make_dataset()
 
@@ -60,78 +60,78 @@ class CvatImporterTest(TestCase):
 
     def test_can_load_video(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id='frame_000010', subset='annotations',
-                        image=np.ones((20, 25, 3)),
-                        annotations=[
-                            Bbox(3, 4, 7, 1, label=2,
-                                id=0,
-                                attributes={
-                                    'occluded': True,
-                                    'outside': False, 'keyframe': True,
-                                    'track_id': 0
-                                }),
-                            Points([21.95, 8.00, 2.55, 15.09, 2.23, 3.16],
-                                label=0,
-                                id=1,
-                                attributes={
-                                    'occluded': False,
-                                    'outside': False, 'keyframe': True,
-                                    'track_id': 1, 'hgl': 'hgkf',
-                                }),
-                        ], attributes={'frame': 10}),
-                    DatasetItem(id='frame_000013', subset='annotations',
-                        image=np.ones((20, 25, 3)),
-                        annotations=[
-                            Bbox(7, 6, 7, 2, label=2,
-                                id=0,
-                                attributes={
-                                    'occluded': False,
-                                    'outside': True, 'keyframe': True,
-                                    'track_id': 0
-                                }),
-                            Points([21.95, 8.00, 9.55, 15.09, 5.23, 1.16],
-                                label=0,
-                                id=1,
-                                attributes={
-                                    'occluded': False,
-                                    'outside': True, 'keyframe': True,
-                                    'track_id': 1, 'hgl': 'jk',
-                                }),
-                            PolyLine([7.85, 13.88, 3.50, 6.67, 15.90, 2.00, 13.31, 7.21],
-                                label=2,
-                                id=2,
-                                attributes={
-                                    'occluded': False,
-                                    'outside': False, 'keyframe': True,
-                                    'track_id': 2,
-                                }),
-                        ], attributes={'frame': 13}),
-                    DatasetItem(id='frame_000016', subset='annotations',
-                        image=Image(path='frame_0000016.png', size=(20, 25)),
-                        annotations=[
-                            Bbox(8, 7, 6, 10, label=2,
-                                id=0,
-                                attributes={
-                                    'occluded': False,
-                                    'outside': True, 'keyframe': True,
-                                    'track_id': 0
-                                }),
-                            PolyLine([7.85, 13.88, 3.50, 6.67, 15.90, 2.00, 13.31, 7.21],
-                                label=2,
-                                id=2,
-                                attributes={
-                                    'occluded': False,
-                                    'outside': True, 'keyframe': True,
-                                    'track_id': 2,
-                                }),
-                        ], attributes={'frame': 16}),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable([
-                        ['klhg', '', {'hgl'}],
-                        ['z U k'],
-                        ['II']
-                    ]),
-                })
+            DatasetItem(id='frame_000010', subset='annotations',
+                image=np.ones((20, 25, 3)),
+                annotations=[
+                    Bbox(3, 4, 7, 1, label=2,
+                        id=0,
+                        attributes={
+                            'occluded': True,
+                            'outside': False, 'keyframe': True,
+                            'track_id': 0
+                        }),
+                    Points([21.95, 8.00, 2.55, 15.09, 2.23, 3.16],
+                        label=0,
+                        id=1,
+                        attributes={
+                            'occluded': False,
+                            'outside': False, 'keyframe': True,
+                            'track_id': 1, 'hgl': 'hgkf',
+                        }),
+                ], attributes={'frame': 10}),
+            DatasetItem(id='frame_000013', subset='annotations',
+                image=np.ones((20, 25, 3)),
+                annotations=[
+                    Bbox(7, 6, 7, 2, label=2,
+                        id=0,
+                        attributes={
+                            'occluded': False,
+                            'outside': True, 'keyframe': True,
+                            'track_id': 0
+                        }),
+                    Points([21.95, 8.00, 9.55, 15.09, 5.23, 1.16],
+                        label=0,
+                        id=1,
+                        attributes={
+                            'occluded': False,
+                            'outside': True, 'keyframe': True,
+                            'track_id': 1, 'hgl': 'jk',
+                        }),
+                    PolyLine([7.85, 13.88, 3.50, 6.67, 15.90, 2.00, 13.31, 7.21],
+                        label=2,
+                        id=2,
+                        attributes={
+                            'occluded': False,
+                            'outside': False, 'keyframe': True,
+                            'track_id': 2,
+                        }),
+                ], attributes={'frame': 13}),
+            DatasetItem(id='frame_000016', subset='annotations',
+                image=Image(path='frame_0000016.png', size=(20, 25)),
+                annotations=[
+                    Bbox(8, 7, 6, 10, label=2,
+                        id=0,
+                        attributes={
+                            'occluded': False,
+                            'outside': True, 'keyframe': True,
+                            'track_id': 0
+                        }),
+                    PolyLine([7.85, 13.88, 3.50, 6.67, 15.90, 2.00, 13.31, 7.21],
+                        label=2,
+                        id=2,
+                        attributes={
+                            'occluded': False,
+                            'outside': True, 'keyframe': True,
+                            'track_id': 2,
+                        }),
+                ], attributes={'frame': 16}),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable([
+                ['klhg', '', {'hgl'}],
+                ['z U k'],
+                ['II']
+            ]),
+        })
 
         parsed_dataset = CvatImporter()(DUMMY_VIDEO_DATASET_DIR).make_dataset()
 
@@ -159,82 +159,82 @@ class CvatConverterTest(TestCase):
         label_categories.attributes.update(['occluded'])
 
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=0, subset='s1', image=np.zeros((5, 10, 3)),
-                        annotations=[
-                            Polygon([0, 0, 4, 0, 4, 4],
-                                label=1, group=4,
-                                attributes={ 'occluded': True }),
-                            Points([1, 1, 3, 2, 2, 3],
-                                label=2,
-                                attributes={ 'a1': 'x', 'a2': 42,
-                                    'unknown': 'bar' }),
-                            Label(1),
-                            Label(2, attributes={ 'a1': 'y', 'a2': 44 }),
-                        ]
-                    ),
-                    DatasetItem(id=1, subset='s1',
-                        annotations=[
-                            PolyLine([0, 0, 4, 0, 4, 4],
-                                label=3, id=4, group=4),
-                            Bbox(5, 0, 1, 9,
-                                label=3, id=4, group=4),
-                        ]
-                    ),
+            DatasetItem(id=0, subset='s1', image=np.zeros((5, 10, 3)),
+                annotations=[
+                    Polygon([0, 0, 4, 0, 4, 4],
+                        label=1, group=4,
+                        attributes={ 'occluded': True }),
+                    Points([1, 1, 3, 2, 2, 3],
+                        label=2,
+                        attributes={ 'a1': 'x', 'a2': 42,
+                            'unknown': 'bar' }),
+                    Label(1),
+                    Label(2, attributes={ 'a1': 'y', 'a2': 44 }),
+                ]
+            ),
+            DatasetItem(id=1, subset='s1',
+                annotations=[
+                    PolyLine([0, 0, 4, 0, 4, 4],
+                        label=3, id=4, group=4),
+                    Bbox(5, 0, 1, 9,
+                        label=3, id=4, group=4),
+                ]
+            ),
 
-                    DatasetItem(id=2, subset='s2', image=np.ones((5, 10, 3)),
-                        annotations=[
-                            Polygon([0, 0, 4, 0, 4, 4], z_order=1,
-                                label=3, group=4,
-                                attributes={ 'occluded': False }),
-                            PolyLine([5, 0, 9, 0, 5, 5]), # will be skipped as no label
-                        ]
-                    ),
+            DatasetItem(id=2, subset='s2', image=np.ones((5, 10, 3)),
+                annotations=[
+                    Polygon([0, 0, 4, 0, 4, 4], z_order=1,
+                        label=3, group=4,
+                        attributes={ 'occluded': False }),
+                    PolyLine([5, 0, 9, 0, 5, 5]), # will be skipped as no label
+                ]
+            ),
 
-                    DatasetItem(id=3, subset='s3', image=Image(
-                        path='3.jpg', size=(2, 4))),
-                ], categories={
-                    AnnotationType.label: label_categories,
-                })
+            DatasetItem(id=3, subset='s3', image=Image(
+                path='3.jpg', size=(2, 4))),
+        ], categories={
+            AnnotationType.label: label_categories,
+        })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=0, subset='s1', image=np.zeros((5, 10, 3)),
-                        annotations=[
-                            Polygon([0, 0, 4, 0, 4, 4],
-                                label=1, group=4,
-                                attributes={ 'occluded': True }),
-                            Points([1, 1, 3, 2, 2, 3],
-                                label=2,
-                                attributes={ 'occluded': False,
-                                    'a1': 'x', 'a2': 42 }),
-                            Label(1),
-                            Label(2, attributes={ 'a1': 'y', 'a2': 44 }),
-                        ], attributes={'frame': 0}
-                    ),
-                    DatasetItem(id=1, subset='s1',
-                        annotations=[
-                            PolyLine([0, 0, 4, 0, 4, 4],
-                                label=3, group=4,
-                                attributes={ 'occluded': False }),
-                            Bbox(5, 0, 1, 9,
-                                label=3, group=4,
-                                attributes={ 'occluded': False }),
-                        ], attributes={'frame': 1}
-                    ),
+            DatasetItem(id=0, subset='s1', image=np.zeros((5, 10, 3)),
+                annotations=[
+                    Polygon([0, 0, 4, 0, 4, 4],
+                        label=1, group=4,
+                        attributes={ 'occluded': True }),
+                    Points([1, 1, 3, 2, 2, 3],
+                        label=2,
+                        attributes={ 'occluded': False,
+                            'a1': 'x', 'a2': 42 }),
+                    Label(1),
+                    Label(2, attributes={ 'a1': 'y', 'a2': 44 }),
+                ], attributes={'frame': 0}
+            ),
+            DatasetItem(id=1, subset='s1',
+                annotations=[
+                    PolyLine([0, 0, 4, 0, 4, 4],
+                        label=3, group=4,
+                        attributes={ 'occluded': False }),
+                    Bbox(5, 0, 1, 9,
+                        label=3, group=4,
+                        attributes={ 'occluded': False }),
+                ], attributes={'frame': 1}
+            ),
 
-                    DatasetItem(id=2, subset='s2', image=np.ones((5, 10, 3)),
-                        annotations=[
-                            Polygon([0, 0, 4, 0, 4, 4], z_order=1,
-                                label=3, group=4,
-                                attributes={ 'occluded': False }),
-                        ], attributes={'frame': 0}
-                    ),
+            DatasetItem(id=2, subset='s2', image=np.ones((5, 10, 3)),
+                annotations=[
+                    Polygon([0, 0, 4, 0, 4, 4], z_order=1,
+                        label=3, group=4,
+                        attributes={ 'occluded': False }),
+                ], attributes={'frame': 0}
+            ),
 
-                    DatasetItem(id=3, subset='s3', image=Image(
-                            path='3.jpg', size=(2, 4)),
-                        attributes={'frame': 0}),
-                ], categories={
-                    AnnotationType.label: label_categories,
-                })
+            DatasetItem(id=3, subset='s3', image=Image(
+                    path='3.jpg', size=(2, 4)),
+                attributes={'frame': 0}),
+        ], categories={
+            AnnotationType.label: label_categories,
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -243,22 +243,21 @@ class CvatConverterTest(TestCase):
 
     def test_relative_paths(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id='1', image=np.ones((4, 2, 3))),
-                    DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3))),
-                    DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3))),
-                ], categories={ AnnotationType.label: LabelCategories() }
-            )
+            DatasetItem(id='1', image=np.ones((4, 2, 3))),
+            DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3))),
+            DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3))),
+        ], categories={ AnnotationType.label: LabelCategories() })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id='1', image=np.ones((4, 2, 3)),
-                        attributes={'frame': 0}),
-                    DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3)),
-                        attributes={'frame': 1}),
-                    DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3)),
-                        attributes={'frame': 2}),
-                ], categories={
-                    AnnotationType.label: LabelCategories()
-                })
+            DatasetItem(id='1', image=np.ones((4, 2, 3)),
+                attributes={'frame': 0}),
+            DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3)),
+                attributes={'frame': 1}),
+            DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3)),
+                attributes={'frame': 2}),
+        ], categories={
+            AnnotationType.label: LabelCategories()
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(source_dataset,
@@ -267,11 +266,11 @@ class CvatConverterTest(TestCase):
 
     def test_preserve_frame_ids(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
-                        attributes={'frame': 40}),
-                ], categories={
-                    AnnotationType.label: LabelCategories()
-                })
+            DatasetItem(id='some/name1', image=np.ones((4, 2, 3)),
+                attributes={'frame': 40}),
+        ], categories={
+            AnnotationType.label: LabelCategories()
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,

--- a/datumaro/tests/test_datumaro_format.py
+++ b/datumaro/tests/test_datumaro_format.py
@@ -43,44 +43,44 @@ class DatumaroConverterTest(TestCase):
         points_categories.add(index, ['cat1', 'cat2'], joints=[[0, 1]])
 
     expected_dataset = Dataset.from_iterable([
-                DatasetItem(id=100, subset='train', image=np.ones((10, 6, 3)),
-                    annotations=[
-                        Caption('hello', id=1),
-                        Caption('world', id=2, group=5),
-                        Label(2, id=3, attributes={
-                            'x': 1,
-                            'y': '2',
-                        }),
-                        Bbox(1, 2, 3, 4, label=4, id=4, z_order=1, attributes={
-                            'score': 1.0,
-                        }),
-                        Bbox(5, 6, 7, 8, id=5, group=5),
-                        Points([1, 2, 2, 0, 1, 1], label=0, id=5, z_order=4),
-                        Mask(label=3, id=5, z_order=2, image=np.ones((2, 3))),
-                    ]),
-                DatasetItem(id=21, subset='train',
-                    annotations=[
-                        Caption('test'),
-                        Label(2),
-                        Bbox(1, 2, 3, 4, 5, id=42, group=42)
-                    ]),
+        DatasetItem(id=100, subset='train', image=np.ones((10, 6, 3)),
+            annotations=[
+                Caption('hello', id=1),
+                Caption('world', id=2, group=5),
+                Label(2, id=3, attributes={
+                    'x': 1,
+                    'y': '2',
+                }),
+                Bbox(1, 2, 3, 4, label=4, id=4, z_order=1, attributes={
+                    'score': 1.0,
+                }),
+                Bbox(5, 6, 7, 8, id=5, group=5),
+                Points([1, 2, 2, 0, 1, 1], label=0, id=5, z_order=4),
+                Mask(label=3, id=5, z_order=2, image=np.ones((2, 3))),
+            ]),
+        DatasetItem(id=21, subset='train',
+            annotations=[
+                Caption('test'),
+                Label(2),
+                Bbox(1, 2, 3, 4, 5, id=42, group=42)
+            ]),
 
-                DatasetItem(id=2, subset='val',
-                    annotations=[
-                        PolyLine([1, 2, 3, 4, 5, 6, 7, 8], id=11, z_order=1),
-                        Polygon([1, 2, 3, 4, 5, 6, 7, 8], id=12, z_order=4),
-                    ]),
+        DatasetItem(id=2, subset='val',
+            annotations=[
+                PolyLine([1, 2, 3, 4, 5, 6, 7, 8], id=11, z_order=1),
+                Polygon([1, 2, 3, 4, 5, 6, 7, 8], id=12, z_order=4),
+            ]),
 
-                DatasetItem(id=42, subset='test',
-                    attributes={'a1': 5, 'a2': '42'}),
+        DatasetItem(id=42, subset='test',
+            attributes={'a1': 5, 'a2': '42'}),
 
-                DatasetItem(id=42),
-                DatasetItem(id=43, image=Image(path='1/b/c.qq', size=(2, 4))),
-            ], categories={
-                AnnotationType.label: label_categories,
-                AnnotationType.mask: mask_categories,
-                AnnotationType.points: points_categories,
-            })
+        DatasetItem(id=42),
+        DatasetItem(id=43, image=Image(path='1/b/c.qq', size=(2, 4))),
+    ], categories={
+        AnnotationType.label: label_categories,
+        AnnotationType.mask: mask_categories,
+        AnnotationType.points: points_categories,
+    })
 
     def test_can_save_and_load(self):
         with TestDir() as test_dir:
@@ -95,10 +95,10 @@ class DatumaroConverterTest(TestCase):
 
     def test_relative_paths(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id='1', image=np.ones((4, 2, 3))),
-                    DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3))),
-                    DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3))),
-                ])
+            DatasetItem(id='1', image=np.ones((4, 2, 3))),
+            DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3))),
+            DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3))),
+        ])
 
         with TestDir() as test_dir:
             self._test_save_and_load(expected_dataset,

--- a/datumaro/tests/test_datumaro_format.py
+++ b/datumaro/tests/test_datumaro_format.py
@@ -43,7 +43,7 @@ class DatumaroConverterTest(TestCase):
     for index, _ in enumerate(label_categories.items):
         points_categories.add(index, ['cat1', 'cat2'], joints=[[0, 1]])
 
-    expected_dataset = Dataset.from_iterable([
+    test_dataset = Dataset.from_iterable([
         DatasetItem(id=100, subset='train', image=np.ones((10, 6, 3)),
             annotations=[
                 Caption('hello', id=1),
@@ -85,22 +85,22 @@ class DatumaroConverterTest(TestCase):
 
     def test_can_save_and_load(self):
         with TestDir() as test_dir:
-            self._test_save_and_load(self.expected_dataset,
+            self._test_save_and_load(self.test_dataset,
                 partial(DatumaroConverter.convert, save_images=True), test_dir)
 
     def test_can_detect(self):
         with TestDir() as test_dir:
-            DatumaroConverter.convert(self.TestExtractor(), save_dir=test_dir)
+            DatumaroConverter.convert(self.test_dataset, save_dir=test_dir)
 
             self.assertTrue(DatumaroImporter.detect(test_dir))
 
     def test_relative_paths(self):
-        expected_dataset = Dataset.from_iterable([
+        test_dataset = Dataset.from_iterable([
             DatasetItem(id='1', image=np.ones((4, 2, 3))),
             DatasetItem(id='subdir1/1', image=np.ones((2, 6, 3))),
             DatasetItem(id='subdir2/1', image=np.ones((5, 4, 3))),
         ])
 
         with TestDir() as test_dir:
-            self._test_save_and_load(expected_dataset,
+            self._test_save_and_load(test_dataset,
                 partial(DatumaroConverter.convert, save_images=True), test_dir)

--- a/datumaro/tests/test_labelme_format.py
+++ b/datumaro/tests/test_labelme_format.py
@@ -92,7 +92,7 @@ class LabelMeConverterTest(TestCase):
 
         with TestDir() as test_dir:
             self._test_save_and_load(
-                source_dataset, 
+                source_dataset,
                 partial(LabelMeConverter.convert, save_images=True),
                 test_dir, target_dataset=target_dataset)
 

--- a/datumaro/tests/test_labelme_format.py
+++ b/datumaro/tests/test_labelme_format.py
@@ -29,65 +29,65 @@ class LabelMeConverterTest(TestCase):
 
     def test_can_save_and_load(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(0, 4, 4, 8, label=2, group=2),
-                            Polygon([0, 4, 4, 4, 5, 6], label=3, attributes={
-                                'occluded': True,
-                                'a1': 'qwe',
-                                'a2': True,
-                                'a3': 123,
-                            }),
-                            Mask(np.array([[0, 1], [1, 0], [1, 1]]), group=2,
-                                attributes={ 'username': 'test' }),
-                            Bbox(1, 2, 3, 4, group=3),
-                            Mask(np.array([[0, 0], [0, 0], [1, 1]]), group=3,
-                                attributes={ 'occluded': True }
-                            ),
-                        ]
+            DatasetItem(id=1, subset='train',
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=2, group=2),
+                    Polygon([0, 4, 4, 4, 5, 6], label=3, attributes={
+                        'occluded': True,
+                        'a1': 'qwe',
+                        'a2': True,
+                        'a3': 123,
+                    }),
+                    Mask(np.array([[0, 1], [1, 0], [1, 1]]), group=2,
+                        attributes={ 'username': 'test' }),
+                    Bbox(1, 2, 3, 4, group=3),
+                    Mask(np.array([[0, 0], [0, 0], [1, 1]]), group=3,
+                        attributes={ 'occluded': True }
                     ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(0, 4, 4, 8, label=0, group=2, id=0,
-                                attributes={
-                                    'occluded': False, 'username': '',
-                                }
-                            ),
-                            Polygon([0, 4, 4, 4, 5, 6], label=1, id=1,
-                                attributes={
-                                    'occluded': True, 'username': '',
-                                    'a1': 'qwe',
-                                    'a2': True,
-                                    'a3': 123,
-                                }
-                            ),
-                            Mask(np.array([[0, 1], [1, 0], [1, 1]]), group=2,
-                                id=2, attributes={
-                                    'occluded': False, 'username': 'test'
-                                }
-                            ),
-                            Bbox(1, 2, 3, 4, group=1, id=3, attributes={
-                                'occluded': False, 'username': '',
-                            }),
-                            Mask(np.array([[0, 0], [0, 0], [1, 1]]), group=1,
-                                id=4, attributes={
-                                    'occluded': True, 'username': ''
-                                }
-                            ),
-                        ]
+            DatasetItem(id=1, subset='train',
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=0, group=2, id=0,
+                        attributes={
+                            'occluded': False, 'username': '',
+                        }
                     ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable([
-                        'label_2', 'label_3']),
-                })
+                    Polygon([0, 4, 4, 4, 5, 6], label=1, id=1,
+                        attributes={
+                            'occluded': True, 'username': '',
+                            'a1': 'qwe',
+                            'a2': True,
+                            'a3': 123,
+                        }
+                    ),
+                    Mask(np.array([[0, 1], [1, 0], [1, 1]]), group=2,
+                        id=2, attributes={
+                            'occluded': False, 'username': 'test'
+                        }
+                    ),
+                    Bbox(1, 2, 3, 4, group=1, id=3, attributes={
+                        'occluded': False, 'username': '',
+                    }),
+                    Mask(np.array([[0, 0], [0, 0], [1, 1]]), group=1,
+                        id=4, attributes={
+                            'occluded': True, 'username': ''
+                        }
+                    ),
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable([
+                'label_2', 'label_3']),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
@@ -96,10 +96,10 @@ class LabelMeConverterTest(TestCase):
 
     def test_cant_save_dataset_with_relative_paths(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id='dir/1', image=np.ones((2, 6, 3))),
-                ], categories={
-                    AnnotationType.label: LabelCategories(),
-                })
+            DatasetItem(id='dir/1', image=np.ones((2, 6, 3))),
+        ], categories={
+            AnnotationType.label: LabelCategories(),
+        })
 
         with self.assertRaisesRegex(Exception, r'only supports flat'):
             with TestDir() as test_dir:
@@ -137,67 +137,67 @@ class LabelMeImporterTest(TestCase):
         ]
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id='img1', image=img1,
-                        annotations=[
-                            Polygon([43, 34, 45, 34, 45, 37, 43, 37],
-                                label=0, id=0,
-                                attributes={
-                                    'occluded': False,
-                                    'username': 'admin'
-                                }
-                            ),
-                            Mask(mask1, label=1, id=1,
-                                attributes={
-                                    'occluded': False,
-                                    'username': 'brussell'
-                                }
-                            ),
-                            Polygon([30, 12, 42, 21, 24, 26, 15, 22, 18, 14, 22, 12, 27, 12],
-                                label=2, group=2, id=2,
-                                attributes={
-                                    'a1': True,
-                                    'occluded': True,
-                                    'username': 'anonymous'
-                                }
-                            ),
-                            Polygon([35, 21, 43, 22, 40, 28, 28, 31, 31, 22, 32, 25],
-                                label=3, group=2, id=3,
-                                attributes={
-                                    'kj': True,
-                                    'occluded': False,
-                                    'username': 'anonymous'
-                                }
-                            ),
-                            Bbox(13, 19, 10, 11, label=4, group=2, id=4,
-                                attributes={
-                                    'hg': True,
-                                    'occluded': True,
-                                    'username': 'anonymous'
-                                }
-                            ),
-                            Mask(mask2, label=5, group=1, id=5,
-                                attributes={
-                                    'd': True,
-                                    'occluded': False,
-                                    'username': 'anonymous'
-                                }
-                            ),
-                            Polygon([64, 21, 74, 24, 72, 32, 62, 34, 60, 27, 62, 22],
-                                label=6, group=1, id=6,
-                                attributes={
-                                    'gfd lkj lkj hi': True,
-                                    'occluded': False,
-                                    'username': 'anonymous'
-                                }
-                            ),
-                        ]
+            DatasetItem(id='img1', image=img1,
+                annotations=[
+                    Polygon([43, 34, 45, 34, 45, 37, 43, 37],
+                        label=0, id=0,
+                        attributes={
+                            'occluded': False,
+                            'username': 'admin'
+                        }
                     ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable([
-                        'window', 'license plate', 'o1',
-                        'q1', 'b1', 'm1', 'hg',
-                    ]),
-                })
+                    Mask(mask1, label=1, id=1,
+                        attributes={
+                            'occluded': False,
+                            'username': 'brussell'
+                        }
+                    ),
+                    Polygon([30, 12, 42, 21, 24, 26, 15, 22, 18, 14, 22, 12, 27, 12],
+                        label=2, group=2, id=2,
+                        attributes={
+                            'a1': True,
+                            'occluded': True,
+                            'username': 'anonymous'
+                        }
+                    ),
+                    Polygon([35, 21, 43, 22, 40, 28, 28, 31, 31, 22, 32, 25],
+                        label=3, group=2, id=3,
+                        attributes={
+                            'kj': True,
+                            'occluded': False,
+                            'username': 'anonymous'
+                        }
+                    ),
+                    Bbox(13, 19, 10, 11, label=4, group=2, id=4,
+                        attributes={
+                            'hg': True,
+                            'occluded': True,
+                            'username': 'anonymous'
+                        }
+                    ),
+                    Mask(mask2, label=5, group=1, id=5,
+                        attributes={
+                            'd': True,
+                            'occluded': False,
+                            'username': 'anonymous'
+                        }
+                    ),
+                    Polygon([64, 21, 74, 24, 72, 32, 62, 34, 60, 27, 62, 22],
+                        label=6, group=1, id=6,
+                        attributes={
+                            'gfd lkj lkj hi': True,
+                            'occluded': False,
+                            'username': 'anonymous'
+                        }
+                    ),
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable([
+                'window', 'license plate', 'o1',
+                'q1', 'b1', 'm1', 'hg',
+            ]),
+        })
 
         parsed = Project.import_from(DUMMY_DATASET_DIR, 'label_me') \
             .make_dataset()

--- a/datumaro/tests/test_mot_format.py
+++ b/datumaro/tests/test_mot_format.py
@@ -28,76 +28,76 @@ class MotConverterTest(TestCase):
 
     def test_can_save_bboxes(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(0, 4, 4, 8, label=2, attributes={
-                                'occluded': True,
-                            }),
-                            Bbox(0, 4, 4, 4, label=3, attributes={
-                                'visibility': 0.4,
-                            }),
-                            Bbox(2, 4, 4, 4, attributes={
-                                'ignored': True
-                            }),
-                        ]
-                    ),
+            DatasetItem(id=1, subset='train',
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=2, attributes={
+                        'occluded': True,
+                    }),
+                    Bbox(0, 4, 4, 4, label=3, attributes={
+                        'visibility': 0.4,
+                    }),
+                    Bbox(2, 4, 4, 4, attributes={
+                        'ignored': True
+                    }),
+                ]
+            ),
 
-                    DatasetItem(id=2, subset='val',
-                        image=np.ones((8, 8, 3)),
-                        annotations=[
-                            Bbox(1, 2, 4, 2, label=3),
-                        ]
-                    ),
+            DatasetItem(id=2, subset='val',
+                image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(1, 2, 4, 2, label=3),
+                ]
+            ),
 
-                    DatasetItem(id=3, subset='test',
-                        image=np.ones((5, 4, 3)) * 3,
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+            DatasetItem(id=3, subset='test',
+                image=np.ones((5, 4, 3)) * 3,
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1,
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(0, 4, 4, 8, label=2, attributes={
-                                'occluded': True,
-                                'visibility': 0.0,
-                                'ignored': False,
-                            }),
-                            Bbox(0, 4, 4, 4, label=3, attributes={
-                                'occluded': False,
-                                'visibility': 0.4,
-                                'ignored': False,
-                            }),
-                            Bbox(2, 4, 4, 4, attributes={
-                                'occluded': False,
-                                'visibility': 1.0,
-                                'ignored': True,
-                            }),
-                        ]
-                    ),
+            DatasetItem(id=1,
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=2, attributes={
+                        'occluded': True,
+                        'visibility': 0.0,
+                        'ignored': False,
+                    }),
+                    Bbox(0, 4, 4, 4, label=3, attributes={
+                        'occluded': False,
+                        'visibility': 0.4,
+                        'ignored': False,
+                    }),
+                    Bbox(2, 4, 4, 4, attributes={
+                        'occluded': False,
+                        'visibility': 1.0,
+                        'ignored': True,
+                    }),
+                ]
+            ),
 
-                    DatasetItem(id=2,
-                        image=np.ones((8, 8, 3)),
-                        annotations=[
-                            Bbox(1, 2, 4, 2, label=3, attributes={
-                                'occluded': False,
-                                'visibility': 1.0,
-                                'ignored': False,
-                            }),
-                        ]
-                    ),
+            DatasetItem(id=2,
+                image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(1, 2, 4, 2, label=3, attributes={
+                        'occluded': False,
+                        'visibility': 1.0,
+                        'ignored': False,
+                    }),
+                ]
+            ),
 
-                    DatasetItem(id=3,
-                        image=np.ones((5, 4, 3)) * 3,
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+            DatasetItem(id=3,
+                image=np.ones((5, 4, 3)) * 3,
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
@@ -113,20 +113,20 @@ class MotImporterTest(TestCase):
 
     def test_can_import(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1,
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(0, 4, 4, 8, label=2, attributes={
-                                'occluded': False,
-                                'visibility': 1.0,
-                                'ignored': False,
-                            }),
-                        ]
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+            DatasetItem(id=1,
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=2, attributes={
+                        'occluded': False,
+                        'visibility': 1.0,
+                        'ignored': False,
+                    }),
+                ]
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'mot_seq') \
             .make_dataset()

--- a/datumaro/tests/test_mot_format.py
+++ b/datumaro/tests/test_mot_format.py
@@ -102,7 +102,8 @@ class MotConverterTest(TestCase):
 
         with TestDir() as test_dir:
             self._test_save_and_load(
-                source_dataset, MotSeqGtConverter.convert,
+                source_dataset,
+                partial(MotSeqGtConverter.convert, save_images=True),
                 test_dir, target_dataset=target_dataset)
 
 

--- a/datumaro/tests/test_tfrecord_format.py
+++ b/datumaro/tests/test_tfrecord_format.py
@@ -48,18 +48,18 @@ class TfrecordConverterTest(TestCase):
 
     def test_can_save_bboxes(self):
         test_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(0, 4, 4, 8, label=2),
-                            Bbox(0, 4, 4, 4, label=3),
-                            Bbox(2, 4, 4, 4),
-                        ], attributes={'source_id': ''}
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+            DatasetItem(id=1, subset='train',
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=2),
+                    Bbox(0, 4, 4, 4, label=3),
+                    Bbox(2, 4, 4, 4),
+                ], attributes={'source_id': ''}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
@@ -68,21 +68,21 @@ class TfrecordConverterTest(TestCase):
 
     def test_can_save_masks(self):
         test_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train', image=np.ones((4, 5, 3)),
-                        annotations=[
-                            Mask(image=np.array([
-                                [1, 0, 0, 1],
-                                [0, 1, 1, 0],
-                                [0, 1, 1, 0],
-                                [1, 0, 0, 1],
-                            ]), label=1),
-                        ],
-                        attributes={'source_id': ''}
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+            DatasetItem(id=1, subset='train', image=np.ones((4, 5, 3)),
+                annotations=[
+                    Mask(image=np.array([
+                        [1, 0, 0, 1],
+                        [0, 1, 1, 0],
+                        [0, 1, 1, 0],
+                        [1, 0, 0, 1],
+                    ]), label=1),
+                ],
+                attributes={'source_id': ''}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
@@ -91,31 +91,31 @@ class TfrecordConverterTest(TestCase):
 
     def test_can_save_dataset_with_no_subsets(self):
         test_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1,
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(2, 1, 4, 4, label=2),
-                            Bbox(4, 2, 8, 4, label=3),
-                        ],
-                        attributes={'source_id': ''}
-                    ),
+            DatasetItem(id=1,
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(2, 1, 4, 4, label=2),
+                    Bbox(4, 2, 8, 4, label=3),
+                ],
+                attributes={'source_id': ''}
+            ),
 
-                    DatasetItem(id=2,
-                        image=np.ones((8, 8, 3)) * 2,
-                        annotations=[
-                            Bbox(4, 4, 4, 4, label=3),
-                        ],
-                        attributes={'source_id': ''}
-                    ),
+            DatasetItem(id=2,
+                image=np.ones((8, 8, 3)) * 2,
+                annotations=[
+                    Bbox(4, 4, 4, 4, label=3),
+                ],
+                attributes={'source_id': ''}
+            ),
 
-                    DatasetItem(id=3,
-                        image=np.ones((8, 4, 3)) * 3,
-                        attributes={'source_id': ''}
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+            DatasetItem(id=3,
+                image=np.ones((8, 4, 3)) * 3,
+                attributes={'source_id': ''}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
@@ -124,13 +124,13 @@ class TfrecordConverterTest(TestCase):
 
     def test_can_save_dataset_with_image_info(self):
         test_dataset = Dataset.from_iterable([
-                    DatasetItem(id='1/q.e',
-                        image=Image(path='1/q.e', size=(10, 15)),
-                        attributes={'source_id': ''}
-                    )
-                ], categories={
-                    AnnotationType.label: LabelCategories(),
-                })
+            DatasetItem(id='1/q.e',
+                image=Image(path='1/q.e', size=(10, 15)),
+                attributes={'source_id': ''}
+            )
+        ], categories={
+            AnnotationType.label: LabelCategories(),
+        })
 
         with TestDir() as test_dir:
             self._test_save_and_load(test_dataset,
@@ -173,32 +173,32 @@ class TfrecordImporterTest(TestCase):
 
     def test_can_import(self):
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=np.ones((16, 16, 3)),
-                        annotations=[
-                            Bbox(0, 4, 4, 8, label=2),
-                            Bbox(0, 4, 4, 4, label=3),
-                            Bbox(2, 4, 4, 4),
-                        ],
-                        attributes={'source_id': '1'}
-                    ),
+            DatasetItem(id=1, subset='train',
+                image=np.ones((16, 16, 3)),
+                annotations=[
+                    Bbox(0, 4, 4, 8, label=2),
+                    Bbox(0, 4, 4, 4, label=3),
+                    Bbox(2, 4, 4, 4),
+                ],
+                attributes={'source_id': '1'}
+            ),
 
-                    DatasetItem(id=2, subset='val',
-                        image=np.ones((8, 8, 3)),
-                        annotations=[
-                            Bbox(1, 2, 4, 2, label=3),
-                        ],
-                        attributes={'source_id': '2'}
-                    ),
+            DatasetItem(id=2, subset='val',
+                image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(1, 2, 4, 2, label=3),
+                ],
+                attributes={'source_id': '2'}
+            ),
 
-                    DatasetItem(id=3, subset='test',
-                        image=np.ones((5, 4, 3)) * 3,
-                        attributes={'source_id': '3'}
-                    ),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(label) for label in range(10)),
-                })
+            DatasetItem(id=3, subset='test',
+                image=np.ones((5, 4, 3)) * 3,
+                attributes={'source_id': '3'}
+            ),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(label) for label in range(10)),
+        })
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'tf_detection_api') \
             .make_dataset()

--- a/datumaro/tests/test_tfrecord_format.py
+++ b/datumaro/tests/test_tfrecord_format.py
@@ -2,7 +2,7 @@ import numpy as np
 import os.path as osp
 
 from unittest import TestCase, skipIf
-
+from datumaro.components.project import Dataset
 from datumaro.components.extractor import (Extractor, DatasetItem,
     AnnotationType, Bbox, Mask, LabelCategories
 )
@@ -47,9 +47,7 @@ class TfrecordConverterTest(TestCase):
         compare_datasets(self, expected=target_dataset, actual=parsed_dataset)
 
     def test_can_save_bboxes(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        test_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train',
                         image=np.ones((16, 16, 3)),
                         annotations=[
@@ -58,25 +56,18 @@ class TfrecordConverterTest(TestCase):
                             Bbox(2, 4, 4, 4),
                         ], attributes={'source_id': ''}
                     ),
-                ])
-
-            def categories(self):
-                label_cat = LabelCategories()
-                for label in range(10):
-                    label_cat.add('label_' + str(label))
-                return {
-                    AnnotationType.label: label_cat,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(label) for label in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
-                TestExtractor(), TfDetectionApiConverter(save_images=True),
+                test_dataset, TfDetectionApiConverter(save_images=True),
                 test_dir)
 
     def test_can_save_masks(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        test_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', image=np.ones((4, 5, 3)),
                         annotations=[
                             Mask(image=np.array([
@@ -88,25 +79,18 @@ class TfrecordConverterTest(TestCase):
                         ],
                         attributes={'source_id': ''}
                     ),
-                ])
-
-            def categories(self):
-                label_cat = LabelCategories()
-                for label in range(10):
-                    label_cat.add('label_' + str(label))
-                return {
-                    AnnotationType.label: label_cat,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(label) for label in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
-                TestExtractor(), TfDetectionApiConverter(save_masks=True),
+                test_dataset, TfDetectionApiConverter(save_masks=True),
                 test_dir)
 
     def test_can_save_dataset_with_no_subsets(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        test_dataset = Dataset.from_iterable([
                     DatasetItem(id=1,
                         image=np.ones((16, 16, 3)),
                         annotations=[
@@ -128,36 +112,28 @@ class TfrecordConverterTest(TestCase):
                         image=np.ones((8, 4, 3)) * 3,
                         attributes={'source_id': ''}
                     ),
-                ])
-
-            def categories(self):
-                label_cat = LabelCategories()
-                for label in range(10):
-                    label_cat.add('label_' + str(label))
-                return {
-                    AnnotationType.label: label_cat,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(label) for label in range(10)),
+                })
 
         with TestDir() as test_dir:
             self._test_save_and_load(
-                TestExtractor(), TfDetectionApiConverter(save_images=True),
+                test_dataset, TfDetectionApiConverter(save_images=True),
                 test_dir)
 
     def test_can_save_dataset_with_image_info(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        test_dataset = Dataset.from_iterable([
                     DatasetItem(id='1/q.e',
                         image=Image(path='1/q.e', size=(10, 15)),
                         attributes={'source_id': ''}
                     )
-                ])
-
-            def categories(self):
-                return { AnnotationType.label: LabelCategories() }
+                ], categories={
+                    AnnotationType.label: LabelCategories(),
+                })
 
         with TestDir() as test_dir:
-            self._test_save_and_load(TestExtractor(),
+            self._test_save_and_load(test_dataset,
                 TfDetectionApiConverter(), test_dir)
 
     def test_labelmap_parsing(self):
@@ -196,9 +172,7 @@ class TfrecordImporterTest(TestCase):
         self.assertTrue(TfDetectionApiImporter.detect(DUMMY_DATASET_DIR))
 
     def test_can_import(self):
-        class DstExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        target_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train',
                         image=np.ones((16, 16, 3)),
                         annotations=[
@@ -221,17 +195,12 @@ class TfrecordImporterTest(TestCase):
                         image=np.ones((5, 4, 3)) * 3,
                         attributes={'source_id': '3'}
                     ),
-                ])
-
-            def categories(self):
-                label_cat = LabelCategories()
-                for label in range(10):
-                    label_cat.add('label_' + str(label))
-                return {
-                    AnnotationType.label: label_cat,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(label) for label in range(10)),
+                })
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'tf_detection_api') \
             .make_dataset()
 
-        compare_datasets(self, DstExtractor(), dataset)
+        compare_datasets(self, target_dataset, dataset)

--- a/datumaro/tests/test_transforms.py
+++ b/datumaro/tests/test_transforms.py
@@ -68,17 +68,17 @@ class TransformsTest(TestCase):
 
     def test_mask_to_polygons_small_polygons_message(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 10, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 0],
-                                    [0, 1, 0],
-                                    [0, 0, 0],
-                                ]),
-                            ),
-                        ]
+            DatasetItem(id=1, image=np.zeros((5, 10, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 0],
+                            [0, 1, 0],
+                            [0, 0, 0],
+                        ]),
                     ),
-                ])
+                ]
+            ),
+        ])
 
         target_dataset = Dataset.from_iterable([
             DatasetItem(id=1, image=np.zeros((5, 10, 3))), ])
@@ -91,121 +91,121 @@ class TransformsTest(TestCase):
 
     def test_polygons_to_masks(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 10, 3)),
-                        annotations=[
-                            Polygon([0, 0, 4, 0, 4, 4]),
-                            Polygon([5, 0, 9, 0, 5, 5]),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 10, 3)),
+                annotations=[
+                    Polygon([0, 0, 4, 0, 4, 4]),
+                    Polygon([5, 0, 9, 0, 5, 5]),
+                ]
+            ),
+        ])
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 10, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
-                                    [0, 0, 0, 0, 0, 1, 1, 1, 0, 0],
-                                    [0, 0, 0, 0, 0, 1, 1, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                ]),
-                            ),
-                            Mask(np.array([
-                                    [0, 1, 1, 1, 0, 0, 0, 0, 0, 0],
-                                    [0, 0, 1, 1, 0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
-                                ]),
-                            ),
-                        ]
+            DatasetItem(id=1, image=np.zeros((5, 10, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 0, 0, 0, 1, 1, 1, 1, 0],
+                            [0, 0, 0, 0, 0, 1, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 1, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        ]),
                     ),
-                ])
+                    Mask(np.array([
+                            [0, 1, 1, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 1, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 1, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0],
+                        ]),
+                    ),
+                ]
+            ),
+        ])
 
         actual = transforms.PolygonsToMasks(source_dataset)
         compare_datasets(self, target_dataset, actual)
 
     def test_crop_covered_segments(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            # The mask is partially covered by the polygon
-                            Mask(np.array([
-                                    [0, 0, 1, 1, 1],
-                                    [0, 0, 1, 1, 1],
-                                    [1, 1, 1, 1, 1],
-                                    [1, 1, 1, 0, 0],
-                                    [1, 1, 1, 0, 0]],
-                                ),
-                                z_order=0),
-                            Polygon([1, 1, 4, 1, 4, 4, 1, 4],
-                                z_order=1),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    # The mask is partially covered by the polygon
+                    Mask(np.array([
+                            [0, 0, 1, 1, 1],
+                            [0, 0, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 0, 0],
+                            [1, 1, 1, 0, 0]],
+                        ),
+                        z_order=0),
+                    Polygon([1, 1, 4, 1, 4, 4, 1, 4],
+                        z_order=1),
+                ]
+            ),
+        ])
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 1, 1, 1],
-                                    [0, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 0],
-                                    [1, 1, 1, 0, 0]],
-                                ),
-                                z_order=0),
-                            Polygon([1, 1, 4, 1, 4, 4, 1, 4],
-                                z_order=1),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 1, 1, 1],
+                            [0, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 0],
+                            [1, 1, 1, 0, 0]],
+                        ),
+                        z_order=0),
+                    Polygon([1, 1, 4, 1, 4, 4, 1, 4],
+                        z_order=1),
+                ]
+            ),
+        ])
 
         actual = transforms.CropCoveredSegments(source_dataset)
         compare_datasets(self, target_dataset, actual)
 
     def test_merge_instance_segments(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 1, 1, 1],
-                                    [0, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 0],
-                                    [1, 1, 1, 0, 0]],
-                                ),
-                                z_order=0, group=1),
-                            Polygon([1, 1, 4, 1, 4, 4, 1, 4],
-                                z_order=1, group=1),
-                            Polygon([0, 0, 0, 2, 2, 2, 2, 0],
-                                z_order=1),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 1, 1, 1],
+                            [0, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 0],
+                            [1, 1, 1, 0, 0]],
+                        ),
+                        z_order=0, group=1),
+                    Polygon([1, 1, 4, 1, 4, 4, 1, 4],
+                        z_order=1, group=1),
+                    Polygon([0, 0, 0, 2, 2, 2, 2, 0],
+                        z_order=1),
+                ]
+            ),
+        ])
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 1, 1, 1],
-                                    [0, 1, 1, 1, 1],
-                                    [1, 1, 1, 1, 1],
-                                    [1, 1, 1, 1, 0],
-                                    [1, 1, 1, 0, 0]],
-                                ),
-                                z_order=0, group=1),
-                            Mask(np.array([
-                                    [1, 1, 0, 0, 0],
-                                    [1, 1, 0, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0]],
-                                ),
-                                z_order=1),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 1, 1, 1],
+                            [0, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 1],
+                            [1, 1, 1, 1, 0],
+                            [1, 1, 1, 0, 0]],
+                        ),
+                        z_order=0, group=1),
+                    Mask(np.array([
+                            [1, 1, 0, 0, 0],
+                            [1, 1, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0]],
+                        ),
+                        z_order=1),
+                ]
+            ),
+        ])
 
         actual = transforms.MergeInstanceSegments(source_dataset,
             include_polygons=True)
@@ -213,16 +213,16 @@ class TransformsTest(TestCase):
 
     def test_map_subsets(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='a'),
-                    DatasetItem(id=2, subset='b'),
-                    DatasetItem(id=3, subset='c'),
-                ])
+            DatasetItem(id=1, subset='a'),
+            DatasetItem(id=2, subset='b'),
+            DatasetItem(id=3, subset='c'),
+        ])
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset=''),
-                    DatasetItem(id=2, subset='a'),
-                    DatasetItem(id=3, subset='c'),
-                ])
+            DatasetItem(id=1, subset=''),
+            DatasetItem(id=2, subset='a'),
+            DatasetItem(id=3, subset='c'),
+        ])
 
         actual = transforms.MapSubsets(source_dataset,
             { 'a': '', 'b': 'a' })
@@ -230,104 +230,104 @@ class TransformsTest(TestCase):
 
     def test_shapes_to_boxes(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [0, 0, 1, 1, 1],
-                                    [0, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 1],
-                                    [1, 0, 0, 0, 0],
-                                    [1, 1, 1, 0, 0]],
-                                ), id=1),
-                            Polygon([1, 1, 4, 1, 4, 4, 1, 4], id=2),
-                            PolyLine([1, 1, 2, 1, 2, 2, 1, 2], id=3),
-                            Points([2, 2, 4, 2, 4, 4, 2, 4], id=4),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [0, 0, 1, 1, 1],
+                            [0, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 1],
+                            [1, 0, 0, 0, 0],
+                            [1, 1, 1, 0, 0]],
+                        ), id=1),
+                    Polygon([1, 1, 4, 1, 4, 4, 1, 4], id=2),
+                    PolyLine([1, 1, 2, 1, 2, 2, 1, 2], id=3),
+                    Points([2, 2, 4, 2, 4, 4, 2, 4], id=4),
+                ]
+            ),
+        ])
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Bbox(0, 0, 4, 4, id=1),
-                            Bbox(1, 1, 3, 3, id=2),
-                            Bbox(1, 1, 1, 1, id=3),
-                            Bbox(2, 2, 2, 2, id=4),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Bbox(0, 0, 4, 4, id=1),
+                    Bbox(1, 1, 3, 3, id=2),
+                    Bbox(1, 1, 1, 1, id=3),
+                    Bbox(2, 2, 2, 2, id=4),
+                ]
+            ),
+        ])
 
         actual = transforms.ShapesToBoxes(source_dataset)
         compare_datasets(self, target_dataset, actual)
 
     def test_id_from_image(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image='path.jpg'),
-                    DatasetItem(id=2),
-                ])
+            DatasetItem(id=1, image='path.jpg'),
+            DatasetItem(id=2),
+        ])
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id='path', image='path.jpg'),
-                    DatasetItem(id=2),
-                ])
+            DatasetItem(id='path', image='path.jpg'),
+            DatasetItem(id=2),
+        ])
 
         actual = transforms.IdFromImageName(source_dataset)
         compare_datasets(self, target_dataset, actual)
 
     def test_boxes_to_masks(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Bbox(0, 0, 3, 3, z_order=1),
-                            Bbox(0, 0, 3, 1, z_order=2),
-                            Bbox(0, 2, 3, 1, z_order=3),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Bbox(0, 0, 3, 3, z_order=1),
+                    Bbox(0, 0, 3, 1, z_order=2),
+                    Bbox(0, 2, 3, 1, z_order=3),
+                ]
+            ),
+        ])
 
         target_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, image=np.zeros((5, 5, 3)),
-                        annotations=[
-                            Mask(np.array([
-                                    [1, 1, 1, 0, 0],
-                                    [1, 1, 1, 0, 0],
-                                    [1, 1, 1, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0]],
-                                ),
-                                z_order=1),
-                            Mask(np.array([
-                                    [1, 1, 1, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0]],
-                                ),
-                                z_order=2),
-                            Mask(np.array([
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [1, 1, 1, 0, 0],
-                                    [0, 0, 0, 0, 0],
-                                    [0, 0, 0, 0, 0]],
-                                ),
-                                z_order=3),
-                        ]
-                    ),
-                ])
+            DatasetItem(id=1, image=np.zeros((5, 5, 3)),
+                annotations=[
+                    Mask(np.array([
+                            [1, 1, 1, 0, 0],
+                            [1, 1, 1, 0, 0],
+                            [1, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0]],
+                        ),
+                        z_order=1),
+                    Mask(np.array([
+                            [1, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0]],
+                        ),
+                        z_order=2),
+                    Mask(np.array([
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [1, 1, 1, 0, 0],
+                            [0, 0, 0, 0, 0],
+                            [0, 0, 0, 0, 0]],
+                        ),
+                        z_order=3),
+                ]
+            ),
+        ])
 
         actual = transforms.BoxesToMasks(source_dataset)
         compare_datasets(self, target_dataset, actual)
 
     def test_random_split(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset="a"),
-                    DatasetItem(id=2, subset="a"),
-                    DatasetItem(id=3, subset="b"),
-                    DatasetItem(id=4, subset="b"),
-                    DatasetItem(id=5, subset="b"),
-                    DatasetItem(id=6, subset=""),
-                    DatasetItem(id=7, subset=""),
-                ])
+            DatasetItem(id=1, subset="a"),
+            DatasetItem(id=2, subset="a"),
+            DatasetItem(id=3, subset="b"),
+            DatasetItem(id=4, subset="b"),
+            DatasetItem(id=5, subset="b"),
+            DatasetItem(id=6, subset=""),
+            DatasetItem(id=7, subset=""),
+        ])
 
         actual = transforms.RandomSplit(source_dataset, splits=[
             ('train', 4.0 / 7.0),

--- a/datumaro/tests/test_transforms.py
+++ b/datumaro/tests/test_transforms.py
@@ -14,22 +14,29 @@ from datumaro.util.test_utils import compare_datasets
 
 class TransformsTest(TestCase):
     def test_reindex(self):
-        source_dataset = Dataset.from_iterable([
+        class SrcExtractor(Extractor):
+            def __iter__(self):
+                return iter([
                     DatasetItem(id=10),
                     DatasetItem(id=10, subset='train'),
                     DatasetItem(id='a', subset='val'),
                 ])
-        target_dataset = Dataset.from_iterable([
+
+        class DstExtractor(Extractor):
+            def __iter__(self):
+                return iter([
                     DatasetItem(id=5),
                     DatasetItem(id=6, subset='train'),
                     DatasetItem(id=7, subset='val'),
                 ])
 
-        actual = transforms.Reindex(source_dataset, start=5)
-        compare_datasets(self, target_dataset, actual)
+        actual = transforms.Reindex(SrcExtractor(), start=5)
+        compare_datasets(self, DstExtractor(), actual)
 
     def test_mask_to_polygons(self):
-        source_dataset = Dataset.from_iterable([
+        class SrcExtractor(Extractor):
+            def __iter__(self):
+                items = [
                     DatasetItem(id=1, image=np.zeros((5, 10, 3)),
                         annotations=[
                             Mask(np.array([
@@ -42,9 +49,12 @@ class TransformsTest(TestCase):
                             ),
                         ]
                     ),
-                ])
+                ]
+                return iter(items)
 
-        target_dataset = Dataset.from_iterable([
+        class DstExtractor(Extractor):
+            def __iter__(self):
+                return iter([
                     DatasetItem(id=1, image=np.zeros((5, 10, 3)),
                         annotations=[
                             Polygon([3.0, 2.5, 1.0, 0.0, 3.5, 0.0, 3.0, 2.5]),
@@ -53,8 +63,8 @@ class TransformsTest(TestCase):
                     ),
                 ])
 
-        actual = transforms.MasksToPolygons(source_dataset)
-        compare_datasets(self, target_dataset, actual)
+        actual = transforms.MasksToPolygons(SrcExtractor())
+        compare_datasets(self, DstExtractor(), actual)
 
     def test_mask_to_polygons_small_polygons_message(self):
         source_dataset = Dataset.from_iterable([
@@ -346,7 +356,7 @@ class TransformsTest(TestCase):
             ])
 
     def test_remap_labels(self):
-        #todo: why this test brokes when I rewrite it on Dataset ?
+        #! why this test brokes when I rewrite it on Dataset ?
         class SrcExtractor(Extractor):
             def __iter__(self):
                 return iter([

--- a/datumaro/tests/test_transforms.py
+++ b/datumaro/tests/test_transforms.py
@@ -356,7 +356,6 @@ class TransformsTest(TestCase):
             ])
 
     def test_remap_labels(self):
-        #! why this test brokes when I rewrite it on Dataset ?
         class SrcExtractor(Extractor):
             def __iter__(self):
                 return iter([

--- a/datumaro/tests/test_yolo_format.py
+++ b/datumaro/tests/test_yolo_format.py
@@ -16,29 +16,29 @@ from datumaro.util.test_utils import TestDir, compare_datasets
 class YoloFormatTest(TestCase):
     def test_can_save_and_load(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train', image=np.ones((8, 8, 3)),
-                        annotations=[
-                            Bbox(0, 2, 4, 2, label=2),
-                            Bbox(0, 1, 2, 3, label=4),
-                        ]),
-                    DatasetItem(id=2, subset='train', image=np.ones((10, 10, 3)),
-                        annotations=[
-                            Bbox(0, 2, 4, 2, label=2),
-                            Bbox(3, 3, 2, 3, label=4),
-                            Bbox(2, 1, 2, 3, label=4),
-                        ]),
+            DatasetItem(id=1, subset='train', image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=2),
+                    Bbox(0, 1, 2, 3, label=4),
+                ]),
+            DatasetItem(id=2, subset='train', image=np.ones((10, 10, 3)),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=2),
+                    Bbox(3, 3, 2, 3, label=4),
+                    Bbox(2, 1, 2, 3, label=4),
+                ]),
 
-                    DatasetItem(id=3, subset='valid', image=np.ones((8, 8, 3)),
-                        annotations=[
-                            Bbox(0, 1, 5, 2, label=2),
-                            Bbox(0, 2, 3, 2, label=5),
-                            Bbox(0, 2, 4, 2, label=6),
-                            Bbox(0, 7, 3, 2, label=7),
-                        ]),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(i) for i in range(10)),
-                })
+            DatasetItem(id=3, subset='valid', image=np.ones((8, 8, 3)),
+                annotations=[
+                    Bbox(0, 1, 5, 2, label=2),
+                    Bbox(0, 2, 3, 2, label=5),
+                    Bbox(0, 2, 4, 2, label=6),
+                    Bbox(0, 7, 3, 2, label=7),
+                ]),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
 
@@ -49,16 +49,16 @@ class YoloFormatTest(TestCase):
 
     def test_can_save_dataset_with_image_info(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=Image(path='1.jpg', size=(10, 15)),
-                        annotations=[
-                            Bbox(0, 2, 4, 2, label=2),
-                            Bbox(3, 3, 2, 3, label=4),
-                        ]),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, subset='train',
+                image=Image(path='1.jpg', size=(10, 15)),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=2),
+                    Bbox(3, 3, 2, 3, label=4),
+                ]),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
 
@@ -72,16 +72,16 @@ class YoloFormatTest(TestCase):
 
     def test_can_load_dataset_with_exact_image_info(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=Image(path='1.jpg', size=(10, 15)),
-                        annotations=[
-                            Bbox(0, 2, 4, 2, label=2),
-                            Bbox(3, 3, 2, 3, label=4),
-                        ]),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, subset='train',
+                image=Image(path='1.jpg', size=(10, 15)),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=2),
+                    Bbox(3, 3, 2, 3, label=4),
+                ]),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(i) for i in range(10)),
+        })
 
         with TestDir() as test_dir:
 
@@ -94,15 +94,15 @@ class YoloFormatTest(TestCase):
 
     def test_relative_paths(self):
         source_dataset = Dataset.from_iterable([
-                    DatasetItem(id='1', subset='train',
-                        image=np.ones((4, 2, 3))),
-                    DatasetItem(id='subdir1/1', subset='train',
-                        image=np.ones((2, 6, 3))),
-                    DatasetItem(id='subdir2/1', subset='train',
-                        image=np.ones((5, 4, 3))),
-                ], categories={
-                    AnnotationType.label: LabelCategories(),
-                })
+            DatasetItem(id='1', subset='train',
+                image=np.ones((4, 2, 3))),
+            DatasetItem(id='subdir1/1', subset='train',
+                image=np.ones((2, 6, 3))),
+            DatasetItem(id='subdir2/1', subset='train',
+                image=np.ones((5, 4, 3))),
+        ], categories={
+            AnnotationType.label: LabelCategories(),
+        })
 
         for save_images in {True, False}:
             with self.subTest(save_images=save_images):
@@ -123,16 +123,16 @@ class YoloImporterTest(TestCase):
 
     def test_can_import(self):
         expected_dataset = Dataset.from_iterable([
-                    DatasetItem(id=1, subset='train',
-                        image=np.ones((10, 15, 3)),
-                        annotations=[
-                            Bbox(0, 2, 4, 2, label=2),
-                            Bbox(3, 3, 2, 3, label=4),
-                        ]),
-                ], categories={
-                    AnnotationType.label: LabelCategories.from_iterable(
-                        'label_' + str(i) for i in range(10)),
-                })
+            DatasetItem(id=1, subset='train',
+                image=np.ones((10, 15, 3)),
+                annotations=[
+                    Bbox(0, 2, 4, 2, label=2),
+                    Bbox(3, 3, 2, 3, label=4),
+                ]),
+        ], categories={
+            AnnotationType.label: LabelCategories.from_iterable(
+                'label_' + str(i) for i in range(10)),
+        })
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'yolo') \
             .make_dataset()

--- a/datumaro/tests/test_yolo_format.py
+++ b/datumaro/tests/test_yolo_format.py
@@ -6,7 +6,7 @@ from unittest import TestCase
 from datumaro.components.extractor import (Extractor, DatasetItem,
     AnnotationType, Bbox, LabelCategories,
 )
-from datumaro.components.project import Project
+from datumaro.components.project import Project, Dataset
 from datumaro.plugins.yolo_format.importer import YoloImporter
 from datumaro.plugins.yolo_format.converter import YoloConverter
 from datumaro.util.image import Image, save_image
@@ -15,9 +15,7 @@ from datumaro.util.test_utils import TestDir, compare_datasets
 
 class YoloFormatTest(TestCase):
     def test_can_save_and_load(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train', image=np.ones((8, 8, 3)),
                         annotations=[
                             Bbox(0, 2, 4, 2, label=2),
@@ -37,18 +35,12 @@ class YoloFormatTest(TestCase):
                             Bbox(0, 2, 4, 2, label=6),
                             Bbox(0, 7, 3, 2, label=7),
                         ]),
-                ])
-
-            def categories(self):
-                label_categories = LabelCategories()
-                for i in range(10):
-                    label_categories.add('label_' + str(i))
-                return {
-                    AnnotationType.label: label_categories,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
-            source_dataset = TestExtractor()
 
             YoloConverter(save_images=True)(source_dataset, test_dir)
             parsed_dataset = YoloImporter()(test_dir).make_dataset()
@@ -56,27 +48,19 @@ class YoloFormatTest(TestCase):
             compare_datasets(self, source_dataset, parsed_dataset)
 
     def test_can_save_dataset_with_image_info(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train',
                         image=Image(path='1.jpg', size=(10, 15)),
                         annotations=[
                             Bbox(0, 2, 4, 2, label=2),
                             Bbox(3, 3, 2, 3, label=4),
                         ]),
-                ])
-
-            def categories(self):
-                label_categories = LabelCategories()
-                for i in range(10):
-                    label_categories.add('label_' + str(i))
-                return {
-                    AnnotationType.label: label_categories,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
-            source_dataset = TestExtractor()
 
             YoloConverter()(source_dataset, test_dir)
 
@@ -87,27 +71,19 @@ class YoloFormatTest(TestCase):
             compare_datasets(self, source_dataset, parsed_dataset)
 
     def test_can_load_dataset_with_exact_image_info(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train',
                         image=Image(path='1.jpg', size=(10, 15)),
                         annotations=[
                             Bbox(0, 2, 4, 2, label=2),
                             Bbox(3, 3, 2, 3, label=4),
                         ]),
-                ])
-
-            def categories(self):
-                label_categories = LabelCategories()
-                for i in range(10):
-                    label_categories.add('label_' + str(i))
-                return {
-                    AnnotationType.label: label_categories,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(i) for i in range(10)),
+                })
 
         with TestDir() as test_dir:
-            source_dataset = TestExtractor()
 
             YoloConverter()(source_dataset, test_dir)
 
@@ -117,24 +93,20 @@ class YoloFormatTest(TestCase):
             compare_datasets(self, source_dataset, parsed_dataset)
 
     def test_relative_paths(self):
-        class TestExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        source_dataset = Dataset.from_iterable([
                     DatasetItem(id='1', subset='train',
                         image=np.ones((4, 2, 3))),
                     DatasetItem(id='subdir1/1', subset='train',
                         image=np.ones((2, 6, 3))),
                     DatasetItem(id='subdir2/1', subset='train',
                         image=np.ones((5, 4, 3))),
-                ])
-
-            def categories(self):
-                return { AnnotationType.label: LabelCategories() }
+                ], categories={
+                    AnnotationType.label: LabelCategories(),
+                })
 
         for save_images in {True, False}:
             with self.subTest(save_images=save_images):
                 with TestDir() as test_dir:
-                    source_dataset = TestExtractor()
 
                     YoloConverter(save_images=save_images)(
                         source_dataset, test_dir)
@@ -150,26 +122,19 @@ class YoloImporterTest(TestCase):
         self.assertTrue(YoloImporter.detect(DUMMY_DATASET_DIR))
 
     def test_can_import(self):
-        class DstExtractor(Extractor):
-            def __iter__(self):
-                return iter([
+        expected_dataset = Dataset.from_iterable([
                     DatasetItem(id=1, subset='train',
                         image=np.ones((10, 15, 3)),
                         annotations=[
                             Bbox(0, 2, 4, 2, label=2),
                             Bbox(3, 3, 2, 3, label=4),
                         ]),
-                ])
-
-            def categories(self):
-                label_categories = LabelCategories()
-                for i in range(10):
-                    label_categories.add('label_' + str(i))
-                return {
-                    AnnotationType.label: label_categories,
-                }
+                ], categories={
+                    AnnotationType.label: LabelCategories.from_iterable(
+                        'label_' + str(i) for i in range(10)),
+                })
 
         dataset = Project.import_from(DUMMY_DATASET_DIR, 'yolo') \
             .make_dataset()
 
-        compare_datasets(self, DstExtractor(), dataset)
+        compare_datasets(self, expected_dataset, dataset)


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Tests are complex.  It's necessary to reduce nesting. 
To achieve this goal was implemented Dataset.from_iterable(), labelCategories.from_iterable() 
and PointsCategories.from_iterable(). The format tests was simplified.

### How has this been tested?
It was tested using unittests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
