### PR TITLE
stop dextr plugin support check from crashing app

### DIFF
--- a/cvat-ui/src/actions/plugins-actions.ts
+++ b/cvat-ui/src/actions/plugins-actions.ts
@@ -39,17 +39,34 @@ export function checkPluginsAsync(): ThunkAction {
             DEXTR_SEGMENTATION: false,
         };
 
-        const promises: Promise<boolean>[] = [
-            PluginChecker.check(SupportedPlugins.ANALYTICS),
-            PluginChecker.check(SupportedPlugins.GIT_INTEGRATION),
-            PluginChecker.check(SupportedPlugins.DEXTR_SEGMENTATION),
-        ];
-
         try {
+            let pluginCheckError: any = null;
+
+            const promises: Promise<boolean>[] = [
+                PluginChecker.check(SupportedPlugins.ANALYTICS).catch((err) => {
+                    pluginCheckError = err;
+                    return false;
+                }),
+                PluginChecker.check(SupportedPlugins.GIT_INTEGRATION).catch(
+                    (err) => {
+                        pluginCheckError = err;
+                        return false;
+                    },
+                ),
+                PluginChecker.check(SupportedPlugins.DEXTR_SEGMENTATION).catch(
+                    (err) => {
+                        pluginCheckError = err;
+                        return false;
+                    },
+                ),
+            ];
+
             const values = await Promise.all(promises);
             [plugins.ANALYTICS, plugins.GIT_INTEGRATION,
                 plugins.DEXTR_SEGMENTATION] = values;
             dispatch(pluginActions.checkedAllPlugins(plugins));
+
+            if (pluginCheckError instanceof Error) throw pluginCheckError;
         } catch (error) {
             dispatch(pluginActions.raisePluginCheckError(error));
         }

--- a/cvat-ui/src/utils/plugin-checker.ts
+++ b/cvat-ui/src/utils/plugin-checker.ts
@@ -27,12 +27,8 @@ class PluginChecker {
                 return isReachable(`${serverHost}/git/repository/meta/get`, 'OPTIONS');
             }
             case SupportedPlugins.DEXTR_SEGMENTATION: {
-                try {
-                    const list = await core.lambda.list();
-                    return list.map((func: any): boolean => func.id).includes('openvino.dextr');
-                } catch (err) {
-                    return false;
-                }
+                const list = await core.lambda.list();
+                return list.map((func: any): boolean => func.id).includes('openvino.dextr');
             }
             case SupportedPlugins.ANALYTICS: {
                 return isReachable(`${serverHost}/analytics/app/kibana`, 'GET');

--- a/cvat-ui/src/utils/plugin-checker.ts
+++ b/cvat-ui/src/utils/plugin-checker.ts
@@ -27,8 +27,12 @@ class PluginChecker {
                 return isReachable(`${serverHost}/git/repository/meta/get`, 'OPTIONS');
             }
             case SupportedPlugins.DEXTR_SEGMENTATION: {
-                const list = await core.lambda.list();
-                return list.map((func: any): boolean => func.id).includes('openvino.dextr');
+                try {
+                    const list = await core.lambda.list();
+                    return list.map((func: any): boolean => func.id).includes('openvino.dextr');
+                } catch (err) {
+                    return false;
+                }
             }
             case SupportedPlugins.ANALYTICS: {
                 return isReachable(`${serverHost}/analytics/app/kibana`, 'GET');


### PR DESCRIPTION
The plugin checker checks for dextr support by requesting the lambda
list but it returns a 503 error when the lambda service is not running
which crashes the app. This change catches dextr support check errors
and returns false.

Fixes: #1965

<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
