### PR TITLE
QA Automation test task - added a simple search test

### DIFF
--- a/tests/cypress/integration/actions_users/case_9999_new_search.js
+++ b/tests/cypress/integration/actions_users/case_9999_new_search.js
@@ -1,0 +1,40 @@
+// Copyright (C) 2021-2022 Intel Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+context('Search a task', () => {
+    const caseId = '39';
+    const labelName = `Case ${caseId}`;
+    const taskName = `New annotation task for ${labelName}`;
+    const attrName = `Attr for ${labelName}`;
+    const textDefaultValue = 'Some default value for type Text';
+    const imageFileName = `image_${labelName.replace(' ', '_').toLowerCase()}`;
+    const archiveName = `${imageFileName}.zip`;
+
+    function searchTask(par) {
+        cy.get('[placeholder="Search ..."]').type(`${par}{Enter}`);
+    }
+
+    before(() => {
+        cy.visit('auth/login');
+        cy.login();
+        cy.goToTaskList();
+        cy.createAnnotationTask(taskName, labelName, attrName, textDefaultValue, archiveName);
+    });
+
+    after(() => {
+        cy.visit('/tasks');
+        cy.deleteTask(taskName);
+        cy.logout();
+    });
+
+    describe('Checking the search function', () => {
+        it('Search a task by caseId', () => {
+            cy.goToTaskList();
+            searchTask(caseId);
+            cy.openTask(taskName);
+        });
+    });
+});


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
