### PR TITLE
Fixed unstable e2e restore tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ non-ascii paths while adding files from "Connected file share" (issue #4428)
 (<https://github.com/openvinotoolkit/cvat/pull/4659>)
 - Project import with skeletons (<https://github.com/opencv/cvat/pull/4867>,
   <https://github.com/opencv/cvat/pull/5004>)
-- Unstable e2e restore tests (<https://github.com/opencv/cvat/pull/5008>)
+- Unstable e2e restore tests (<https://github.com/opencv/cvat/pull/5010>)
 
 ### Security
 - TDB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ non-ascii paths while adding files from "Connected file share" (issue #4428)
 (<https://github.com/openvinotoolkit/cvat/pull/4659>)
 - Project import with skeletons (<https://github.com/opencv/cvat/pull/4867>,
   <https://github.com/opencv/cvat/pull/5004>)
+- Unstable e2e restore tests (<https://github.com/opencv/cvat/pull/5008>)
 
 ### Security
 - TDB

--- a/tests/cypress/integration/actions_tasks2/case_97_export_import_task.js
+++ b/tests/cypress/integration/actions_tasks2/case_97_export_import_task.js
@@ -113,8 +113,12 @@ context('Export, import an annotation task.', { browser: '!firefox' }, () => {
             cy.wait('@importTask').its('response.statusCode').should('equal', 201);
             cy.wait('@importTask').its('response.statusCode').should('equal', 204);
             cy.wait('@importTask').its('response.statusCode').should('equal', 202);
-            cy.wait('@importTask', { timeout: 5000 }).its('response.statusCode').should('equal', 202);
-            cy.wait('@importTask').its('response.statusCode').should('equal', 201);
+            cy.wait('@importTask').then((interception) => {
+                cy.wrap(interception).its('response.statusCode').should('be.oneOf', [201, 202]);
+                if (interception.response.statusCode === 202) {
+                    cy.wait('@importTask').its('response.statusCode').should('equal', 201);
+                }
+            });
             cy.contains('The task has been restored succesfully. Click here to open').should('exist').and('be.visible');
             cy.closeNotification('.ant-notification-notice-info');
             cy.openTask(taskName);

--- a/tests/cypress/support/commands_projects.js
+++ b/tests/cypress/support/commands_projects.js
@@ -213,13 +213,15 @@ Cypress.Commands.add('restoreProject', (archiveWithBackup, sourceStorage = null)
         cy.wait('@restoreProject').its('response.statusCode').should('equal', 201);
         cy.wait('@restoreProject').its('response.statusCode').should('equal', 204);
         cy.wait('@restoreProject').its('response.statusCode').should('equal', 202);
-        cy.wait('@restoreProject', { timeout: 5000 }).its('response.statusCode').should('equal', 202);
-        cy.wait('@restoreProject').its('response.statusCode').should('equal', 201);
     } else {
         cy.wait('@restoreProject').its('response.statusCode').should('equal', 202);
-        cy.wait('@restoreProject', { timeout: 3000 }).its('response.statusCode').should('equal', 202);
-        cy.wait('@restoreProject').its('response.statusCode').should('equal', 201);
     }
+    cy.wait('@restoreProject').then((interception) => {
+        cy.wrap(interception).its('response.statusCode').should('be.oneOf', [201, 202]);
+        if (interception.response.statusCode === 202) {
+            cy.wait('@restoreProject').its('response.statusCode').should('equal', 201);
+        }
+    });
 
     cy.contains('The project has been restored succesfully. Click here to open')
         .should('exist')


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Resolved #4995

The problem with restore tests arises when network runs slow, which can happen from time to time. After backup was uploaded tests were checking for restoring status. If its in progress, server returned `202`, if it ended server returned `201`. When network is fast enough `202` is returned, and if its slow, backup restore is ended already which leads to `201` response. Hence we need to make waiting for `202` response optional.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
