### PR TITLE
Added cypress test to create a task with only bounding boxes

### DIFF
--- a/cvat-ui/src/components/labels-editor/label-form.tsx
+++ b/cvat-ui/src/components/labels-editor/label-form.tsx
@@ -441,6 +441,7 @@ export default class LabelForm extends React.Component<Props> {
                 <Input
                     ref={this.inputNameRef}
                     placeholder='Label name'
+                    className='cvat-label-name-input'
                     onKeyUp={(event): void => {
                         if (event.key === 'Escape' || event.key === 'Esc' || event.keyCode === 27) {
                             onCancel();
@@ -464,7 +465,7 @@ export default class LabelForm extends React.Component<Props> {
 
         return (
             <Form.Item name='type' initialValue={value}>
-                <Select disabled={isSkeleton} showSearch={false}>
+                <Select className='cvat-label-type-input' disabled={isSkeleton} showSearch={false}>
                     {isSkeleton && (
                         <Select.Option
                             className='cvat-label-type-option-skeleton'

--- a/tests/cypress/integration/actions_tasks/task_rectangles_only.js
+++ b/tests/cypress/integration/actions_tasks/task_rectangles_only.js
@@ -1,0 +1,100 @@
+// Copyright (C) 2022 CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+/// <reference types="cypress" />
+
+context('Creating a task with only bounding boxes', () => {
+    const taskName = 'A task with bounding boxes';
+    const imagesFolder = `cypress/fixtures/${taskName}`;
+    const archiveName = `${taskName}.zip`;
+    const archivePath = `cypress/fixtures/${archiveName}`;
+    const imageParams = {
+        width: 800,
+        height: 800,
+        color: 'gray',
+        textOffset: { x: 10, y: 10 },
+        text: 'skeletons pipeline',
+        count: 1,
+    };
+    const labelSpecification = {
+        name: 'car',
+        type: 'rectangle',
+    };
+    let taskID = null;
+
+    before(() => {
+        cy.visit('auth/login');
+        cy.login();
+        cy.imageGenerator(
+            imagesFolder,
+            taskName,
+            imageParams.width,
+            imageParams.height,
+            imageParams.color,
+            imageParams.textOffset.x,
+            imageParams.textOffset.y,
+            imageParams.text,
+            imageParams.count,
+        );
+        cy.createZipArchive(imagesFolder, archivePath);
+    });
+
+    after(() => {
+        cy.logout();
+        cy.getAuthKey().then((response) => {
+            const authKey = response.body.key;
+            cy.request({
+                method: 'DELETE',
+                url: `/api/tasks/${taskID}`,
+                headers: {
+                    Authorization: `Token ${authKey}`,
+                },
+            });
+        });
+    });
+
+    describe('Creating a task with only bounding boxes', () => {
+        it('Task created, UI allows to create only bounding boxes', () => {
+            cy.get('.cvat-create-task-dropdown').click();
+            cy.get('.cvat-create-task-button').click({ force: true });
+            cy.url().should('include', '/tasks/create');
+            cy.get('[id="name"]').type(taskName);
+
+            cy.get('.cvat-constructor-viewer-new-item').click();
+            cy.get('[placeholder="Label name"]').type(labelSpecification.name);
+            if (labelSpecification.type) {
+                cy.get('.cvat-label-type-input').click();
+                cy.get('.ant-select-dropdown')
+                    .not('.ant-select-dropdown-hidden')
+                    .within(() => {
+                        cy.get(`.cvat-label-type-option-${labelSpecification.type}`).click();
+                    });
+            }
+            cy.contains('Continue').scrollIntoView().click();
+            cy.get('input[type="file"]').attachFile(archiveName, { subjectType: 'drag-n-drop' });
+
+            cy.intercept('/api/tasks?**').as('taskPost');
+            cy.contains('Submit & Open').scrollIntoView().click();
+
+            cy.wait('@taskPost').then((interception) => {
+                taskID = interception.response.body.id;
+                expect(interception.response.statusCode).to.be.equal(201);
+                cy.intercept(`/api/tasks/${taskID}?**`).as('getTask');
+                cy.wait('@getTask', { timeout: 10000 });
+                cy.get('.cvat-task-jobs-table-row').should('exist').and('be.visible');
+                cy.openJob();
+
+                cy.get('.cvat-canvas-container').should('exist').and('be.visible');
+                cy.get('.cvat-draw-rectangle-control').should('exist').and('be.visible');
+                cy.get('.cvat-draw-polygon-control').should('not.exist');
+                cy.get('.cvat-draw-polyline-control').should('not.exist');
+                cy.get('.cvat-draw-points-control').should('not.exist');
+                cy.get('.cvat-draw-cuboid-control').should('not.exist');
+                cy.get('.cvat-draw-skeleton-control').should('not.exist');
+                cy.get('.cvat-draw-ellipse-control').should('not.exist');
+                cy.get('.cvat-setup-tag-control').should('not.exist');
+            });
+        });
+    });
+});

--- a/tests/cypress/support/commands_filters_feature.js
+++ b/tests/cypress/support/commands_filters_feature.js
@@ -82,8 +82,8 @@ Cypress.Commands.add(
                         .not('.ant-dropdown-hidden')
                         .contains('[role="menuitem"]', field)
                         .trigger('mouseover');
-                    cy.get('.ant-dropdown-menu-sub').contains(label).trigger('mouseover');
-                    cy.contains('.ant-dropdown-menu-item-only-child', labelAttr).click();
+                    cy.get('.ant-dropdown-menu-sub').should('be.visible').contains(label).trigger('mouseover');
+                    cy.contains('.ant-dropdown-menu-item-only-child', labelAttr).should('be.visible').click();
                 } else {
                     cy.get('.ant-dropdown').not('.ant-dropdown-hidden').contains('[role="menuitem"]', field).click();
                 }


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
