### PR TITLE
Fix redundant writing of skeleton annotations (CVAT for images)

### DIFF
--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -2996,11 +2996,13 @@ export class SkeletonTrack extends Track {
         if (updatedOccluded.length) {
             updatedOccluded.forEach((el) => { el.updateFlags.occluded = true; });
             updateElements(updatedOccluded, HistoryActions.CHANGED_OCCLUDED);
+            this.saveOccluded(data.occluded, frame);
         }
 
         if (updatedOutside.length) {
             updatedOutside.forEach((el) => { el.updateFlags.outside = true; });
             updateElements(updatedOutside, HistoryActions.CHANGED_OUTSIDE);
+            this.saveOutside(frame, data.outside);
         }
 
         if (updatedKeyframe.length) {
@@ -3010,16 +3012,19 @@ export class SkeletonTrack extends Track {
             this.saveKeyframe(frame, data.keyframe);
             data.updateFlags.keyframe = false;
             updateElements(updatedKeyframe, HistoryActions.CHANGED_KEYFRAME);
+            this.saveKeyframe(frame, data.keyframe);
         }
 
         if (updatedHidden.length) {
             updatedHidden.forEach((el) => { el.updateFlags.hidden = true; });
             updateElements(updatedHidden, HistoryActions.CHANGED_HIDDEN, 'hidden');
+            this.saveHidden(data.hidden, frame);
         }
 
         if (updatedLock.length) {
             updatedLock.forEach((el) => { el.updateFlags.lock = true; });
             updateElements(updatedLock, HistoryActions.CHANGED_LOCK, 'lock');
+            this.saveLock(data.lock, frame);
         }
 
         const result = Track.prototype.save.call(this, frame, data);


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Fixed #5279 

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
