### PR TITLE
Fix docker-compose.https.yml service names

### DIFF
--- a/docker-compose.https.yml
+++ b/docker-compose.https.yml
@@ -5,7 +5,7 @@
 version: '3.3'
 
 services:
-  cvat:
+  cvat_server:
     labels:
       - traefik.http.routers.cvat.entrypoints=websecure
       - traefik.http.routers.cvat.tls.certresolver=lets-encrypt


### PR DESCRIPTION
`cvat` service in `docker-compose.https.yml` has become `cvat_server`


### Motivation and context
I tried to build with ` docker-compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.https.yml -f components/analytics/docker-compose.analytics.yml build` but got the following message:

```
ERROR: The Compose file is invalid because:
Service cvat has neither an image nor a build context specified. At least one must be provided.
```

### How has this been tested?

Tested with the above command following the proposed changes and it successfully built.

### Checklist

- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ x ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
