### PR TITLE
Replace unintended Cyrillic C letters with Latin C

### DIFF
--- a/cvat-ui/src/reducers/shortcuts-reducer.ts
+++ b/cvat-ui/src/reducers/shortcuts-reducer.ts
@@ -325,7 +325,7 @@ const defaultKeyMap = ({
     SWITCH_TOOLS_BLOCKER_STATE: {
         name: 'Switch algorithm blocker',
         description: 'Postpone running the algorithm for interaction tools',
-        sequences: ['сtrl'],
+        sequences: ['ctrl'],
         action: 'keydown',
         applicable: [DimensionType.DIM_2D],
     },

--- a/site/content/en/docs/contributing/setup-additional-components.md
+++ b/site/content/en/docs/contributing/setup-additional-components.md
@@ -140,7 +140,7 @@ Server = nuclio
 </details>
 
 ## Run Cypress tests
-- Install Сypress as described in the [documentation](https://docs.cypress.io/guides/getting-started/installing-cypress.html).
+- Install Cypress as described in the [documentation](https://docs.cypress.io/guides/getting-started/installing-cypress.html).
 - Run cypress tests:
 ```bash
     cd <cvat_local_repository>/tests

--- a/site/content/en/docs/manual/advanced/annotation-with-polygons/edit-polygon.md
+++ b/site/content/en/docs/manual/advanced/annotation-with-polygons/edit-polygon.md
@@ -8,7 +8,7 @@ To edit a polygon you have to click on it while holding `Shift`, it will open th
 
 - In the editor you can create new points or delete part of a polygon by closing the line on another point.
 - When `Intelligent polygon cropping` option is activated in the settings,
-  СVAT considers two criteria to decide which part of a polygon should be cut off during automatic editing.
+  CVAT considers two criteria to decide which part of a polygon should be cut off during automatic editing.
   - The first criteria is a number of cut points.
   - The second criteria is a length of a cut curve.
 

--- a/site/content/en/docs/manual/advanced/export-import-datasets.md
+++ b/site/content/en/docs/manual/advanced/export-import-datasets.md
@@ -11,11 +11,11 @@ description: 'This section explains how to download and upload datasets
 You can export a dataset to a project, task or job.
 
 1. To download the latest annotations, you have to save all changes first.
-   Сlick the `Save` button. There is a `Ctrl+S` shortcut to save annotations quickly.
+   Click the `Save` button. There is a `Ctrl+S` shortcut to save annotations quickly.
 
    ![](/images/image028.jpg)
 
-1. After that, сlick the `Menu` button.
+1. After that, click the `Menu` button.
    Exporting and importing of task and project datasets takes place through the `Action` menu.
 1. Press the `Export task dataset` button.
 

--- a/site/content/en/docs/manual/basics/3d-object-annotation-basics.md
+++ b/site/content/en/docs/manual/basics/3d-object-annotation-basics.md
@@ -40,7 +40,7 @@ You can place an object only near the dots of the point cloud.
 
   ![](/images/gif026_carla_town3.gif)
 
-To adjust the size precisely, you need to edit the cuboid on the projections, for this change `Сursor` on control
+To adjust the size precisely, you need to edit the cuboid on the projections, for this change `Cursor` on control
 sidebar or press `Esc`. In each projection you can:
 
 Move the object in the projection plane - to do this, hover over the object,

--- a/site/content/en/docs/manual/basics/objects-sidebar.md
+++ b/site/content/en/docs/manual/basics/objects-sidebar.md
@@ -55,7 +55,7 @@ The action menu contains:
 - `Create object URL` - puts a link to an object on the clipboard.
   After you open the link, this object will be filtered.
 - `Make a copy`- copies an object. The keyboard shortcut is `Ctrl + C` `Ctrl + V`.
-- `Propagate` - Сopies the form to several frames,
+- `Propagate` - Copies the form to several frames,
   invokes a dialog box in which you can specify the number of copies
   or the frame onto which you want to copy the object. The keyboard shortcut `Ctrl + B`.
 

--- a/tests/cypress/integration/actions_projects_models/case_95_move_task_to_project.js
+++ b/tests/cypress/integration/actions_projects_models/case_95_move_task_to_project.js
@@ -21,7 +21,7 @@ context('Move a task to a project.', { browser: '!firefox' }, () => {
         name3d: `Case ${caseID} 3D`,
         label3d: 'Bus',
         attrName3d: 'Type',
-        attrValue3d: 'Сity bus',
+        attrValue3d: 'City bus',
     };
 
     const project = {
@@ -50,7 +50,9 @@ context('Move a task to a project.', { browser: '!firefox' }, () => {
         cy.imageGenerator(imagesFolder, imageFileName, width, height, color, posX, posY, task.name, imagesCount);
         cy.createZipArchive(directoryToArchive, archivePath);
         cy.goToTaskList();
-        cy.createAnnotationTask(task.nameSecond, task.labelSecond, task.attrNameSecons, task.attrValueSecond, archiveName);
+        cy.createAnnotationTask(
+            task.nameSecond, task.labelSecond, task.attrNameSecons, task.attrValueSecond, archiveName,
+        );
         cy.createAnnotationTask(task.name3d, task.label3d, task.attrName3d, task.attrValue3d, archiveName3d);
     });
 

--- a/tests/cypress/integration/actions_tasks3/case_18_filters_functionality.js
+++ b/tests/cypress/integration/actions_tasks3/case_18_filters_functionality.js
@@ -306,7 +306,7 @@ context('Filters functionality.', () => {
         });
 
         it('Verify to show all filters', () => {
-            cy.сheckFiltersModalOpened();
+            cy.checkFiltersModalOpened();
             cy.get('.recently-used-wrapper').trigger('mouseover');
             cy.get('.ant-dropdown')
                 .not('.ant-dropdown-hidden')

--- a/tests/cypress/integration/actions_users/registration_involved/issue_1599_pl_user_registration.js
+++ b/tests/cypress/integration/actions_users/registration_involved/issue_1599_pl_user_registration.js
@@ -6,7 +6,7 @@
 
 context('Issue 1599 (Polish alphabet).', () => {
     const firstName = 'Świętobor';
-    const lastName = 'Сzcić';
+    const lastName = 'Czcić';
     const userName = 'Testuser_pl';
     const email = 'Testuser_pl@local.local';
     const password = 'Qwerty123!';

--- a/tests/cypress/integration/issues_prs/issue_1886_point_coordinates_not_duplicated.js
+++ b/tests/cypress/integration/issues_prs/issue_1886_point_coordinates_not_duplicated.js
@@ -6,13 +6,13 @@
 
 import { taskName, advancedConfigurationParams, labelName } from '../../support/const';
 
-context("Point coordinates are not duplicated while polygon's interpolation.", () => {
+context('Point coordinates are not duplicated while polygon\'s interpolation.', () => {
     const issueId = '1886';
-    let pointsСoordinates = [];
+    const pointsCoordinates = [];
     const createPolygonTrack = {
         reDraw: false,
         type: 'Track',
-        labelName: labelName,
+        labelName,
         pointsMap: [
             { x: 300, y: 450 },
             { x: 400, y: 450 },
@@ -49,15 +49,15 @@ context("Point coordinates are not duplicated while polygon's interpolation.", (
             });
             cy.get('#cvat_canvas_shape_1')
                 .should('have.prop', 'animatedPoints')
-                .then(($pointsСoordinates) => {
-                    for (let i of $pointsСoordinates) {
-                        pointsСoordinates.push(`${i.x}, ${i.y}`);
+                .then(($pointsCoordinates) => {
+                    for (const i of $pointsCoordinates) {
+                        pointsCoordinates.push(`${i.x}, ${i.y}`);
                     }
                 });
         });
         it('The coordinates of the points are not duplicated', () => {
-            for (let i = 0; i < pointsСoordinates.length - 1; i++) {
-                cy.expect(pointsСoordinates[i]).not.equal(pointsСoordinates[i + 1]);
+            for (let i = 0; i < pointsCoordinates.length - 1; i++) {
+                cy.expect(pointsCoordinates[i]).not.equal(pointsCoordinates[i + 1]);
             }
         });
     });

--- a/tests/cypress/integration/issues_prs/pr_2203_error_cannot_read_property_at_saving_job.js
+++ b/tests/cypress/integration/issues_prs/pr_2203_error_cannot_read_property_at_saving_job.js
@@ -6,7 +6,7 @@
 
 import { taskName, labelName } from '../../support/const';
 
-context('Check error сannot read property at saving job', () => {
+context('Check error cannot read property at saving job', () => {
     const prId = '2203';
     const createRectangleShape2Points = {
         points: 'By 2 Points',

--- a/tests/cypress/integration/issues_prs2/issue_1391_delete_point.js
+++ b/tests/cypress/integration/issues_prs2/issue_1391_delete_point.js
@@ -8,11 +8,11 @@ import { taskName, labelName } from '../../support/const';
 
 context('When delete a point, the required point is deleted.', () => {
     const issueId = '1391';
-    let pointsСoordinatesBeforeDeletePoint = [];
-    let pointsСoordinatesAfterDeletePoint = [];
+    const pointsCoordinatesBeforeDeletePoint = [];
+    const pointsCoordinatesAfterDeletePoint = [];
     const createPolylinesShape = {
         type: 'Shape',
-        labelName: labelName,
+        labelName,
         pointsMap: [
             { x: 309, y: 250 },
             { x: 309, y: 350 },
@@ -34,9 +34,9 @@ context('When delete a point, the required point is deleted.', () => {
         it('Get points coordinates from created polyline', () => {
             cy.get('#cvat_canvas_shape_1')
                 .should('have.prop', 'animatedPoints')
-                .then(($pointsСoordinates) => {
-                    for (let i of $pointsСoordinates) {
-                        pointsСoordinatesBeforeDeletePoint.push(`${i.x}, ${i.y}`);
+                .then(($pointsCoordinates) => {
+                    for (const i of $pointsCoordinates) {
+                        pointsCoordinatesBeforeDeletePoint.push(`${i.x}, ${i.y}`);
                     }
                 });
         });
@@ -59,15 +59,15 @@ context('When delete a point, the required point is deleted.', () => {
         it('Get points coordinates from turned out polyline', () => {
             cy.get('#cvat_canvas_shape_1')
                 .should('have.prop', 'animatedPoints')
-                .then(($pointsСoordinates) => {
-                    for (let i of $pointsСoordinates) {
-                        pointsСoordinatesAfterDeletePoint.push(`${i.x}, ${i.y}`);
+                .then(($pointsCoordinates) => {
+                    for (const i of $pointsCoordinates) {
+                        pointsCoordinatesAfterDeletePoint.push(`${i.x}, ${i.y}`);
                     }
                 });
         });
         it('Coordinate of second point before delete not in coordinates array after delete', () => {
-            cy.get(pointsСoordinatesBeforeDeletePoint).then((point) => {
-                cy.expect(pointsСoordinatesAfterDeletePoint).not.contain(point[1]);
+            cy.get(pointsCoordinatesBeforeDeletePoint).then((point) => {
+                cy.expect(pointsCoordinatesAfterDeletePoint).not.contain(point[1]);
             });
         });
     });

--- a/tests/cypress/support/commands_filters_feature.js
+++ b/tests/cypress/support/commands_filters_feature.js
@@ -4,7 +4,7 @@
 
 /// <reference types="cypress" />
 
-Cypress.Commands.add('сheckFiltersModalOpened', () => {
+Cypress.Commands.add('checkFiltersModalOpened', () => {
     cy.document().then((doc) => {
         const filterModal = Array.from(doc.querySelectorAll('.cvat-filters-modal-visible'));
         if (filterModal.length === 0) {
@@ -34,28 +34,28 @@ Cypress.Commands.add('collectRuleID', () => {
 });
 
 Cypress.Commands.add('clearFilters', () => {
-    cy.сheckFiltersModalOpened();
+    cy.checkFiltersModalOpened();
     cy.contains('button', 'Clear filters').click();
     cy.get('.cvat-filters-modal-visible').should('not.exist');
     cy.get('.cvat-filters-modal').should('not.exist');
 });
 
 Cypress.Commands.add('addFiltersGroup', (groupIndex) => {
-    cy.сheckFiltersModalOpened();
+    cy.checkFiltersModalOpened();
     cy.collectGroupID().then((groupIdIndex) => {
         cy.get(`[data-id="${groupIdIndex[groupIndex]}"]`).contains('button', 'Add group').first().click();
     });
 });
 
 Cypress.Commands.add('addFiltersRule', (groupIndex) => {
-    cy.сheckFiltersModalOpened();
+    cy.checkFiltersModalOpened();
     cy.collectGroupID().then((groupIdIndex) => {
         cy.get(`[data-id="${groupIdIndex[groupIndex]}"]`).contains('button', 'Add rule').click();
     });
 });
 
 Cypress.Commands.add('setGroupCondition', (groupIndex, condition) => {
-    cy.сheckFiltersModalOpened();
+    cy.checkFiltersModalOpened();
     cy.collectGroupID().then((groupIdIndex) => {
         cy.get(`[data-id="${groupIdIndex[groupIndex]}"]`).within(() => {
             cy.get('.group--header').first().trigger('mouseover');
@@ -69,7 +69,7 @@ Cypress.Commands.add(
     ({
         groupIndex, ruleIndex, field, operator, valueSource, value, label, labelAttr, submit,
     }) => {
-        cy.сheckFiltersModalOpened();
+        cy.checkFiltersModalOpened();
         cy.collectGroupID().then((groupIdIndex) => {
             cy.collectRuleID().then((ruleIdIndex) => {
                 cy.get(`[data-id="${groupIdIndex[groupIndex]}"]`)
@@ -132,7 +132,7 @@ Cypress.Commands.add(
 );
 
 Cypress.Commands.add('selectFilterValue', (filterValue) => {
-    cy.сheckFiltersModalOpened();
+    cy.checkFiltersModalOpened();
     cy.get('.recently-used-wrapper').trigger('mouseover');
     cy.get('.ant-dropdown')
         .not('.ant-dropdown-hidden')


### PR DESCRIPTION
The only change in production code is the one in `shortcuts-reducer.ts`.  It makes no functional difference, however, because the shortcut in question is not handled by the regular shortcut mechanism; the control key is handled separately in `interactionHandler.ts`, while the string "ctrl" in `shortcuts-reducer.ts` is only used for display purposes.

Fix ESLint errors in altered files, as well.

<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
These Cyrillic Cs interfere with searching and can cause confusion.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I'm relying on GitHub Actions.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
