### PR TITLE
analytics build fix

### DIFF
--- a/components/analytics/docker-compose.analytics.yml
+++ b/components/analytics/docker-compose.analytics.yml
@@ -31,7 +31,7 @@ services:
 
   cvat_kibana_setup:
     container_name: cvat_kibana_setup
-    image: cvat
+    image: cvat/server
     volumes: ['./components/analytics/kibana:/home/django/kibana:ro']
     depends_on: ['cvat']
     working_dir: '/home/django'


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

### Motivation and context
When I was building the repository with analytics (docker-compose -f docker-compose.yml -f components/analytics/docker-compose.analytics.yml up -d --build), I got the following error.

Pulling cvat_kibana_setup (cvat:)...
ERROR: pull access denied for cvat, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

To fix the build error, I changed this one line in the docker-compose.analytics

### How has this been tested?
Again running docker-compose -f docker-compose.yml -f components/analytics/docker-compose.analytics.yml up -d --build. It builds then,

### Checklist
- [x ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License
- [x ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
