### PR TITLE
Fix SDK tests: login once per class

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -162,9 +162,10 @@ jobs:
       - name: Running REST API tests
         run: |
           pip3 install --user /tmp/cvat_sdk/
+          pip3 install --user cvat-cli/
           pip3 install --user -r tests/python/requirements.txt
           pytest tests/python/rest_api -k 'GET' -s
-          pytest tests/python/sdk
+          pytest tests/python/sdk tests/python/cli
 
       - name: Creating a log file from cvat containers
         if: failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,6 +164,7 @@ jobs:
           pip3 install --user /tmp/cvat_sdk/
           pip3 install --user -r tests/python/requirements.txt
           pytest tests/python/rest_api -k 'GET' -s
+          pytest tests/python/sdk
 
       - name: Creating a log file from cvat containers
         if: failure()

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -177,7 +177,7 @@ REST_FRAMEWORK = {
         'rest_framework.throttling.AnonRateThrottle',
     ],
     'DEFAULT_THROTTLE_RATES': {
-        'anon': '150/minute',
+        'anon': '100/minute',
     },
     'DEFAULT_METADATA_CLASS': 'rest_framework.metadata.SimpleMetadata',
     'DEFAULT_SCHEMA_CLASS': 'cvat.apps.iam.schema.CustomAutoSchema',

--- a/tests/python/cli/test_cli.py
+++ b/tests/python/cli/test_cli.py
@@ -26,7 +26,7 @@ class TestCLI:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        changedb,  # force fixture call order to allow DB setup
+        restore_db_per_function,  # force fixture call order to allow DB setup
         fxt_stdout: io.StringIO,
         tmp_path: Path,
         admin_user: str,

--- a/tests/python/rest_api/test_analytics.py
+++ b/tests/python/rest_api/test_analytics.py
@@ -10,7 +10,7 @@ import pytest
 from shared.utils.config import server_get
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetAnalytics:
     endpoint = "analytics/app/kibana"
 

--- a/tests/python/rest_api/test_auth.py
+++ b/tests/python/rest_api/test_auth.py
@@ -11,7 +11,7 @@ from cvat_sdk.api_client import ApiClient, Configuration, models
 from shared.utils.config import BASE_URL, USER_PASS, make_api_client
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestBasicAuth:
     def test_can_do_basic_auth(self, admin_user: str):
         username = admin_user
@@ -22,7 +22,7 @@ class TestBasicAuth:
             assert user.username == username
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestTokenAuth:
     @staticmethod
     def login(client: ApiClient, username: str) -> models.Token:
@@ -87,7 +87,7 @@ class TestTokenAuth:
             assert response.status == HTTPStatus.UNAUTHORIZED
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestCredentialsManagement:
     def test_can_register(self):
         username = "newuser"

--- a/tests/python/rest_api/test_check_objects_integrity.py
+++ b/tests/python/rest_api/test_check_objects_integrity.py
@@ -13,7 +13,7 @@ from deepdiff import DeepDiff
 from shared.utils import config
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetResources:
     @pytest.mark.parametrize("path", glob.glob(osp.join(config.ASSETS_DIR, "*.json")))
     def test_check_objects_integrity(self, path):

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -11,7 +11,7 @@ from deepdiff import DeepDiff
 from shared.utils.config import get_method, patch_method, post_method
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetCloudStorage:
     def _test_can_see(self, user, storage_id, data, **kwargs):
         response = get_method(user, f"cloudstorages/{storage_id}", **kwargs)
@@ -92,7 +92,7 @@ class TestGetCloudStorage:
             self._test_cannot_see(username, storage_id, org_id=org_id)
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPostCloudStorage:
     _SPEC = {
         "provider_type": "AWS_S3_BUCKET",
@@ -167,7 +167,7 @@ class TestPostCloudStorage:
             self._test_cannot_create(username, self._SPEC, org_id=org_id)
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchCloudStorage:
     _SPEC = {
         "display_name": "New display name",

--- a/tests/python/rest_api/test_invitations.py
+++ b/tests/python/rest_api/test_invitations.py
@@ -10,7 +10,7 @@ import pytest
 from shared.utils.config import post_method
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestCreateInvitations:
     def _test_post_invitation_201(self, user, data, invitee, **kwargs):
         response = post_method(user, "invitations", data, **kwargs)

--- a/tests/python/rest_api/test_issues.py
+++ b/tests/python/rest_api/test_issues.py
@@ -15,7 +15,7 @@ from deepdiff import DeepDiff
 from shared.utils.config import make_api_client
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPostIssues:
     def _test_check_response(self, user, data, is_allow, **kwargs):
         with make_api_client(user) as client:
@@ -120,7 +120,7 @@ class TestPostIssues:
         self._test_check_response(username, data, is_allow, org_id=org)
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchIssues:
     def _test_check_response(self, user, issue_id, data, is_allow, **kwargs):
         with make_api_client(user) as client:
@@ -242,7 +242,7 @@ class TestPatchIssues:
             )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestDeleteIssues:
     def _test_check_response(self, user, issue_id, expect_success, **kwargs):
         with make_api_client(user) as client:

--- a/tests/python/rest_api/test_jobs.py
+++ b/tests/python/rest_api/test_jobs.py
@@ -47,7 +47,7 @@ def filter_jobs(jobs, tasks, org):
     return jobs, kwargs
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetJobs:
     def _test_get_job_200(self, user, jid, data, **kwargs):
         with make_api_client(user) as client:
@@ -97,7 +97,7 @@ class TestGetJobs:
                     self._test_get_job_403(user["username"], job["id"], **kwargs)
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestListJobs:
     def _test_list_jobs_200(self, user, data, **kwargs):
         with make_api_client(user) as client:
@@ -142,7 +142,7 @@ class TestListJobs:
                 self._test_list_jobs_403(user["username"], **kwargs)
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetAnnotations:
     def _test_get_job_annotations_200(self, user, jid, data, **kwargs):
         with make_api_client(user) as client:
@@ -266,7 +266,7 @@ class TestGetAnnotations:
             self._test_get_job_annotations_403(username, job_id, **kwargs)
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchJobAnnotations:
     def _check_respone(self, username, jid, expect_success, data=None, org=None):
         kwargs = {}
@@ -402,7 +402,7 @@ class TestPatchJobAnnotations:
         self._check_respone(username, jid, expect_success, data, org=org)
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchJob:
     @pytest.fixture(scope="class")
     def find_task_staff_user(self, is_task_staff):
@@ -489,7 +489,7 @@ class TestPatchJob:
                 assert response.status == HTTPStatus.FORBIDDEN
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestJobDataset:
     def _export_dataset(self, username, jid, **kwargs):
         with make_api_client(username) as api_client:

--- a/tests/python/rest_api/test_memberships.py
+++ b/tests/python/rest_api/test_memberships.py
@@ -11,7 +11,7 @@ from deepdiff import DeepDiff
 from shared.utils.config import get_method, patch_method
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetMemberships:
     def _test_can_see_memberships(self, user, data, **kwargs):
         response = get_method(user, "memberships", **kwargs)
@@ -44,7 +44,7 @@ class TestGetMemberships:
             self._test_cannot_see_memberships(user, org_id=1)
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchMemberships:
     _ORG = 2
 

--- a/tests/python/rest_api/test_organizations.py
+++ b/tests/python/rest_api/test_organizations.py
@@ -42,7 +42,7 @@ class TestMetadataOrganizations:
         assert response.status_code == HTTPStatus.OK
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetOrganizations:
     _ORG = 2
 
@@ -76,7 +76,7 @@ class TestGetOrganizations:
             assert response.status_code == HTTPStatus.NOT_FOUND
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchOrganizations:
     _ORG = 2
 
@@ -128,7 +128,7 @@ class TestPatchOrganizations:
             assert response.status_code != HTTPStatus.OK
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestDeleteOrganizations:
     _ORG = 2
 

--- a/tests/python/rest_api/test_projects.py
+++ b/tests/python/rest_api/test_projects.py
@@ -17,7 +17,7 @@ from shared.utils.config import get_method, make_api_client, patch_method
 from .utils import export_dataset
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetProjects:
     def _find_project_by_user_org(self, user, projects, is_project_staff_flag, is_project_staff):
         for p in projects:
@@ -265,7 +265,7 @@ class TestGetProjectBackup:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPostProjects:
     def _test_create_project_201(self, user, spec, **kwargs):
         with make_api_client(user) as api_client:
@@ -351,7 +351,7 @@ class TestPostProjects:
         self._test_create_project_201(user["username"], spec, org_id=user["org"])
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestImportExportDatasetProject:
     def _test_export_project(self, username, pid, format_name):
         with make_api_client(username) as api_client:
@@ -459,7 +459,7 @@ class TestImportExportDatasetProject:
             assert response.status == HTTPStatus.ACCEPTED
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchProjectLabel:
     def test_admin_can_delete_label(self, projects):
         project = deepcopy(list(projects)[1])

--- a/tests/python/rest_api/test_remote_url.py
+++ b/tests/python/rest_api/test_remote_url.py
@@ -32,7 +32,7 @@ def _wait_until_task_is_created(username, task_id):
     raise Exception("Cannot create task")
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestCreateFromRemote:
     task_id = 12
 

--- a/tests/python/rest_api/test_resource_import_export.py
+++ b/tests/python/rest_api/test_resource_import_export.py
@@ -103,7 +103,7 @@ def _idempotent_saving_resource_to_cloud_storage(*args, **kwargs):
     remove_asset(args[1]["resource"], kwargs["filename"])
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestSaveResource:
     _USERNAME = "admin1"
     _ORG = 2
@@ -213,7 +213,7 @@ def _import_dataset_from_cloud_storage(user, obj_id, obj, **kwargs):
         status = response.status_code
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 @pytest.mark.usefixtures("restore_cvat_data")
 class TestImportResource:
     _USERNAME = "admin1"

--- a/tests/python/rest_api/test_server.py
+++ b/tests/python/rest_api/test_server.py
@@ -10,7 +10,7 @@ import pytest
 from shared.utils.config import make_api_client
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetServer:
     def test_can_retrieve_about_unauthorized(self):
         with make_api_client(user=None, password=None) as api_client:
@@ -28,7 +28,7 @@ class TestGetServer:
             assert len(data.exporters) != 0
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetSchema:
     def test_can_get_schema_unauthorized(self):
         with make_api_client(user=None, password=None) as api_client:

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -27,7 +27,7 @@ def get_cloud_storage_content(username, cloud_storage_id, manifest):
         return data
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetTasks:
     def _test_task_list_200(self, user, project_id, data, exclude_paths="", **kwargs):
         with make_api_client(user) as api_client:
@@ -142,7 +142,7 @@ class TestGetTasks:
         self._test_assigned_users_to_see_task_data(tasks, users, is_task_staff, org=org["slug"])
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPostTasks:
     def _test_create_task_201(self, user, spec, **kwargs):
         with make_api_client(user) as api_client:
@@ -264,7 +264,7 @@ class TestPostTasks:
         self._test_create_task_201(username, spec)
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetData:
     _USERNAME = "user1"
 
@@ -285,7 +285,7 @@ class TestGetData:
             assert response.headers["Content-Type"] == content_type
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchTaskAnnotations:
     def _test_check_response(self, is_allow, response, data=None):
         if is_allow:
@@ -391,7 +391,7 @@ class TestPatchTaskAnnotations:
         self._test_check_response(is_allow, response, data)
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetTaskDataset:
     def _test_export_task(self, username, tid, **kwargs):
         with make_api_client(username) as api_client:
@@ -403,7 +403,7 @@ class TestGetTaskDataset:
         assert response.data
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 @pytest.mark.usefixtures("restore_cvat_data")
 class TestPostTaskData:
     _USERNAME = "admin1"

--- a/tests/python/rest_api/test_users.py
+++ b/tests/python/rest_api/test_users.py
@@ -14,7 +14,7 @@ from deepdiff import DeepDiff
 from shared.utils.config import make_api_client
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetUsers:
     def _test_can_see(
         self,

--- a/tests/python/rest_api/test_webhooks.py
+++ b/tests/python/rest_api/test_webhooks.py
@@ -12,7 +12,7 @@ from deepdiff import DeepDiff
 from shared.utils.config import delete_method, get_method, patch_method, post_method
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPostWebhooks:
     proj_webhook = {
         "description": "webhook description",
@@ -370,7 +370,7 @@ class TestPostWebhooks:
         assert response.status_code == HTTPStatus.BAD_REQUEST
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetWebhooks:
     def test_admin_can_get_webhook(self, webhooks, users, projects):
         proj_webhooks = [w for w in webhooks if w["type"] == "project"]
@@ -528,7 +528,7 @@ class TestGetWebhooks:
         assert DeepDiff(webhook, response.json(), ignore_order=True) == {}
 
 
-@pytest.mark.usefixtures("dontchangedb")
+@pytest.mark.usefixtures("restore_db_per_class")
 class TestGetListWebhooks:
     def test_can_get_webhooks_list(self, webhooks):
         response = get_method("admin2", "webhooks")
@@ -732,7 +732,7 @@ class TestGetListWebhooks:
         assert DeepDiff(expected_response, response.json()["results"], ignore_order=True) == {}
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestPatchWebhooks:
     WID = 2
 
@@ -977,7 +977,7 @@ class TestPatchWebhooks:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestDeleteWebhooks:
     @pytest.mark.parametrize(
         "privilege, allow", [("user", False), ("business", False), ("admin", True)]

--- a/tests/python/rest_api/test_webhooks_sender.py
+++ b/tests/python/rest_api/test_webhooks_sender.py
@@ -72,7 +72,7 @@ def get_deliveries(webhook_id):
     return deliveries, last_payload
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookProjectEvents:
     def test_webhook_update_project_name(self):
         response = post_method("admin1", "projects", {"name": "project"})
@@ -173,7 +173,7 @@ class TestWebhookProjectEvents:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookIntersection:
     # Test case description:
     #     few webhooks are triggered by the same event
@@ -284,7 +284,7 @@ class TestWebhookIntersection:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookTaskEvents:
     def test_webhook_update_task_assignee(self, users, tasks):
         task_id, project_id = next(
@@ -382,7 +382,7 @@ class TestWebhookTaskEvents:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookJobEvents:
     def test_webhook_update_job_assignee(self, jobs, tasks, users):
         job = next(
@@ -449,7 +449,7 @@ class TestWebhookJobEvents:
         assert payload["job"]["state"] == patch_data["state"]
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookIssueEvents:
     def test_webhook_update_issue_resolved(self, issues, jobs, tasks):
         issue = next(
@@ -545,7 +545,7 @@ class TestWebhookIssueEvents:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookMembershipEvents:
     def test_webhook_update_membership_role(self, memberships):
         roles = {"worker", "supervisor", "maintainer"}
@@ -594,7 +594,7 @@ class TestWebhookMembershipEvents:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookOrganizationEvents:
     def test_webhook_update_organization_name(self, organizations):
         org_id = list(organizations)[0]["id"]
@@ -611,7 +611,7 @@ class TestWebhookOrganizationEvents:
         assert payload["organization"]["name"] == patch_data["name"]
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookCommentEvents:
     def test_webhook_update_comment_message(self, comments, issues, jobs, tasks):
         org_comments = list(
@@ -684,7 +684,7 @@ class TestWebhookCommentEvents:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookPing:
     def test_ping_webhook(self, projects):
         project_id = list(projects)[0]["id"]
@@ -709,7 +709,7 @@ class TestWebhookPing:
         )
 
 
-@pytest.mark.usefixtures("changedb")
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestWebhookRedelivery:
     def test_webhook_redelivery(self, projects):
         project = list(projects)[0]

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -8,7 +8,7 @@ import pytest
 from cvat_sdk import Client
 from PIL import Image
 
-from shared.utils.config import BASE_URL
+from shared.utils.config import BASE_URL, USER_PASS
 from shared.utils.helpers import generate_image_file
 
 from .util import generate_coco_json
@@ -45,3 +45,14 @@ def fxt_coco_file(tmp_path: Path, fxt_image_file: Path):
     generate_coco_json(ann_filename, img_info=(img_filename, *img_size))
 
     yield ann_filename
+
+
+@pytest.fixture(scope="class")
+def fxt_login(admin_user: str, dontchangedb):
+    client = Client(BASE_URL)
+    client.config.status_check_period = 0.01
+    user = admin_user
+
+    with client:
+        client.login((user, USER_PASS))
+        yield (client, user)

--- a/tests/python/sdk/fixtures.py
+++ b/tests/python/sdk/fixtures.py
@@ -48,7 +48,7 @@ def fxt_coco_file(tmp_path: Path, fxt_image_file: Path):
 
 
 @pytest.fixture(scope="class")
-def fxt_login(admin_user: str, dontchangedb):
+def fxt_login(admin_user: str, restore_db_per_class):
     client = Client(BASE_URL)
     client.config.status_check_period = 0.01
     user = admin_user

--- a/tests/python/sdk/test_client.py
+++ b/tests/python/sdk/test_client.py
@@ -21,7 +21,7 @@ class TestClientUsecases:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        changedb,  # force fixture call order to allow DB setup
+        restore_db_per_function,  # force fixture call order to allow DB setup
         fxt_logger: Tuple[Logger, io.StringIO],
         fxt_client: Client,
         fxt_stdout: io.StringIO,

--- a/tests/python/sdk/test_issues_comments.py
+++ b/tests/python/sdk/test_issues_comments.py
@@ -19,19 +19,20 @@ class TestIssuesUsecases:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        changedb,  # force fixture call order to allow DB setup
         tmp_path: Path,
+        fxt_login: Tuple[Client, str],
         fxt_logger: Tuple[Logger, io.StringIO],
-        fxt_client: Client,
         fxt_stdout: io.StringIO,
-        admin_user: str,
     ):
         self.tmp_path = tmp_path
-        _, self.logger_stream = fxt_logger
-        self.client = fxt_client
+        logger, self.logger_stream = fxt_logger
         self.stdout = fxt_stdout
-        self.user = admin_user
-        self.client.login((self.user, USER_PASS))
+        self.client, self.user = fxt_login
+        self.client.logger = logger
+
+        api_client = self.client.api_client
+        for k in api_client.configuration.logger:
+            api_client.configuration.logger[k] = logger
 
         yield
 
@@ -138,19 +139,20 @@ class TestCommentsUsecases:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        changedb,  # force fixture call order to allow DB setup
         tmp_path: Path,
+        fxt_login: Tuple[Client, str],
         fxt_logger: Tuple[Logger, io.StringIO],
-        fxt_client: Client,
         fxt_stdout: io.StringIO,
-        admin_user: str,
     ):
         self.tmp_path = tmp_path
-        _, self.logger_stream = fxt_logger
-        self.client = fxt_client
+        logger, self.logger_stream = fxt_logger
         self.stdout = fxt_stdout
-        self.user = admin_user
-        self.client.login((self.user, USER_PASS))
+        self.client, self.user = fxt_login
+        self.client.logger = logger
+
+        api_client = self.client.api_client
+        for k in api_client.configuration.logger:
+            api_client.configuration.logger[k] = logger
 
         yield
 

--- a/tests/python/sdk/test_issues_comments.py
+++ b/tests/python/sdk/test_issues_comments.py
@@ -12,8 +12,6 @@ from cvat_sdk import Client
 from cvat_sdk.api_client import exceptions, models
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 
-from shared.utils.config import USER_PASS
-
 
 class TestIssuesUsecases:
     @pytest.fixture(autouse=True)

--- a/tests/python/sdk/test_jobs.py
+++ b/tests/python/sdk/test_jobs.py
@@ -14,8 +14,6 @@ from cvat_sdk.api_client import models
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 from PIL import Image
 
-from shared.utils.config import USER_PASS
-
 from .util import make_pbar
 
 

--- a/tests/python/sdk/test_jobs.py
+++ b/tests/python/sdk/test_jobs.py
@@ -23,19 +23,20 @@ class TestJobUsecases:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        changedb,  # force fixture call order to allow DB setup
         tmp_path: Path,
+        fxt_login: Tuple[Client, str],
         fxt_logger: Tuple[Logger, io.StringIO],
-        fxt_client: Client,
         fxt_stdout: io.StringIO,
-        admin_user: str,
     ):
         self.tmp_path = tmp_path
-        _, self.logger_stream = fxt_logger
-        self.client = fxt_client
+        logger, self.logger_stream = fxt_logger
         self.stdout = fxt_stdout
-        self.user = admin_user
-        self.client.login((self.user, USER_PASS))
+        self.client, self.user = fxt_login
+        self.client.logger = logger
+
+        api_client = self.client.api_client
+        for k in api_client.configuration.logger:
+            api_client.configuration.logger[k] = logger
 
         yield
 

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -14,7 +14,6 @@ from cvat_sdk.api_client import exceptions
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
 from PIL import Image
 
-from shared.utils.config import USER_PASS
 from shared.utils.helpers import generate_image_files
 
 from .util import make_pbar

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -24,19 +24,20 @@ class TestTaskUsecases:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        changedb,  # force fixture call order to allow DB setup
         tmp_path: Path,
+        fxt_login: Tuple[Client, str],
         fxt_logger: Tuple[Logger, io.StringIO],
-        fxt_client: Client,
         fxt_stdout: io.StringIO,
-        admin_user: str,
     ):
         self.tmp_path = tmp_path
-        _, self.logger_stream = fxt_logger
-        self.client = fxt_client
+        logger, self.logger_stream = fxt_logger
         self.stdout = fxt_stdout
-        self.user = admin_user
-        self.client.login((self.user, USER_PASS))
+        self.client, self.user = fxt_login
+        self.client.logger = logger
+
+        api_client = self.client.api_client
+        for k in api_client.configuration.logger:
+            api_client.configuration.logger[k] = logger
 
         yield
 

--- a/tests/python/sdk/test_users.py
+++ b/tests/python/sdk/test_users.py
@@ -11,26 +11,25 @@ import pytest
 from cvat_sdk import Client, models
 from cvat_sdk.api_client import exceptions
 
-from shared.utils.config import USER_PASS
-
 
 class TestUserUsecases:
     @pytest.fixture(autouse=True)
     def setup(
         self,
-        changedb,  # force fixture call order to allow DB setup
         tmp_path: Path,
+        fxt_login: Tuple[Client, str],
         fxt_logger: Tuple[Logger, io.StringIO],
-        fxt_client: Client,
         fxt_stdout: io.StringIO,
-        admin_user: str,
     ):
         self.tmp_path = tmp_path
-        _, self.logger_stream = fxt_logger
-        self.client = fxt_client
+        logger, self.logger_stream = fxt_logger
         self.stdout = fxt_stdout
-        self.user = admin_user
-        self.client.login((self.user, USER_PASS))
+        self.client, self.user = fxt_login
+        self.client.logger = logger
+
+        api_client = self.client.api_client
+        for k in api_client.configuration.logger:
+            api_client.configuration.logger[k] = logger
 
         yield
 

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -311,7 +311,7 @@ def services(request):
 
 
 @pytest.fixture(scope="function")
-def changedb(request):
+def restore_db_per_function(request):
     # Note that autouse fixtures are executed first within their scope, so be aware of the order
     # Pre-test DB setups (eg. with class-declared autouse setup() method) may be cleaned.
     # https://docs.pytest.org/en/stable/reference/fixtures.html#autouse-fixtures-are-executed-first-within-their-scope
@@ -323,7 +323,7 @@ def changedb(request):
 
 
 @pytest.fixture(scope="class")
-def dontchangedb(request):
+def restore_db_per_class(request):
     platform = request.config.getoption("--platform")
     if platform == "local":
         docker_restore_db()


### PR DESCRIPTION
### Motivation and context
Recently we used workaround with increasing throttle rate to make our tests green.
This PR resolve root cause of the "throttle error" problem in our tests

- [x] Get back original value of throttle rate
- [x] Use login for SDK tests once per test class
- [x] Add SDK tests for main.yml workflow
- [x] Rename `changedb` fixture


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
