### PR TITLE
No extra rerender of different pages with each click

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,7 @@ non-ascii paths while adding files from "Connected file share" (issue #4428)
 - Deleted frames become restored if a user deletes frames from another job of the same task
 (<https://github.com/opencv/cvat/pull/5138>)
 - Wrong issue position when create a quick issue on a rotated shape (<https://github.com/opencv/cvat/pull/5162>)
+- Extra rerenders of different pages with each click (<https://github.com/opencv/cvat/pull/5178>)
 - Skeleton points exported out of order in the COCO Keypoints format
   (<https://github.com/opencv/cvat/issues/5048>)
 - Changing an object causes current z layer to be set to the maximum (<https://github.com/opencv/cvat/pull/5145>)

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -163,6 +163,25 @@ export default function ResourceFilterHOC(
         }, []);
 
         useEffect(() => {
+            const listener = (event: MouseEvent): void => {
+                const path: HTMLElement[] = event.composedPath()
+                    .filter((el: EventTarget) => el instanceof HTMLElement) as HTMLElement[];
+                if (path.some((el: HTMLElement) => el.id === 'root') && !path.some((el: HTMLElement) => el.classList.contains('ant-btn'))) {
+                    if (builderVisible) {
+                        onBuilderVisibleChange(false);
+                    }
+
+                    if (predefinedVisible) {
+                        onRecentVisibleChange(false);
+                    }
+                }
+            };
+
+            window.addEventListener('click', listener);
+            return () => window.removeEventListener('click', listener);
+        }, [builderVisible, predefinedVisible]);
+
+        useEffect(() => {
             if (!isMounted) {
                 // do not request resources until on mount hook is done
                 return;

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -129,20 +129,6 @@ export default function ResourceFilterHOC(
             setRecentFilters(receiveRecentFilters());
             setIsMounted(true);
 
-            const listener = (event: MouseEvent): void => {
-                const path: HTMLElement[] = event.composedPath()
-                    .filter((el: EventTarget) => el instanceof HTMLElement) as HTMLElement[];
-                if (path.some((el: HTMLElement) => el.id === 'root') && !path.some((el: HTMLElement) => el.classList.contains('ant-btn'))) {
-                    if (builderVisible) {
-                        onBuilderVisibleChange(false);
-                    }
-
-                    if (predefinedVisible) {
-                        onRecentVisibleChange(false);
-                    }
-                }
-            };
-
             try {
                 if (value) {
                     const tree = QbUtils.loadFromJsonLogic(JSON.parse(value), config);
@@ -157,9 +143,6 @@ export default function ResourceFilterHOC(
             } catch (_: any) {
                 // nothing to do
             }
-
-            window.addEventListener('click', listener);
-            return () => window.removeEventListener('click', listener);
         }, []);
 
         useEffect(() => {

--- a/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/filtering.tsx
@@ -133,8 +133,13 @@ export default function ResourceFilterHOC(
                 const path: HTMLElement[] = event.composedPath()
                     .filter((el: EventTarget) => el instanceof HTMLElement) as HTMLElement[];
                 if (path.some((el: HTMLElement) => el.id === 'root') && !path.some((el: HTMLElement) => el.classList.contains('ant-btn'))) {
-                    onBuilderVisibleChange(false);
-                    onRecentVisibleChange(false);
+                    if (builderVisible) {
+                        onBuilderVisibleChange(false);
+                    }
+
+                    if (predefinedVisible) {
+                        onRecentVisibleChange(false);
+                    }
                 }
             };
 

--- a/cvat-ui/src/components/resource-sorting-filtering/sorting.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/sorting.tsx
@@ -119,6 +119,9 @@ function SortingModalComponent(props: Props): JSX.Element {
 
     useEffect(() => {
         setIsMounted(true);
+    }, []);
+
+    useEffect(() => {
         const listener = (event: MouseEvent): void => {
             const path: HTMLElement[] = event.composedPath()
                 .filter((el: EventTarget) => el instanceof HTMLElement) as HTMLElement[];
@@ -131,7 +134,7 @@ function SortingModalComponent(props: Props): JSX.Element {
 
         window.addEventListener('click', listener);
         return () => window.removeEventListener('click', listener);
-    }, []);
+    }, [visible]);
 
     useEffect(() => {
         if (!isMounted) return;

--- a/cvat-ui/src/components/resource-sorting-filtering/sorting.tsx
+++ b/cvat-ui/src/components/resource-sorting-filtering/sorting.tsx
@@ -123,7 +123,9 @@ function SortingModalComponent(props: Props): JSX.Element {
             const path: HTMLElement[] = event.composedPath()
                 .filter((el: EventTarget) => el instanceof HTMLElement) as HTMLElement[];
             if (path.some((el: HTMLElement) => el.id === 'root') && !path.some((el: HTMLElement) => el.classList.contains('ant-btn'))) {
-                onVisibleChange(false);
+                if (visible) {
+                    onVisibleChange(false);
+                }
             }
         };
 


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
