### PR TITLE
[WIP] QA Automation test task - cli json label loading test

### DIFF
--- a/site/content/en/docs/contributing/development-environment.md
+++ b/site/content/en/docs/contributing/development-environment.md
@@ -27,6 +27,28 @@ description: 'Installing a development environment for different operating syste
   brew install git python pyenv redis curl openssl node sqlite3 geos
   ```
 
+  Arch Linux
+  ```bash
+  # Update the system and AUR (you can use any other AUR helper of choice) first:
+  sudo pacman -Syyu
+  pikaur -Syu
+  ```
+
+  ```bash
+  # Install the required dependencies:
+  sudo pacman -S base-devel curl git redis cmake gcc python python-pip tk libldap libsasl pkgconf ffmpeg geos openldap python-lda
+  ```
+
+  ```bash
+  # Since migration only works with Python<=3.9, because the Iterable class has been removed from collections in Python 3.10, install Python<=3.9 if you don’t have it:
+  pikaur -S python39
+  ```
+
+  ```bash
+  # Install Node.js 16, yarn and npm
+  sudo pacman -S nodejs-lts-gallium yarn npm
+  ```
+
 - Install Chrome
 
 - Install FFmpeg libraries (libav\*) version 4.0 or higher.
@@ -102,6 +124,17 @@ description: 'Installing a development environment for different operating syste
   > On Mac with Apple Silicon (M1) in order to install TensorFlow you will have to edit `cvat/requirements/base.txt`.
   > Change `tensorflow` to `tensorflow-macos`
   > May need to downgrade version Python to 3.9.* or upgrade version `tensorflow-macos`
+
+  > Note for Arch Linux users:
+  >
+  > In order to build `python-ldap`, the `gcc` compiler needs to be pointed to the right file, since lib name has been changed from `libldap_r` to `libldap`, otherwise wheels for `python-ldap` won't be built and the install will fail. You need to create a symlink between the newer and older `ldap` libraries:
+  > ```
+  > sudo ln -s /usr/lib/libldap.so /usr/lib/libldap_r.so
+  > ```
+  >
+  > Because PyAV as of version 10.0.0 already [works](https://github.com/PyAV-Org/PyAV/pull/910) with FFMPEG5, you may consider changing the `av` version requirement in `/cvat/cvat/requirements/base.txt` to 10.0.0 or higher.
+  >
+  > Perform these actions before installing cvat requirements from the list mentioned above.
 
 - Create a super user for CVAT:
 
@@ -182,3 +215,10 @@ You develop CVAT under WSL (Windows subsystem for Linux) following next steps.
 
 - You might have to manually start the redis server. You can do this with `redis-server`.
 Alternatively you can also use a redis docker image instead of using the redis-server locally.
+
+## Note for Arch Linux users
+- You need to start `redis` and `docker` services manually in order to begin debugging/running tests:
+  ```bash
+  sudo systemctl start redis.service
+  sudo systemctl start docker.service
+  ```

--- a/tests/python/cli/test_cli.py
+++ b/tests/python/cli/test_cli.py
@@ -220,3 +220,23 @@ class TestCLI:
             self.run_cli(*(["--insecure"] if not verify else []), "ls")
 
         assert capture.value.args[0] == verify
+
+    def test_load_json_file_into_labels(self, fxt_coco_file):
+
+        image = generate_images(str(self.tmp_path), 1)
+
+        # TODO:
+        #  the opened file is valid, but becomes empty and yields a KeyError
+        #  when passed to deserialization method as run_cli argument
+
+        with open(fxt_coco_file, "r") as source:
+            output = self.run_cli(
+                "create",
+                "test_task",
+                ResourceType.LOCAL.name,
+                image,
+                "--labels",
+                json.load(source),
+            )
+
+            assert output is not None

--- a/tests/python/sdk/test_schema.py
+++ b/tests/python/sdk/test_schema.py
@@ -1,0 +1,27 @@
+import pytest
+from cvat_sdk import Client
+from cvat_sdk.core.client import make_client
+from cvat_sdk.core import schema as sc
+from cvat_sdk.core.exceptions import InvalidHostException
+from shared.utils.config import BASE_URL
+
+
+class TestSchemaDetection:
+    """
+    Testing whether the client can detect the URL schema
+    """
+
+    @pytest.mark.parametrize("get_schema", ['http://', 'https://', '', None, 'ftp://'])
+    def test_schema_detection(self, get_schema):
+
+        host, port = BASE_URL.split("://", maxsplit=1)[1].rsplit(":", maxsplit=1)
+
+        if get_schema is not None:
+            try:
+                client = make_client(host=get_schema + host, port=int(port))
+            except InvalidHostException:
+                client = Client(BASE_URL)  # changing to another instance creation method to get urls
+        else:
+            raise InvalidHostException()
+
+        assert sc.detect_schema(client.api_map.host) == get_schema + host + ":" + port


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Running a quick scan in pytest-cov on cvat-cli, I detected some files that need added testing coverage.
Since the plans for python modules testing could not be found in [Projects](https://github.com/opencv/cvat/projects?type=classic), I decided to stick to the parts that had the most lines missing, as well as were of interest to me.

In this case it was `.env/lib/python3.9/site-packages/cvat_cli/parser.py`. What surprised me was the fact that the lines related to labels' json file load upon task creation were never executed, but [CLI](https://opencv.github.io/cvat/docs/api_sdk/cli/) docs' entry shows that this possibility exists and the [code](https://github.com/inpv/cvat/blob/12a295af72ff65e1c68c47536c761c739680dcd6/cvat-cli/src/cvat_cli/parser.py#L28) does too.

The reason this particular test is still WIP though is because since Python interpreter is pointer based, so there's probably no way to pass an opened json file as an argument to another method during a pytest run - even serializing it back and loading again, passing into a fixture and storing in `self.tmp_data` yields the same results.

Here's the error stack trace:

```
(.env) [inpv@pluto cvat]$ python3.9 -m pytest --cov-config=.coveragerc --cov=cvat_cli --cov-report=html --cov-context=test tests/python/cli -k 'test_load_json_file_into_labels'
===================================== test session starts ======================================
platform linux -- Python 3.9.15, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/inpv/Development/cvat/.env/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/inpv/Development/cvat/tests/python, configfile: pytest.ini
plugins: cov-4.0.0, xdist-3.0.2
collected 14 items / 13 deselected / 1 selected                                                

tests/python/cli/test_cli.py::TestCLI::test_load_json_file_into_labels WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "https_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "http_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
[+] Running 15/0
[+] Running 15/17-elasticsearch-1         Running                                          0.0s
[+] Running 15/17-elasticsearch-1         Running                                          0.0s
[+] Running 15/17-elasticsearch-1         Running                                          0.0s
[+] Running 15/17-elasticsearch-1         Running                                          0.0s
[+] Running 15/17-elasticsearch-1         Running                                          0.0s
[+] Running 15/17-elasticsearch-1         Running                                          0.0s
[+] Running 15/17-elasticsearch-1         Running                                          0.0s
[+] Running 17/17-elasticsearch-1         Running                                          0.0s
 ⠿ Container test-elasticsearch-1         Running                                          0.0s
 ⠿ Container test-minio-1                 Running                                          0.0s
 ⠿ Container test-cvat_opa-1              Running                                          0.0s
 ⠿ Container test-traefik-1               Running                                          0.0s
 ⠿ Container test-cvat_redis-1            Running                                          0.0s
 ⠿ Container test-kibana-1                Running                                          0.0s
 ⠿ Container test-cvat_db-1               Running                                          0.0s
 ⠿ Container test-webhook_receiver-1      Running                                          0.0s
 ⠿ Container test-mc-1                    Started                                          0.8s
 ⠿ Container test-logstash-1              Running                                          0.0s
 ⠿ Container test-cvat_worker_webhooks-1  Runni...                                         0.0s
 ⠿ Container test-cvat_server-1           Running                                          0.0s
 ⠿ Container test-cvat_worker_default-1   Runnin...                                        0.0s
 ⠿ Container test-cvat_utils-1            Running                                          0.0s
 ⠿ Container test-cvat_worker_low-1       Running                                          0.0s
 ⠿ Container test-cvat_ui-1               Running                                          0.0s
 ⠿ Container test-cvat_kibana_setup-1     Started                                          0.8s
FAILED            [100%]

=========================================== FAILURES ===========================================
___________________________ TestCLI.test_load_json_file_into_labels ____________________________

self = <cli.test_cli.TestCLI object at 0x7f3c7c740130>
fxt_coco_file = PosixPath('/tmp/pytest-of-inpv/pytest-2/test_load_json_file_into_label0/coco.json')

    def test_load_json_file_into_labels(self, fxt_coco_file):
    
        image = generate_images(str(self.tmp_path), 1)
    
        # TODO:
        #  the opened file is valid, but becomes empty and yields a KeyError
        #  when passed to deserialization method as run_cli argument
    
        with open(fxt_coco_file, "r") as source:
>           output = self.run_cli(
                "create",
                "test_task",
                ResourceType.LOCAL.name,
                image,
                "--labels",
                json.load(source),
            )

tests/python/cli/test_cli.py:233: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
tests/python/cli/test_cli.py:88: in run_cli
    run_cli(
tests/python/cli/util.py:22: in run_cli
    assert expected_code == main(args)
.env/lib/python3.9/site-packages/cvat_cli/__main__.py:43: in main
    parsed_args = parser.parse_args(args)
/usr/lib/python3.9/argparse.py:1825: in parse_args
    args, argv = self.parse_known_args(args, namespace)
/usr/lib/python3.9/argparse.py:1858: in parse_known_args
    namespace, args = self._parse_known_args(args, namespace)
/usr/lib/python3.9/argparse.py:1902: in _parse_known_args
    option_tuple = self._parse_optional(arg_string)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = ArgumentParser(prog='__main__.py', usage=None, description='Perform common operations related to CVAT tasks.\n\n', formatter_class=<class 'argparse.HelpFormatter'>, conflict_handler='error', add_help=True)
arg_string = {'annotations': [{'area': 17702.0, 'bbox': [574.0, 407.0, 167.0, 106.0], 'category_id': 1, 'id': 1, ...}], 'categories...percategory': ''}], 'images': [{'coco_url': '', 'date_captured': '', 'file_name': 'img_0.png', 'flickr_url': '', ...}]}

    def _parse_optional(self, arg_string):
        # if it's an empty string, it was meant to be a positional
        if not arg_string:
            return None
    
        # if it doesn't start with a prefix, it was meant to be positional
>       if not arg_string[0] in self.prefix_chars:
E       KeyError: 0

/usr/lib/python3.9/argparse.py:2189: KeyError

---------- coverage: platform linux, python 3.9.15-final-0 -----------
Coverage HTML written to dir htmlcov

=================================== short test summary info ====================================
FAILED tests/python/cli/test_cli.py::TestCLI::test_load_json_file_into_labels - KeyError: 0
============================== 1 failed, 13 deselected in 11.18s ===============================
```

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
The test code has been launched on a (custom) Arch Linux dev env, using python3.9, pytest and pytest-cov plugin.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
