### PR TITLE
fix type declaration of private fields in cvat-canvas which are possibly null

### DIFF
--- a/cvat-canvas/package.json
+++ b/cvat-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.15.2",
+  "version": "2.15.3",
   "description": "Part of Computer Vision Annotation Tool which presents its canvas library",
   "main": "src/canvas.ts",
   "scripts": {

--- a/cvat-canvas/src/typescript/drawHandler.ts
+++ b/cvat-canvas/src/typescript/drawHandler.ts
@@ -86,7 +86,7 @@ export class DrawHandlerImpl implements DrawHandler {
         y: number;
     };
     private crosshair: Crosshair;
-    private drawData: DrawData;
+    private drawData: DrawData | null;
     private geometry: Geometry;
     private autoborderHandler: AutoborderHandler;
     private autobordersEnabled: boolean;
@@ -100,7 +100,7 @@ export class DrawHandlerImpl implements DrawHandler {
     private initialized: boolean;
     private canceled: boolean;
     private pointsGroup: SVG.G | null;
-    private shapeSizeElement: ShapeSizeElement;
+    private shapeSizeElement: ShapeSizeElement | null;
 
     private getFinalEllipseCoordinates(points: number[], fitIntoFrame: boolean): number[] {
         const { offset } = this.geometry;

--- a/cvat-canvas/src/typescript/editHandler.ts
+++ b/cvat-canvas/src/typescript/editHandler.ts
@@ -20,11 +20,11 @@ export interface EditHandler {
 export class EditHandlerImpl implements EditHandler {
     private onEditDone: (state: any, points: number[]) => void;
     private autoborderHandler: AutoborderHandler;
-    private geometry: Geometry;
+    private geometry: Geometry | null;
     private canvas: SVG.Container;
-    private editData: EditData;
-    private editedShape: SVG.Shape;
-    private editLine: SVG.PolyLine;
+    private editData: EditData | null;
+    private editedShape: SVG.Shape | null;
+    private editLine: SVG.PolyLine | null;
     private clones: SVG.Polygon[];
     private controlPointsSize: number;
     private autobordersEnabled: boolean;

--- a/cvat-canvas/src/typescript/groupHandler.ts
+++ b/cvat-canvas/src/typescript/groupHandler.ts
@@ -22,7 +22,7 @@ export class GroupHandlerImpl implements GroupHandler {
     private bindedOnSelectStart: (event: MouseEvent) => void;
     private bindedOnSelectUpdate: (event: MouseEvent) => void;
     private bindedOnSelectStop: (event: MouseEvent) => void;
-    private selectionRect: SVG.Rect;
+    private selectionRect: SVG.Rect | null;
     private startSelectionPoint: {
         x: number;
         y: number;

--- a/cvat-canvas/src/typescript/mergeHandler.ts
+++ b/cvat-canvas/src/typescript/mergeHandler.ts
@@ -24,7 +24,7 @@ export class MergeHandlerImpl implements MergeHandler {
     private constraints: {
         labelID: number;
         shapeType: string;
-    };
+    } | null;
 
     private addConstraints(): void {
         const shape = this.statesToBeMerged[0];

--- a/cvat-canvas/src/typescript/splitHandler.ts
+++ b/cvat-canvas/src/typescript/splitHandler.ts
@@ -16,7 +16,7 @@ export class SplitHandlerImpl implements SplitHandler {
     private onSplitDone: (object: any) => void;
     private onFindObject: (event: MouseEvent) => void;
     private canvas: SVG.Container;
-    private highlightedShape: SVG.Shape;
+    private highlightedShape: SVG.Shape | null;
     private initialized: boolean;
     private splitDone: boolean;
 


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
some private fields of classes used in cvat-canvas are type-declared as non-null, whereas they are actually assigned the null value.
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
