### PR TITLE
Fixed redrawing a skeleton (Shift+N)

### DIFF
--- a/cvat-canvas/package.json
+++ b/cvat-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.15.1",
+  "version": "2.15.2",
   "description": "Part of Computer Vision Annotation Tool which presents its canvas library",
   "main": "src/canvas.ts",
   "scripts": {

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -263,7 +263,8 @@ export class CanvasViewImpl implements CanvasView, Listener {
         }
 
         if (data) {
-            const { clientID, points } = data as any;
+            const { clientID, elements } = data as any;
+            const points = data.points || elements.map((el: any) => el.points).flat();
             if (typeof clientID === 'number') {
                 const event: CustomEvent = new CustomEvent('canvas.canceled', {
                     bubbles: false,

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.41.3",
+  "version": "1.41.4",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -1,4 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/cvat-ui/src/actions/annotation-actions.ts
+++ b/cvat-ui/src/actions/annotation-actions.ts
@@ -1516,6 +1516,16 @@ export function searchEmptyFrameAsync(sessionInstance: any, frameFrom: number, f
     };
 }
 
+const ShapeTypeToControl: Record<ShapeType, ActiveControl> = {
+    [ShapeType.RECTANGLE]: ActiveControl.DRAW_RECTANGLE,
+    [ShapeType.POLYLINE]: ActiveControl.DRAW_POLYLINE,
+    [ShapeType.POLYGON]: ActiveControl.DRAW_POLYGON,
+    [ShapeType.POINTS]: ActiveControl.DRAW_POINTS,
+    [ShapeType.CUBOID]: ActiveControl.DRAW_CUBOID,
+    [ShapeType.ELLIPSE]: ActiveControl.DRAW_ELLIPSE,
+    [ShapeType.SKELETON]: ActiveControl.DRAW_SKELETON,
+};
+
 export function pasteShapeAsync(): ThunkAction {
     return async (dispatch: ActionCreator<Dispatch>): Promise<void> => {
         const {
@@ -1528,22 +1538,7 @@ export function pasteShapeAsync(): ThunkAction {
         } = getStore().getState().annotation;
 
         if (initialState && canvasInstance) {
-            let activeControl = ActiveControl.CURSOR;
-            if (initialState.shapeType === ShapeType.RECTANGLE) {
-                activeControl = ActiveControl.DRAW_RECTANGLE;
-            } else if (initialState.shapeType === ShapeType.POINTS) {
-                activeControl = ActiveControl.DRAW_POINTS;
-            } else if (initialState.shapeType === ShapeType.POLYGON) {
-                activeControl = ActiveControl.DRAW_POLYGON;
-            } else if (initialState.shapeType === ShapeType.POLYLINE) {
-                activeControl = ActiveControl.DRAW_POLYLINE;
-            } else if (initialState.shapeType === ShapeType.CUBOID) {
-                activeControl = ActiveControl.DRAW_CUBOID;
-            } else if (initialState.shapeType === ShapeType.ELLIPSE) {
-                activeControl = ActiveControl.DRAW_ELLIPSE;
-            } else if (initialState.shapeType === ShapeType.SKELETON) {
-                activeControl = ActiveControl.DRAW_SKELETON;
-            }
+            const activeControl = ShapeTypeToControl[initialState.shapeType as ShapeType] || ActiveControl.CURSOR;
 
             dispatch({
                 type: AnnotationActionTypes.PASTE_SHAPE,
@@ -1623,21 +1618,8 @@ export function repeatDrawShapeAsync(): ThunkAction {
 
             return;
         }
-        if (activeShapeType === ShapeType.RECTANGLE) {
-            activeControl = ActiveControl.DRAW_RECTANGLE;
-        } else if (activeShapeType === ShapeType.POINTS) {
-            activeControl = ActiveControl.DRAW_POINTS;
-        } else if (activeShapeType === ShapeType.POLYGON) {
-            activeControl = ActiveControl.DRAW_POLYGON;
-        } else if (activeShapeType === ShapeType.POLYLINE) {
-            activeControl = ActiveControl.DRAW_POLYLINE;
-        } else if (activeShapeType === ShapeType.CUBOID) {
-            activeControl = ActiveControl.DRAW_CUBOID;
-        } else if (activeShapeType === ShapeType.ELLIPSE) {
-            activeControl = ActiveControl.DRAW_ELLIPSE;
-        } else if (activeShapeType === ShapeType.SKELETON) {
-            activeControl = ActiveControl.DRAW_SKELETON;
-        }
+
+        activeControl = ShapeTypeToControl[activeShapeType];
 
         dispatch({
             type: AnnotationActionTypes.REPEAT_DRAW_SHAPE,
@@ -1689,31 +1671,20 @@ export function redrawShapeAsync(): ThunkAction {
         if (activatedStateID !== null) {
             const [state] = states.filter((_state: any): boolean => _state.clientID === activatedStateID);
             if (state && state.objectType !== ObjectType.TAG) {
-                let activeControl = ActiveControl.CURSOR;
-                if (state.shapeType === ShapeType.RECTANGLE) {
-                    activeControl = ActiveControl.DRAW_RECTANGLE;
-                } else if (state.shapeType === ShapeType.POINTS) {
-                    activeControl = ActiveControl.DRAW_POINTS;
-                } else if (state.shapeType === ShapeType.POLYGON) {
-                    activeControl = ActiveControl.DRAW_POLYGON;
-                } else if (state.shapeType === ShapeType.POLYLINE) {
-                    activeControl = ActiveControl.DRAW_POLYLINE;
-                } else if (state.shapeType === ShapeType.CUBOID) {
-                    activeControl = ActiveControl.DRAW_CUBOID;
-                } else if (state.shapeType === ShapeType.SKELETON) {
-                    activeControl = ActiveControl.DRAW_SKELETON;
-                }
-
+                const activeControl = ShapeTypeToControl[state.shapeType as ShapeType] || ActiveControl.CURSOR;
                 dispatch({
                     type: AnnotationActionTypes.REPEAT_DRAW_SHAPE,
                     payload: {
                         activeControl,
                     },
                 });
+
                 if (canvasInstance instanceof Canvas) {
                     canvasInstance.cancel();
                 }
+
                 canvasInstance.draw({
+                    skeletonSVG: state.shapeType === ShapeType.SKELETON ? state.label.structure.svg : undefined,
                     enabled: true,
                     redraw: activatedStateID,
                     shapeType: state.shapeType,

--- a/tests/cypress/integration/skeletons_pipeline.js
+++ b/tests/cypress/integration/skeletons_pipeline.js
@@ -169,7 +169,7 @@ context('Manipulations with skeletons', () => {
             cy.get(selector).should('not.exist');
         }
 
-        it.skip('Creating and removing a skeleton shape', () => {
+        it('Creating and removing a skeleton shape', () => {
             createSkeletonObject('shape');
             deleteSkeleton('#cvat_canvas_shape_1', 'shape', false);
             cy.removeAnnotations();
@@ -212,7 +212,7 @@ context('Manipulations with skeletons', () => {
             cy.removeAnnotations();
         });
 
-        it.skip('Splitting two skeletons and merge them back', () => {
+        it('Splitting two skeletons and merge them back', () => {
             createSkeletonObject('track');
 
             const splittingFrame = Math.trunc(imageParams.count / 2);

--- a/tests/cypress/integration/skeletons_pipeline.js
+++ b/tests/cypress/integration/skeletons_pipeline.js
@@ -205,14 +205,13 @@ context('Manipulations with skeletons', () => {
             deleteSkeleton('#cvat_canvas_shape_1', 'track', false);
 
             cy.removeAnnotations();
-
+            cy.goCheckFrameNumber(0);
             createSkeletonObject('track');
             deleteSkeleton('#cvat_canvas_shape_1', 'track', true);
-
-            cy.removeAnnotations();
         });
 
         it('Splitting two skeletons and merge them back', () => {
+            cy.removeAnnotations();
             createSkeletonObject('track');
 
             const splittingFrame = Math.trunc(imageParams.count / 2);
@@ -223,32 +222,32 @@ context('Manipulations with skeletons', () => {
 
             // check objects after splitting
             cy.get('#cvat_canvas_shape_1').should('not.exist');
-            cy.get('#cvat_canvas_shape_18').should('exist').and('not.be.visible');
-            cy.get('#cvat_canvas_shape_24').should('exist').and('be.visible');
+            cy.get('#cvat_canvas_shape_12').should('exist').and('not.be.visible');
+            cy.get('#cvat_canvas_shape_18').should('exist').and('be.visible');
 
             cy.goToNextFrame(splittingFrame + 1);
 
-            cy.get('#cvat_canvas_shape_18').should('not.exist');
-            cy.get('#cvat_canvas_shape_24').should('exist').and('be.visible');
+            cy.get('#cvat_canvas_shape_12').should('not.exist');
+            cy.get('#cvat_canvas_shape_18').should('exist').and('be.visible');
 
             // now merge them back
             cy.get('.cvat-merge-control').click();
-            cy.get('#cvat_canvas_shape_24').click();
+            cy.get('#cvat_canvas_shape_18').click();
 
             cy.goCheckFrameNumber(0);
 
-            cy.get('#cvat_canvas_shape_18').click();
+            cy.get('#cvat_canvas_shape_12').click();
             cy.get('body').type('m');
 
             // and check objects after merge
+            cy.get('#cvat_canvas_shape_12').should('not.exist');
             cy.get('#cvat_canvas_shape_18').should('not.exist');
-            cy.get('#cvat_canvas_shape_24').should('not.exist');
 
-            cy.get('#cvat_canvas_shape_30').should('exist').and('be.visible');
+            cy.get('#cvat_canvas_shape_24').should('exist').and('be.visible');
             cy.goCheckFrameNumber(splittingFrame + 1);
-            cy.get('#cvat_canvas_shape_30').should('exist').and('be.visible');
+            cy.get('#cvat_canvas_shape_24').should('exist').and('be.visible');
             cy.goCheckFrameNumber(imageParams.count - 1);
-            cy.get('#cvat_canvas_shape_30').should('exist').and('be.visible');
+            cy.get('#cvat_canvas_shape_24').should('exist').and('be.visible');
 
             cy.removeAnnotations();
         });


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
