### PR TITLE
Fix TUS offset queries in production environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ non-ascii paths while adding files from "Connected file share" (issue #4428)
 - Create manifest with cvat/server docker container command (<https://github.com/opencv/cvat/pull/5172>)
 - Cannot assign a resource to a user who has an organization (<https://github.com/opencv/cvat/pull/5218>)
 - Oriented bounding boxes broken with COCO format ss(<https://github.com/opencv/cvat/pull/5219>)
+- Fixed upload resumption in production environments
+  (<https://github.com/opencv/cvat/issues/4839>)
 
 ### Security
 - TDB

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -29,6 +29,8 @@ class Uploader:
     Implements common uploading protocols
     """
 
+    _CHUNK_SIZE = 10 * 2**20
+
     def __init__(self, client: Client):
         self._client = client
 
@@ -248,8 +250,6 @@ class Uploader:
         return MyTusUploader(client=client, api_client=api_client, **kwargs)
 
     def _upload_file_data_with_tus(self, url, filename, *, meta=None, pbar=None, logger=None):
-        CHUNK_SIZE = 10 * 2**20
-
         file_size = os.stat(filename).st_size
         if pbar is None:
             pbar = NullProgressReporter()
@@ -262,7 +262,7 @@ class Uploader:
                 url=url.rstrip("/") + "/",
                 metadata=meta,
                 file_stream=input_file_with_progress,
-                chunk_size=CHUNK_SIZE,
+                chunk_size=Uploader._CHUNK_SIZE,
                 log_func=logger,
             )
             tus_uploader.upload()

--- a/mod_wsgi.conf
+++ b/mod_wsgi.conf
@@ -2,3 +2,15 @@ LoadModule xsendfile_module /usr/lib/apache2/modules/mod_xsendfile.so
 XSendFile On
 XSendFilePath ${HOME}/data/
 XSendFilePath ${HOME}/static/
+
+# The presence of an Apache output filter (mod_xsendfile) causes mod_wsgi
+# to internally convert HEAD requests to GET before passing them to the
+# application, for reasons explained here:
+# <http://blog.dscpl.com.au/2009/10/wsgi-issues-with-http-head-requests.html>.
+# However, we need HEAD requests passed through as-is, because the TUS
+# protocol requires them. It should be safe to disable this functionality in
+# our case, because mod_xsendfile does not examine the response body (it
+# either passes it through or discards it entirely based on the headers),
+# so it shouldn't matter whether the application omits the body in response
+# to a HEAD request.
+WSGIMapHEADToGET Off

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -12,6 +12,7 @@ import pytest
 from cvat_sdk import Client, models
 from cvat_sdk.api_client import exceptions
 from cvat_sdk.core.proxies.tasks import ResourceType, Task
+from cvat_sdk.core.uploading import Uploader
 from PIL import Image
 
 from shared.utils.helpers import generate_image_files
@@ -279,7 +280,7 @@ class TestTaskUsecases:
         assert "100%" in pbar_out.getvalue().strip("\r").split("\r")[-1]
         assert self.stdout.getvalue() == ""
 
-    def test_can_create_from_backup(self, fxt_new_task: Task, fxt_backup_file: Path):
+    def _test_can_create_from_backup(self, fxt_new_task: Task, fxt_backup_file: Path):
         pbar_out = io.StringIO()
         pbar = make_pbar(file=pbar_out)
 
@@ -291,6 +292,15 @@ class TestTaskUsecases:
         assert "imported sucessfully" in self.logger_stream.getvalue()
         assert "100%" in pbar_out.getvalue().strip("\r").split("\r")[-1]
         assert self.stdout.getvalue() == ""
+
+    def test_can_create_from_backup(self, fxt_new_task: Task, fxt_backup_file: Path):
+        self._test_can_create_from_backup(fxt_new_task, fxt_backup_file)
+
+    def test_can_create_from_backup_in_chunks(
+        self, monkeypatch: pytest.MonkeyPatch, fxt_new_task: Task, fxt_backup_file: Path
+    ):
+        monkeypatch.setattr(Uploader, "_CHUNK_SIZE", 100)
+        self._test_can_create_from_backup(fxt_new_task, fxt_backup_file)
 
     def test_can_get_jobs(self, fxt_new_task: Task):
         jobs = fxt_new_task.get_jobs()


### PR DESCRIPTION
Previously, `mod_wsgi` would convert `HEAD` requests into `GET`, which would be rejected, so clients were unable to resume an upload that failed midway through.

To make use of this, update the SDK code to enable upload resumption.

<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Fixes #4839.

### How has this been tested?
SDK unit tests. For the old server workaround, I manually disabled the fix and checked that the tests still pass.
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
