### PR TITLE
Use `docker-compose pull` to upgrade

### DIFF
--- a/site/content/en/docs/faq.md
+++ b/site/content/en/docs/faq.md
@@ -12,16 +12,22 @@ description: 'Answers to frequently asked questions'
 Before updating, please follow the [backup guide](/docs/administration/advanced/backup_guide/)
 and backup all CVAT volumes.
 
-To update CVAT, you should clone or download the new version of CVAT and rebuild the CVAT docker images as usual.
+To update CVAT, you should clone or download the new version of CVAT and pull the CVAT docker images as usual.
 
 ```bash
-docker-compose build
+docker-compose pull
 ```
 
 and run containers:
 
 ```bash
 docker-compose up -d
+```
+
+If you wish to run a development version, you can build the images locally:
+
+```bash
+docker-compose -f docker-compose.dev.yml build
 ```
 
 Sometimes the update process takes a lot of time due to changes in the database schema and data.


### PR DESCRIPTION
### Motivation and context
A documentation change. The upgrade guide point to the use of `docker-compose build` but since the default setup uses Docker hub images, it should reference `docker-compose pull`. Fixes #4467 and #4469. Makes PR #4562 redundant.

### How has this been tested?
Yup, on my VM.

### Checklist
- [x] I submit my changes into the `develop` branch
- [ ] ~~I have added a description of my changes into [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file~~ - documentation change, seems irrelevant
- [x] I have updated the [documentation](
  https://github.com/opencv/cvat/blob/develop/README.md#documentation) accordingly
- [ ] ~~I have added tests to cover my changes~~ - documentation change, seems irrelevant
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] ~~I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~ - documentation change, seems irrelevant

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
- [ ] ~~I have updated the license header for each file (see an example below)~~ - no new files

```python
# Copyright (C) 2022 Intel Corporation
#
# SPDX-License-Identifier: MIT
```
