### PR TITLE
Projects page lazy loading

### DIFF
--- a/cvat-ui/src/components/projects-page/project-list.tsx
+++ b/cvat-ui/src/components/projects-page/project-list.tsx
@@ -2,31 +2,45 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useCallback } from 'react';
+import React, { useEffect, useState } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
-import { Row, Col } from 'antd/lib/grid';
-import Pagination from 'antd/lib/pagination';
+import { Row, Col, RowProps } from 'antd/lib/grid';
+import Spin from 'antd/lib/spin';
 
-import { getProjectsAsync } from 'actions/projects-actions';
+import { getProjectsLazyAsync } from 'actions/projects-actions';
 import { CombinedState, Project } from 'reducers';
+import { useOnScreen } from 'utils/hooks';
 import ProjectItem from './project-item';
 
-export default function ProjectListComponent(): JSX.Element {
+export interface ProjectListComponentProps extends RowProps {
+    amount?: number; // the number of projects given by the API on one page
+}
+
+export default function ProjectListComponent({ amount = 12, ...props }: ProjectListComponentProps): JSX.Element {
     const dispatch = useDispatch();
     const projectsCount = useSelector((state: CombinedState) => state.projects.count);
     const projects = useSelector((state: CombinedState) => state.projects.current);
     const gettingQuery = useSelector((state: CombinedState) => state.projects.gettingQuery);
     const tasksQuery = useSelector((state: CombinedState) => state.projects.tasksGettingQuery);
-    const { page } = gettingQuery;
+    const fetching = useSelector((state: CombinedState) => state.projects.fetching);
+    const [lastPage, setlastPage] = useState<number>(1);
+    const loaderRef = React.useRef<HTMLDivElement | null>(null);
+    const loaderIsVisible = useOnScreen(loaderRef);
 
-    const changePage = useCallback((p: number) => {
-        dispatch(
-            getProjectsAsync({
-                ...gettingQuery,
-                page: p,
-            }, tasksQuery),
-        );
-    }, [gettingQuery]);
+    useEffect(() => {
+        if (!fetching && loaderIsVisible && lastPage <= Math.ceil(projectsCount / amount)) {
+            dispatch(
+                getProjectsLazyAsync(
+                    {
+                        ...gettingQuery,
+                        page: lastPage + 1,
+                    },
+                    tasksQuery,
+                ),
+            );
+            setlastPage(lastPage + 1);
+        }
+    }, [loaderIsVisible]);
 
     const dimensions = {
         md: 22,
@@ -36,8 +50,8 @@ export default function ProjectListComponent(): JSX.Element {
     };
 
     return (
-        <>
-            <Row justify='center' align='middle' className='cvat-project-list-content'>
+        <Row className='cvat-project-list-content' {...props}>
+            <Row justify='center' align='middle'>
                 <Col className='cvat-projects-list' {...dimensions}>
                     {projects.map(
                         (project: Project): JSX.Element => (
@@ -46,19 +60,11 @@ export default function ProjectListComponent(): JSX.Element {
                     )}
                 </Col>
             </Row>
-            <Row justify='center' align='middle'>
-                <Col {...dimensions}>
-                    <Pagination
-                        className='cvat-projects-pagination'
-                        onChange={changePage}
-                        showSizeChanger={false}
-                        total={projectsCount}
-                        pageSize={12}
-                        current={page}
-                        showQuickJumper
-                    />
-                </Col>
-            </Row>
-        </>
+            {lastPage < Math.ceil(projectsCount / amount) && (
+                <Row justify='center' ref={loaderRef} align='middle' {...dimensions} className='cvat-project-list-loader'>
+                    <Spin size='large' className='cvat-spinner' />
+                </Row>
+            )}
+        </Row>
     );
 }

--- a/cvat-ui/src/components/projects-page/projects-page.tsx
+++ b/cvat-ui/src/components/projects-page/projects-page.tsx
@@ -9,7 +9,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import Spin from 'antd/lib/spin';
 
 import { CombinedState, Indexable } from 'reducers';
-import { getProjectsAsync, restoreProjectAsync } from 'actions/projects-actions';
+import { getProjectsLazyAsync, restoreProjectAsync } from 'actions/projects-actions';
 import FeedbackComponent from 'components/feedback/feedback';
 import { updateHistoryFromQuery } from 'components/resource-sorting-filtering';
 import ImportDatasetModal from 'components/import-dataset-modal/import-dataset-modal';
@@ -38,7 +38,7 @@ export default function ProjectsPageComponent(): JSX.Element {
     }
 
     useEffect(() => {
-        dispatch(getProjectsAsync({ ...updatedQuery }));
+        dispatch(getProjectsLazyAsync({ ...updatedQuery }));
         setIsMounted(true);
     }, []);
 

--- a/cvat-ui/src/components/projects-page/styles.scss
+++ b/cvat-ui/src/components/projects-page/styles.scss
@@ -174,7 +174,16 @@
 }
 
 .cvat-project-list-content {
+    max-height: calc(100% - 40px);
+    overflow-y: auto;
     padding-bottom: $grid-unit-size;
+}
+
+.cvat-project-list-loader {
+    margin-top: 50px;
+    position: relative;
+    width: 100%;
+    height: 300px;
 }
 
 .cvat-projects-list {

--- a/cvat-ui/src/reducers/index.ts
+++ b/cvat-ui/src/reducers/index.ts
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
+// eslint-disable-next-line import/no-extraneous-dependencies
 import { Canvas3d } from 'cvat-canvas3d/src/typescript/canvas3d';
 import { Canvas, RectDrawingMethod, CuboidDrawingMethod } from 'cvat-canvas-wrapper';
 import { IntelligentScissors } from 'utils/opencv-wrapper/intelligent-scissors';
@@ -40,6 +41,7 @@ export interface ProjectsState {
     initialized: boolean;
     fetching: boolean;
     count: number;
+    pages: { [key: number]: Project[] },
     current: Project[];
     gettingQuery: ProjectsQuery;
     tasksGettingQuery: TasksQuery & { ordering: string };

--- a/cvat-ui/src/reducers/projects-reducer.ts
+++ b/cvat-ui/src/reducers/projects-reducer.ts
@@ -14,6 +14,7 @@ const defaultState: ProjectsState = {
     initialized: false,
     fetching: false,
     count: 0,
+    pages: {},
     current: [],
     gettingQuery: {
         page: 1,
@@ -63,6 +64,26 @@ export default (state: ProjectsState = defaultState, action: AnyAction): Project
                 fetching: true,
                 count: 0,
                 current: [],
+            };
+        case ProjectsActionTypes.GET_PROJECTS_LAZY:
+            if (!state.pages[action.payload.page]) {
+                const combinedWithPreviews = action.payload.array.map(
+                    (project: any, index: number): Project => ({
+                        instance: project,
+                        preview: action.payload.previews[index],
+                    }),
+                );
+                state.pages[action.payload.page] = combinedWithPreviews;
+                state.current = Object.keys(state.pages).reduce(
+                    (acc, key) => acc.concat(state.pages[+key]),
+                    [] as Project[],
+                );
+            }
+            return {
+                ...state,
+                initialized: false,
+                fetching: false,
+                count: action.payload.count,
             };
         case ProjectsActionTypes.GET_PROJECTS_SUCCESS: {
             const combinedWithPreviews = action.payload.array.map(

--- a/cvat-ui/src/utils/hooks.ts
+++ b/cvat-ui/src/utils/hooks.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2021-2022 Intel Corporation
 //
 // SPDX-License-Identifier: MIT
-import { useRef, useEffect, useState } from 'react';
+import React, { useRef, useEffect, useState } from 'react';
 
 // eslint-disable-next-line import/prefer-default-export
 export function usePrevious<T>(value: T): T | undefined {
@@ -58,4 +58,25 @@ export function useCardHeightHOC(params: ICardHeightHOC): () => string {
 
         return height;
     };
+}
+
+export function useOnScreen(ref: React.MutableRefObject<HTMLElement | null>): boolean {
+    const [isIntersecting, setIntersecting] = useState(false);
+    useEffect(() => {
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                setIntersecting(entry.isIntersecting);
+            },
+        );
+
+        if (ref.current) {
+            observer.observe(ref.current);
+        }
+        return () => {
+            if (ref.current) {
+                observer.unobserve(ref.current);
+            }
+        };
+    }, []);
+    return isIntersecting;
 }


### PR DESCRIPTION
# Realization of "lazy loading" of project cards.

updated package: `cvat-ui`

The current approach to navigating project card pages loads data every time the page is opened, causing lots of React renders, API queries and increasing time to interactivity state. 

[Preview old behavior.](https://postimg.cc/Ln87FrWb)

The project card script has been redesigned to "infinite scrolling".  Which allows us to reduce the number of requests to the API by at least half, significantly reduce the number of React re-renderers and reduce the time to the state of interactivity. 

[New behavior preview.](https://postimg.cc/NyBjgGwc)

### Checklist
- [ ] ~I submit my changes into the `develop` branch~
- [ ] ~I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file~
- [ ] ~I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~
- [ ] ~I have added tests to cover my changes~
- [ ] ~I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~
- [ ] ~I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~

### License

- [ x ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
