### PR TITLE
Fix tag for analytics compose file

### DIFF
--- a/components/analytics/docker-compose.analytics.yml
+++ b/components/analytics/docker-compose.analytics.yml
@@ -29,7 +29,7 @@ services:
 
   cvat_kibana_setup:
     container_name: cvat_kibana_setup
-    image: cvat/server:${CVAT_VERSION:-latest}
+    image: cvat/server:${CVAT_VERSION:-dev}
     volumes: ['./components/analytics/kibana:/home/django/kibana:ro']
     depends_on: ['cvat_server']
     working_dir: '/home/django'


### PR DESCRIPTION
### Motivation and context
Tag for cvat/server in compose file for analytics differ from tag for cvat/server in docker-compose.yml file. I haven't seen any errors related to this issue, but I've noticed that when I run CVAT with analytics, I pull cvat/server twice.

This PR makes the tags the same

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
