### PR TITLE
Fixed invisible label view in label constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ non-ascii paths while adding files from "Connected file share" (issue #4428)
 - Project import/export with skeletons (<https://github.com/opencv/cvat/pull/4867>,
   <https://github.com/opencv/cvat/pull/5004>)
 - Unstable e2e restore tests (<https://github.com/opencv/cvat/pull/5010>)
+- Invisible label item in label constructor when label color background is white,
+ or close to it (<https://github.com/opencv/cvat/pull/5041>)
 
 ### Security
 - TDB

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.42.0",
+  "version": "1.42.1",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
+++ b/cvat-ui/src/components/labels-editor/constructor-viewer-item.tsx
@@ -22,11 +22,26 @@ export default function ConstructorViewerItem(props: ConstructorViewerItemProps)
         color, label, onUpdate, onDelete,
     } = props;
 
+    const backgroundColor = color || consts.NEW_LABEL_COLOR;
+    let textColor = '#ffffff';
+    try {
+        // convert color to grayscale and from the result get better text color
+        // (for darken background -> lighter text, etc.)
+        const [r, g, b] = [backgroundColor.slice(1, 3), backgroundColor.slice(3, 5), backgroundColor.slice(5, 7)];
+        const grayscale = (parseInt(r, 16) + parseInt(g, 16) + parseInt(b, 16)) / 3;
+        if (grayscale - 128 >= 0) {
+            textColor = '#000000';
+        }
+    } catch (_: any) {
+        // nothing to do
+    }
+
     return (
-        <div style={{ background: color || consts.NEW_LABEL_COLOR }} className='cvat-constructor-viewer-item'>
-            <Text>{label.name}</Text>
+        <div style={{ background: backgroundColor }} className='cvat-constructor-viewer-item'>
+            <Text style={{ color: textColor }}>{label.name}</Text>
             <CVATTooltip title='Update attributes'>
                 <span
+                    style={{ color: textColor }}
                     role='button'
                     tabIndex={0}
                     onClick={(): void => onUpdate(label)}
@@ -37,6 +52,7 @@ export default function ConstructorViewerItem(props: ConstructorViewerItemProps)
             </CVATTooltip>
             <CVATTooltip title='Delete label'>
                 <span
+                    style={{ color: textColor }}
                     role='button'
                     tabIndex={0}
                     onClick={(): void => onDelete(label)}

--- a/cvat-ui/src/components/labels-editor/styles.scss
+++ b/cvat-ui/src/components/labels-editor/styles.scss
@@ -45,15 +45,14 @@ textarea.ant-input.cvat-raw-labels-viewer {
     margin: 2px;
     margin-left: $grid-unit-size * 2;
     user-select: none;
-    border: 1px solid $transparent-color;
+    border: 1px solid $border-color-2;
     opacity: 0.6;
 
     > span {
         margin-left: 5px;
-        color: white;
 
         > span[role='img']:hover {
-            filter: invert(1);
+            filter: invert(0.2);
         }
     }
 


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Related #5031 

**Before:**
![image](https://user-images.githubusercontent.com/40690378/193916921-cc6928c5-4884-4588-bf56-bacc651dced7.png)

**After:**
![image](https://user-images.githubusercontent.com/40690378/193916852-ca0e28d7-339a-4443-a960-a1fb1ecedac4.png)


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
