### PR TITLE
FIX: Remove a possibly duplicated encodeURI() (Issue #4428)

### DIFF
--- a/cvat-core/src/server-proxy.ts
+++ b/cvat-core/src/server-proxy.ts
@@ -243,13 +243,12 @@ class ServerProxy {
 
         async function share(directoryArg) {
             const { backendAPI } = config;
-            const directory = encodeURI(directoryArg);
 
             let response = null;
             try {
                 response = await Axios.get(`${backendAPI}/server/share`, {
                     proxy: config.proxy,
-                    params: { directory },
+                    params: { directory: directoryArg },
                 });
             } catch (errorData) {
                 throw generateError(errorData);


### PR DESCRIPTION
FIX: Remove possibly duplicated encodeURI() to prevent double encode non-ascii path (Issue #4428 Cannot connect file share，cannot recognize non-ascii path)


<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Fixing the issue non-ascii path #4428 
When you create a task and trying to select files from `Connected file share`,
you get multiple `Could not load share data from the server` error popups
if you try to expand a directory named in non-ascii code.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Following documentation https://opencv.github.io/cvat/docs/administration/basics/installation/#share-path,
setup a share path for CVAT, which contains (sub)directory encoded in non ascii code.

- Create a project and task, and then `Connected file share` tab under `Select files` section.
- Click/expand directories until you encounter the non-ascii named directory.
- Expand the non-ascii named directory and see that no error dialog pop-ups.


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
