### PR TITLE
QA Automation test task - sdk schema detection test

### DIFF
--- a/site/content/en/docs/contributing/development-environment.md
+++ b/site/content/en/docs/contributing/development-environment.md
@@ -27,6 +27,28 @@ description: 'Installing a development environment for different operating syste
   brew install git python pyenv redis curl openssl node sqlite3 geos
   ```
 
+  Arch Linux
+  ```bash
+  # Update the system and AUR (you can use any other AUR helper of choice) first:
+  sudo pacman -Syyu
+  pikaur -Syu
+  ```
+
+  ```bash
+  # Install the required dependencies:
+  sudo pacman -S base-devel curl git redis cmake gcc python python-pip tk libldap libsasl pkgconf ffmpeg geos openldap python-lda
+  ```
+
+  ```bash
+  # Since migration only works with Python<=3.9, because the Iterable class has been removed from collections in Python 3.10, install Python<=3.9 if you don’t have it:
+  pikaur -S python39
+  ```
+
+  ```bash
+  # Install Node.js 16, yarn and npm
+  sudo pacman -S nodejs-lts-gallium yarn npm
+  ```
+
 - Install Chrome
 
 - Install FFmpeg libraries (libav\*) version 4.0 or higher.
@@ -102,6 +124,17 @@ description: 'Installing a development environment for different operating syste
   > On Mac with Apple Silicon (M1) in order to install TensorFlow you will have to edit `cvat/requirements/base.txt`.
   > Change `tensorflow` to `tensorflow-macos`
   > May need to downgrade version Python to 3.9.* or upgrade version `tensorflow-macos`
+
+  > Note for Arch Linux users:
+  >
+  > In order to build `python-ldap`, the `gcc` compiler needs to be pointed to the right file, since lib name has been changed from `libldap_r` to `libldap`, otherwise wheels for `python-ldap` won't be built and the install will fail. You need to create a symlink between the newer and older `ldap` libraries:
+  > ```
+  > sudo ln -s /usr/lib/libldap.so /usr/lib/libldap_r.so
+  > ```
+  >
+  > Because PyAV as of version 10.0.0 already [works](https://github.com/PyAV-Org/PyAV/pull/910) with FFMPEG5, you may consider changing the `av` version requirement in `/cvat/cvat/requirements/base.txt` to 10.0.0 or higher.
+  >
+  > Perform these actions before installing cvat requirements from the list mentioned above.
 
 - Create a super user for CVAT:
 
@@ -182,3 +215,10 @@ You develop CVAT under WSL (Windows subsystem for Linux) following next steps.
 
 - You might have to manually start the redis server. You can do this with `redis-server`.
 Alternatively you can also use a redis docker image instead of using the redis-server locally.
+
+## Note for Arch Linux users
+- You need to start `redis` and `docker` services manually in order to begin debugging/running tests:
+  ```bash
+  sudo systemctl start redis.service
+  sudo systemctl start docker.service
+  ```

--- a/tests/python/sdk/test_schema.py
+++ b/tests/python/sdk/test_schema.py
@@ -1,0 +1,27 @@
+import pytest
+from cvat_sdk import Client
+from cvat_sdk.core.client import make_client
+from cvat_sdk.core import schema as sc
+from cvat_sdk.core.exceptions import InvalidHostException
+from shared.utils.config import BASE_URL
+
+
+class TestSchemaDetection:
+    """
+    Testing whether the client can detect the URL schema
+    """
+
+    @pytest.mark.parametrize("get_schema", ['http://', 'https://', '', None, 'ftp://'])
+    def test_schema_detection(self, get_schema):
+
+        host, port = BASE_URL.split("://", maxsplit=1)[1].rsplit(":", maxsplit=1)
+
+        if get_schema is not None:
+            try:
+                client = make_client(host=get_schema + host, port=int(port))
+            except InvalidHostException:
+                client = Client(BASE_URL)  # changing to another instance creation method to get urls
+        else:
+            raise InvalidHostException()
+
+        assert sc.detect_schema(client.api_map.host) == get_schema + host + ":" + port


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Running a quick scan in pytest-cov on cvat-cli, I detected some files that need added testing coverage.
Since the plans for python modules testing could not be found in [Projects](https://github.com/opencv/cvat/projects?type=classic), I decided to stick to the parts that had the most lines missing, as well as were of interest to me.

The file in testing in this task is `.env/lib/python3.9/site-packages/cvat_sdk/core/schema.py`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
The test code has been launched on a (custom) Arch Linux dev env, using python3.9, pytest and pytest-cov plugin.

The file located at `.env/lib/python3.9/site-packages/cvat_sdk/core/schema.py` had 0% test coverage and is supposed to automatically detect the URL schemas when creating an [API client](https://opencv.github.io/cvat/docs/api_sdk/sdk/lowlevel-api/) instance. I managed to cover 33% of it without changing the existing module code.

The two cases that detect `http://` and `https://` schemas pass as intended, the three negative cases either raise an exception, assertion or SSL verification error.

NB! Since the PyPI `cvat-cli` and `cvat-sdk` packages haven't been updated yet, and installing them locally returns an error, I decided not to suppress SSL cert verification errors explicitly, especially since now there are options to enable insecure [authorization](https://github.com/opencv/cvat/commit/68375ec23e6c60441c3c574448b6c0b76d129d60).

The full pytest logs:

```
(.env) [%USER%@%HOST% cvat]$ python3.9 -m pytest --cov-config=.coveragerc --cov=cvat_sdk --cov-report=html --cov-context=test tests/python/sdk -k 'test_schema_detection'
===================================== test session starts ======================================
platform linux -- Python 3.9.15, pytest-6.2.5, py-1.11.0, pluggy-1.0.0 -- /home/%USER%/Development/cvat/.env/bin/python3.9
cachedir: .pytest_cache
rootdir: /home/%USER%/Development/cvat/tests/python, configfile: pytest.ini
plugins: cov-4.0.0, xdist-3.0.2
collected 79 items / 74 deselected / 5 selected                                                

tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[http:/] WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "http_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "https_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
WARN[0000] The "no_proxy" variable is not set. Defaulting to a blank string. 
[+] Running 15/0
[+] Running 15/17-cvat_redis-1            Running                                          0.0s
[+] Running 15/17-cvat_redis-1            Running                                          0.0s
[+] Running 15/17-cvat_redis-1            Running                                          0.0s
[+] Running 15/17-cvat_redis-1            Running                                          0.0s
[+] Running 16/17-cvat_redis-1            Running                                          0.0s
[+] Running 17/17-cvat_redis-1            Running                                          0.0s
 ⠿ Container test-cvat_redis-1            Running                                          0.0s
 ⠿ Container test-traefik-1               Running                                          0.0s
 ⠿ Container test-webhook_receiver-1      Running                                          0.0s
 ⠿ Container test-cvat_db-1               Running                                          0.0s
 ⠿ Container test-cvat_opa-1              Running                                          0.0s
 ⠿ Container test-elasticsearch-1         Running                                          0.0s
 ⠿ Container test-minio-1                 Running                                          0.0s
 ⠿ Container test-logstash-1              Running                                          0.0s
 ⠿ Container test-cvat_worker_low-1       Running                                          0.0s
 ⠿ Container test-kibana-1                Running                                          0.0s
 ⠿ Container test-mc-1                    Started                                          0.7s
 ⠿ Container test-cvat_utils-1            Running                                          0.0s
 ⠿ Container test-cvat_worker_default-1   Runnin...                                        0.0s
 ⠿ Container test-cvat_worker_webhooks-1  Runni...                                         0.0s
 ⠿ Container test-cvat_server-1           Running                                          0.0s
 ⠿ Container test-cvat_ui-1               Running                                          0.0s
 ⠿ Container test-cvat_kibana_setup-1     Started                                          0.6s
PASSED [ 20%]
tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[https:/] PASSED [ 40%]
tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[] FAILED     [ 60%]
tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[None] FAILED [ 80%]
tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[ftp:/] FAILED [100%]

=========================================== FAILURES ===========================================
_________________________ TestSchemaDetection.test_schema_detection[] __________________________

self = <sdk.test_schema.TestSchemaDetection object at 0x7f05bdf07940>, get_schema = ''

    @pytest.mark.parametrize("get_schema", ['http://', 'https://', '', None, 'ftp://'])
    def test_schema_detection(self, get_schema):
    
        host, port = BASE_URL.split("://", maxsplit=1)[1].rsplit(":", maxsplit=1)
    
        if get_schema is not None:
            try:
                client = make_client(host=get_schema + host, port=int(port))
            except InvalidHostException:
                client = Client(BASE_URL)  # changing to another instance creation method to get urls
        else:
            raise InvalidHostException()
    
>       assert sc.detect_schema(client.api_map.host) == get_schema + host + ":" + port
E       AssertionError: assert 'http://localhost:8080' == 'localhost:8080'
E         - localhost:8080
E         + http://localhost:8080
E         ? +++++++

tests/python/sdk/test_schema.py:27: AssertionError
-------------------------------------- Captured log call ---------------------------------------
WARNING  urllib3.connectionpool:connectionpool.py:812 Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1129)'))': /api/schema/
WARNING  urllib3.connectionpool:connectionpool.py:812 Retrying (Retry(total=1, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1129)'))': /api/schema/
WARNING  urllib3.connectionpool:connectionpool.py:812 Retrying (Retry(total=0, connect=None, read=None, redirect=None, status=None)) after connection broken by 'SSLError(SSLCertVerificationError(1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: self signed certificate (_ssl.c:1129)'))': /api/schema/
_______________________ TestSchemaDetection.test_schema_detection[None] ________________________

self = <sdk.test_schema.TestSchemaDetection object at 0x7f05bdd9adf0>, get_schema = None

    @pytest.mark.parametrize("get_schema", ['http://', 'https://', '', None, 'ftp://'])
    def test_schema_detection(self, get_schema):
    
        host, port = BASE_URL.split("://", maxsplit=1)[1].rsplit(":", maxsplit=1)
    
        if get_schema is not None:
            try:
                client = make_client(host=get_schema + host, port=int(port))
            except InvalidHostException:
                client = Client(BASE_URL)  # changing to another instance creation method to get urls
        else:
>           raise InvalidHostException()
E           cvat_sdk.core.exceptions.InvalidHostException

tests/python/sdk/test_schema.py:25: InvalidHostException
______________________ TestSchemaDetection.test_schema_detection[ftp://] _______________________

self = <sdk.test_schema.TestSchemaDetection object at 0x7f05bdd9a6a0>, get_schema = 'ftp://'

    @pytest.mark.parametrize("get_schema", ['http://', 'https://', '', None, 'ftp://'])
    def test_schema_detection(self, get_schema):
    
        host, port = BASE_URL.split("://", maxsplit=1)[1].rsplit(":", maxsplit=1)
    
        if get_schema is not None:
            try:
                client = make_client(host=get_schema + host, port=int(port))
            except InvalidHostException:
                client = Client(BASE_URL)  # changing to another instance creation method to get urls
        else:
            raise InvalidHostException()
    
>       assert sc.detect_schema(client.api_map.host) == get_schema + host + ":" + port
E       AssertionError: assert 'http://localhost:8080' == 'ftp://localhost:8080'
E         - ftp://localhost:8080
E         ? ^
E         + http://localhost:8080
E         ? ^^

tests/python/sdk/test_schema.py:27: AssertionError

---------- coverage: platform linux, python 3.9.15-final-0 -----------
Coverage HTML written to dir htmlcov

=================================== short test summary info ====================================
FAILED tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[] - Assert...
FAILED tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[None] - cv...
FAILED tests/python/sdk/test_schema.py::TestSchemaDetection::test_schema_detection[ftp:/] - A...
========================= 3 failed, 2 passed, 74 deselected in 16.04s ==========================

```


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
