### PR TITLE
Used addEventListener instead of overriding window.onerror for global error handling

### DIFF
--- a/cvat-ui/package-lock.json
+++ b/cvat-ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.8.2",
+  "version": "1.8.3",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/index.tsx
+++ b/cvat-ui/src/index.tsx
@@ -144,20 +144,17 @@ ReactDOM.render(
     document.getElementById('root'),
 );
 
-window.onerror = (
-    message: Event | string,
-    source?: string,
-    lineno?: number,
-    colno?: number,
-    error?: Error,
-) => {
-    if (typeof (message) === 'string' && source && typeof (lineno) === 'number' && (typeof (colno) === 'number') && error) {
+window.addEventListener('error', (errorEvent: ErrorEvent) => {
+    if (errorEvent.filename
+        && typeof (errorEvent.lineno) === 'number'
+        && typeof (errorEvent.colno) === 'number'
+        && errorEvent.error) {
         const logPayload = {
-            filename: source,
-            line: lineno,
-            message: error.message,
-            column: colno,
-            stack: error.stack,
+            filename: errorEvent.filename,
+            line: errorEvent.lineno,
+            message: errorEvent.error.message,
+            column: errorEvent.colno,
+            stack: errorEvent.error.stack,
         };
 
         const store = getCVATStore();
@@ -171,4 +168,4 @@ window.onerror = (
             logger.log(LogType.sendException, logPayload);
         }
     }
-};
+});


### PR DESCRIPTION
<!---
Copyright (C) 2020 Intel Corporation

SPDX-License-Identifier: MIT
-->

<!-- Raised an issue to propose your change (https://github.com/opencv/cvat/issues).
It will help avoiding duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/opencv/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->
Used addEventListener instead of overriding window.onerror for global error handling

### Motivation and context
The global error handler can be overridden by web analytic framework and part of errors may be uncaught.

### How has this been tested?
Manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] I have updated the license header for each file (see an example below)

```python
# Copyright (C) 2020 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
