### PR TITLE
Fix interpolation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Annotations aren't updated after reopening a task (<https://github.com/opencv/cvat/pull/1753>)
 - Labels aren't updated after reopening a task (<https://github.com/opencv/cvat/pull/1753>)
 - Canvas isn't fitted after collapsing side panel in attribute annotation mode (<https://github.com/opencv/cvat/pull/1753>)
+- Error when interpolating polygons (<https://github.com/opencv/cvat/pull/1878>)
 
 ### Security
 - SQL injection in Django `CVE-2020-9402` (<https://github.com/opencv/cvat/pull/1657>)

--- a/cvat/apps/dataset_manager/annotation.py
+++ b/cvat/apps/dataset_manager/annotation.py
@@ -442,11 +442,11 @@ class TrackManager(ObjectManager):
 
     @staticmethod
     def get_interpolated_shapes(track, start_frame, end_frame):
-        def copy_shape(source, frame, points = None):
+        def copy_shape(source, frame, points=None):
             copied = deepcopy(source)
             copied["keyframe"] = True
             copied["frame"] = frame
-            if points:
+            if points is not None:
                 copied["points"] = points
             return copied
 

--- a/cvat/apps/dataset_manager/tests/test_annotation.py
+++ b/cvat/apps/dataset_manager/tests/test_annotation.py
@@ -8,7 +8,7 @@ from unittest import TestCase
 
 
 class TrackManagerTest(TestCase):
-    def test_single_point_interpolation(self):
+    def test_point_interpolation(self):
         track = {
             "frame": 0,
             "label_id": 0,
@@ -28,6 +28,96 @@ class TrackManagerTest(TestCase):
                     "attributes": [],
                     "points": [3.0, 4.0, 5.0, 6.0],
                     "type": "points",
+                    "occluded": False,
+                    "outside": True
+                },
+            ]
+        }
+
+        interpolated = TrackManager.get_interpolated_shapes(track, 0, 2)
+
+        self.assertEqual(len(interpolated), 3)
+
+    def test_polygon_interpolation(self):
+        track = {
+            "frame": 0,
+            "label_id": 0,
+            "group": None,
+            "attributes": [],
+            "shapes": [
+                {
+                    "frame": 0,
+                    "points": [1.0, 2.0, 3.0, 4.0, 5.0, 2.0],
+                    "type": "polygon",
+                    "occluded": False,
+                    "outside": False,
+                    "attributes": []
+                },
+                {
+                    "frame": 2,
+                    "attributes": [],
+                    "points": [3.0, 4.0, 5.0, 6.0, 7.0, 6.0, 4.0, 5.0],
+                    "type": "polygon",
+                    "occluded": False,
+                    "outside": True
+                },
+            ]
+        }
+
+        interpolated = TrackManager.get_interpolated_shapes(track, 0, 2)
+
+        self.assertEqual(len(interpolated), 3)
+
+    def test_bbox_interpolation(self):
+        track = {
+            "frame": 0,
+            "label_id": 0,
+            "group": None,
+            "attributes": [],
+            "shapes": [
+                {
+                    "frame": 0,
+                    "points": [1.0, 2.0, 3.0, 4.0],
+                    "type": "rectangle",
+                    "occluded": False,
+                    "outside": False,
+                    "attributes": []
+                },
+                {
+                    "frame": 2,
+                    "attributes": [],
+                    "points": [3.0, 4.0, 5.0, 6.0],
+                    "type": "rectangle",
+                    "occluded": False,
+                    "outside": True
+                },
+            ]
+        }
+
+        interpolated = TrackManager.get_interpolated_shapes(track, 0, 2)
+
+        self.assertEqual(len(interpolated), 3)
+
+    def test_line_interpolation(self):
+        track = {
+            "frame": 0,
+            "label_id": 0,
+            "group": None,
+            "attributes": [],
+            "shapes": [
+                {
+                    "frame": 0,
+                    "points": [1.0, 2.0, 3.0, 4.0, 5.0, 6.0],
+                    "type": "polyline",
+                    "occluded": False,
+                    "outside": False,
+                    "attributes": []
+                },
+                {
+                    "frame": 2,
+                    "attributes": [],
+                    "points": [3.0, 4.0, 5.0, 6.0],
+                    "type": "polyline",
                     "occluded": False,
                     "outside": True
                 },


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Fixes #1869

Adds simple interpolation tests.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Unit tests

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
