### PR TITLE
Add image sha256 to tfrecord

### DIFF
--- a/datumaro/datumaro/plugins/tf_detection_api_format/converter.py
+++ b/datumaro/datumaro/plugins/tf_detection_api_format/converter.py
@@ -5,6 +5,7 @@
 
 import codecs
 from collections import OrderedDict
+import hashlib
 import logging as log
 import os
 import os.path as osp
@@ -180,15 +181,18 @@ class TfDetectionApiConverter(Converter):
 
         features.update({
             'image/encoded': bytes_feature(b''),
-            'image/format': bytes_feature(b'')
+            'image/format': bytes_feature(b''),
+            'image/key/sha256': bytes_feature(b''),
         })
         if self._save_images:
             if item.has_image and item.image.has_data:
                 buffer, fmt = self._save_image(item, filename)
+                key = hashlib.sha256(buffer).hexdigest()
 
                 features.update({
                     'image/encoded': bytes_feature(buffer),
                     'image/format': bytes_feature(fmt.encode('utf-8')),
+                    'image/key/sha256': bytes_feature(key.encode('utf8')),
                 })
             else:
                 log.warning("Item '%s' has no image" % item.id)

--- a/datumaro/datumaro/plugins/tf_detection_api_format/extractor.py
+++ b/datumaro/datumaro/plugins/tf_detection_api_format/extractor.py
@@ -85,6 +85,10 @@ class TfDetectionApiExtractor(SourceExtractor):
             'image/width': tf.io.FixedLenFeature([], tf.int64),
             'image/encoded': tf.io.FixedLenFeature([], tf.string),
             'image/format': tf.io.FixedLenFeature([], tf.string),
+
+            # use varlen to avoid errors when this field is missing
+            'image/key/sha256': tf.io.VarLenFeature(tf.string),
+
             # Object boxes and classes.
             'image/object/bbox/xmin': tf.io.VarLenFeature(tf.float32),
             'image/object/bbox/xmax': tf.io.VarLenFeature(tf.float32),


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Closes #1829. It [looks](https://github.com/tensorflow/models/blob/master/research/object_detection/data_decoders/tf_example_decoder.py#L225) like this field is not mandatory.

Added `image/sha256` field to tfrecords.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Manual test

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
