### PR TITLE
Fix ESLint errors in `cvat-data.ts`

### DIFF
--- a/cvat-data/src/ts/cvat-data.ts
+++ b/cvat-data/src/ts/cvat-data.ts
@@ -2,23 +2,23 @@
 //
 // SPDX-License-Identifier: MIT
 
-const { Mutex } = require('async-mutex');
+import { Mutex } from 'async-mutex';
 // eslint-disable-next-line max-classes-per-file
-const { MP4Reader, Bytestream } = require('./3rdparty/mp4');
-const ZipDecoder = require('./unzip_imgs.worker');
-const H264Decoder = require('./3rdparty/Decoder.worker');
+import { MP4Reader, Bytestream } from './3rdparty/mp4';
+import ZipDecoder from './unzip_imgs.worker';
+import H264Decoder from './3rdparty/Decoder.worker';
 
-const BlockType = Object.freeze({
+export const BlockType = Object.freeze({
     MP4VIDEO: 'mp4video',
     ARCHIVE: 'archive',
 });
 
-const DimensionType = Object.freeze({
+export const DimensionType = Object.freeze({
     DIM_3D: '3d',
     DIM_2D: '2d',
 });
 
-class FrameProvider {
+export class FrameProvider {
     constructor(
         blockType,
         blockSize,
@@ -373,9 +373,3 @@ class FrameProvider {
         return [...this._blocksRanges].sort((a, b) => a.split(':')[0] - b.split(':')[0]);
     }
 }
-
-module.exports = {
-    FrameProvider,
-    BlockType,
-    DimensionType,
-};

--- a/cvat-data/tsconfig.json
+++ b/cvat-data/tsconfig.json
@@ -9,5 +9,5 @@
       "noEmit": true,
       "baseUrl": "src",
     },
-    "include": ["src/*.ts"]
+    "include": ["src/ts/*.ts"]
 }


### PR DESCRIPTION
By converting it into an ES6 module.  Also, fix `tsconfig.json` so that ESLint knows that the file is actually in the project.

<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I checked that viewing frames in the UI still works.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
