### PR TITLE
Improved UX of user logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,7 @@ non-ascii paths while adding files from "Connected file share" (issue #4428)
 - Job assignee can not resolve an issue (<https://github.com/opencv/cvat/pull/5167>)
 - Create manifest with cvat/server docker container command (<https://github.com/opencv/cvat/pull/5172>)
 - Cannot assign a resource to a user who has an organization (<https://github.com/opencv/cvat/pull/5218>)
+- Logs and annotations are not saved when logout from a job page (<https://github.com/opencv/cvat/pull/5266>)
 - Oriented bounding boxes broken with COCO format ss(<https://github.com/opencv/cvat/pull/5219>)
 - Fixed upload resumption in production environments
   (<https://github.com/opencv/cvat/issues/4839>)

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.43.1",
+  "version": "1.43.2",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/cvat-app.tsx
+++ b/cvat-ui/src/components/cvat-app.tsx
@@ -449,7 +449,7 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
                         <Route exact path='/auth/email-confirmation' component={EmailConfirmationPage} />
 
                         <Redirect
-                            to={location.pathname.length > 1 && !location.pathname.includes('/auth/logout') ? `/auth/login/?next=${location.pathname}` : '/auth/login'}
+                            to={location.pathname.length > 1 ? `/auth/login?next=${location.pathname}` : '/auth/login'}
                         />
                     </Switch>
                 </GlobalErrorBoundary>

--- a/cvat-ui/src/components/cvat-app.tsx
+++ b/cvat-ui/src/components/cvat-app.tsx
@@ -14,6 +14,7 @@ import Spin from 'antd/lib/spin';
 import Text from 'antd/lib/typography/Text';
 import 'antd/dist/antd.css';
 
+import LogoutComponent from 'components/logout-component';
 import LoginPageContainer from 'containers/login-page/login-page';
 import LoginWithTokenComponent from 'components/login-with-token/login-with-token';
 import RegisterPageContainer from 'containers/register-page/register-page';
@@ -373,6 +374,7 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
                                     <ShortcutsDialog />
                                     <GlobalHotKeys keyMap={subKeyMap} handlers={handlers}>
                                         <Switch>
+                                            <Route exact path='/auth/logout' component={LogoutComponent} />
                                             <Route exact path='/projects' component={ProjectsPageComponent} />
                                             <Route exact path='/projects/create' component={CreateProjectPageComponent} />
                                             <Route exact path='/projects/:id' component={ProjectPageComponent} />
@@ -447,7 +449,7 @@ class CVATApplication extends React.PureComponent<CVATAppProps & RouteComponentP
                         <Route exact path='/auth/email-confirmation' component={EmailConfirmationPage} />
 
                         <Redirect
-                            to={location.pathname.length > 1 ? `/auth/login/?next=${location.pathname}` : '/auth/login'}
+                            to={location.pathname.length > 1 && !location.pathname.includes('/auth/logout') ? `/auth/login/?next=${location.pathname}` : '/auth/login'}
                         />
                     </Switch>
                 </GlobalErrorBoundary>

--- a/cvat-ui/src/components/header/header.tsx
+++ b/cvat-ui/src/components/header/header.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corp
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -152,7 +152,6 @@ function HeaderContainer(props: Props): JSX.Element {
         changePasswordFetching,
         settingsDialogShown,
         switchSettingsShortcut,
-        onLogout,
         switchSettingsDialog,
         switchChangePasswordDialog,
         renderChangePasswordItem,
@@ -364,7 +363,9 @@ function HeaderContainer(props: Props): JSX.Element {
             <Menu.Item
                 key='logout'
                 icon={logoutFetching ? <LoadingOutlined /> : <LogoutOutlined />}
-                onClick={onLogout}
+                onClick={() => {
+                    history.push('/auth/logout');
+                }}
                 disabled={logoutFetching}
             >
                 Logout

--- a/cvat-ui/src/components/logout-component.tsx
+++ b/cvat-ui/src/components/logout-component.tsx
@@ -5,15 +5,20 @@
 import Spin from 'antd/lib/spin';
 import React, { useEffect } from 'react';
 import { useDispatch } from 'react-redux';
+import { useHistory } from 'react-router';
 
 import { saveLogsAsync } from 'actions/annotation-actions';
 import { logoutAsync } from 'actions/auth-actions';
 
 function LogoutComponent(): JSX.Element {
     const dispatch = useDispatch();
+    const history = useHistory();
+
     useEffect(() => {
         dispatch(saveLogsAsync()).then(() => {
-            dispatch(logoutAsync());
+            dispatch(logoutAsync()).then(() => {
+                history.goBack();
+            });
         });
     }, []);
 

--- a/cvat-ui/src/components/logout-component.tsx
+++ b/cvat-ui/src/components/logout-component.tsx
@@ -1,0 +1,27 @@
+// Copyright (C) 2022 CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+import Spin from 'antd/lib/spin';
+import React, { useEffect } from 'react';
+import { useDispatch } from 'react-redux';
+
+import { saveLogsAsync } from 'actions/annotation-actions';
+import { logoutAsync } from 'actions/auth-actions';
+
+function LogoutComponent(): JSX.Element {
+    const dispatch = useDispatch();
+    useEffect(() => {
+        dispatch(saveLogsAsync()).then(() => {
+            dispatch(logoutAsync());
+        });
+    }, []);
+
+    return (
+        <div className='cvat-logout-page cvat-spinner-container'>
+            <Spin className='cvat-spinner' />
+        </div>
+    );
+}
+
+export default React.memo(LogoutComponent);

--- a/cvat-ui/src/utils/redux.ts
+++ b/cvat-ui/src/utils/redux.ts
@@ -1,4 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -18,6 +19,6 @@ export function createAction<T extends string, P>(type: T, payload?: P): Action<
 
 export type ActionUnion<A extends ActionCreatorsMapObject> = ReturnType<A[keyof A]>;
 
-export type ThunkAction<R = {}, A extends Action = AnyAction> = _ThunkAction<R, CombinedState, {}, A>;
+export type ThunkAction<R = Promise<void>, A extends Action = AnyAction> = _ThunkAction<R, CombinedState, {}, A>;
 
 export type ThunkDispatch<E = {}, A extends Action = AnyAction> = _ThunkDispatch<CombinedState, E, A>;

--- a/tests/cypress/integration/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/integration/actions_users/issue_1810_login_logout.js
@@ -1,4 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
+// Copyright (C) 2022 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 

--- a/tests/cypress/integration/actions_users/issue_1810_login_logout.js
+++ b/tests/cypress/integration/actions_users/issue_1810_login_logout.js
@@ -46,7 +46,7 @@ context('When clicking on the Logout button, get the user session closed.', () =
                     .trigger('mouseover', { which: 1 });
             });
             cy.get('span[aria-label="logout"]').click();
-            cy.url().should('include', `/auth/login/?next=/tasks/${taskId}`);
+            cy.url().should('include', `/auth/login?next=/tasks/${taskId}`);
             // login to task
             login(Cypress.env('user'), Cypress.env('password'));
             cy.url().should('include', `/tasks/${taskId}`).and('not.include', '/auth/login');


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved #5265
Implemented by logging out via a component which saves logs
Also the component has dedicated URL ``/auth/logout`` and when a user goes there, the browser suggests to save unsaved changes on annotation view. 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
