### PR TITLE
Migrate to using pathlib in most of the SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ from online detectors & interactors) (<https://github.com/opencv/cvat/pull/4543>
 - Allowed trailing slashes in the SDK host address (<https://github.com/opencv/cvat/pull/5057>)
 - Adjusted initial camera position, enabled 'Reset zoom' option for 3D canvas (<https://github.com/opencv/cvat/pull/5395>)
 - Enabled authentication via email (<https://github.com/opencv/cvat/pull/5037>)
+- In the SDK, functions taking paths as strings now also accept path-like objects
+  (<https://github.com/opencv/cvat/pull/5435>)
 
 ### Deprecated
 - TDB

--- a/cvat-sdk/cvat_sdk/core/downloading.py
+++ b/cvat-sdk/cvat_sdk/core/downloading.py
@@ -5,8 +5,8 @@
 
 from __future__ import annotations
 
-import os.path as osp
 from contextlib import closing
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from cvat_sdk.api_client.api_client import Endpoint
@@ -28,7 +28,7 @@ class Downloader:
     def download_file(
         self,
         url: str,
-        output_path: str,
+        output_path: Path,
         *,
         timeout: int = 60,
         pbar: Optional[ProgressReporter] = None,
@@ -39,7 +39,7 @@ class Downloader:
 
         CHUNK_SIZE = 10 * 2**20
 
-        assert not osp.exists(output_path)
+        assert not output_path.exists()
 
         response = self._client.api_client.rest_client.GET(
             url,
@@ -70,7 +70,7 @@ class Downloader:
     def prepare_and_download_file_from_endpoint(
         self,
         endpoint: Endpoint,
-        filename: str,
+        filename: Path,
         *,
         url_params: Optional[Dict[str, Any]] = None,
         query_params: Optional[Dict[str, Any]] = None,

--- a/cvat-sdk/cvat_sdk/core/proxies/tasks.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/tasks.py
@@ -7,10 +7,9 @@ from __future__ import annotations
 import io
 import json
 import mimetypes
-import os
-import os.path as osp
 import shutil
 from enum import Enum
+from pathlib import Path
 from time import sleep
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence
 
@@ -34,7 +33,7 @@ from cvat_sdk.core.uploading import AnnotationUploader, DataUploader, Uploader
 from cvat_sdk.core.utils import filter_dict
 
 if TYPE_CHECKING:
-    from _typeshed import SupportsWrite
+    from _typeshed import StrPath, SupportsWrite
 
 
 class ResourceType(Enum):
@@ -67,7 +66,7 @@ class Task(
     def upload_data(
         self,
         resource_type: ResourceType,
-        resources: Sequence[str],
+        resources: Sequence[StrPath],
         *,
         pbar: Optional[ProgressReporter] = None,
         params: Optional[Dict[str, Any]] = None,
@@ -77,15 +76,8 @@ class Task(
         """
         params = params or {}
 
-        data = {}
-        if resource_type is ResourceType.LOCAL:
-            pass  # handled later
-        elif resource_type is ResourceType.REMOTE:
-            data["remote_files"] = resources
-        elif resource_type is ResourceType.SHARE:
-            data["server_files"] = resources
+        data = {"image_quality": 70}
 
-        data["image_quality"] = 70
         data.update(
             filter_dict(
                 params,
@@ -105,6 +97,15 @@ class Task(
             data["frame_filter"] = f"step={params.get('frame_step')}"
 
         if resource_type in [ResourceType.REMOTE, ResourceType.SHARE]:
+            for resource in resources:
+                if not isinstance(resource, str):
+                    raise TypeError(f"resources: expected instances of str, got {type(resource)}")
+
+            if resource_type is ResourceType.REMOTE:
+                data["remote_files"] = resources
+            elif resource_type is ResourceType.SHARE:
+                data["server_files"] = resources
+
             self.api.create_data(
                 self.id,
                 data_request=models.DataRequest(**data),
@@ -114,12 +115,14 @@ class Task(
                 self.api.create_data_endpoint.path, kwsub={"id": self.id}
             )
 
-            DataUploader(self._client).upload_files(url, resources, pbar=pbar, **data)
+            DataUploader(self._client).upload_files(
+                url, list(map(Path, resources)), pbar=pbar, **data
+            )
 
     def import_annotations(
         self,
         format_name: str,
-        filename: str,
+        filename: StrPath,
         *,
         status_check_period: Optional[int] = None,
         pbar: Optional[ProgressReporter] = None,
@@ -127,6 +130,8 @@ class Task(
         """
         Upload annotations for a task in the specified format (e.g. 'YOLO ZIP 1.0').
         """
+
+        filename = Path(filename)
 
         AnnotationUploader(self._client).upload_file_and_wait(
             self.api.create_annotations_endpoint,
@@ -178,7 +183,7 @@ class Task(
         self,
         frame_ids: Sequence[int],
         *,
-        outdir: str = "",
+        outdir: StrPath = ".",
         quality: str = "original",
         filename_pattern: str = "frame_{frame_id:06d}{frame_ext}",
     ) -> Optional[List[Image.Image]]:
@@ -186,7 +191,9 @@ class Task(
         Download the requested frame numbers for a task and save images as outdir/filename_pattern
         """
         # TODO: add arg descriptions in schema
-        os.makedirs(outdir, exist_ok=True)
+
+        outdir = Path(outdir)
+        outdir.mkdir(exist_ok=True)
 
         for frame_id in frame_ids:
             frame_bytes = self.get_frame(frame_id, quality=quality)
@@ -202,12 +209,12 @@ class Task(
                 im_ext = ".jpg"
 
             outfile = filename_pattern.format(frame_id=frame_id, frame_ext=im_ext)
-            im.save(osp.join(outdir, outfile))
+            im.save(outdir / outfile)
 
     def export_dataset(
         self,
         format_name: str,
-        filename: str,
+        filename: StrPath,
         *,
         pbar: Optional[ProgressReporter] = None,
         status_check_period: Optional[int] = None,
@@ -216,6 +223,9 @@ class Task(
         """
         Download annotations for a task in the specified format (e.g. 'YOLO ZIP 1.0').
         """
+
+        filename = Path(filename)
+
         if include_images:
             endpoint = self.api.retrieve_dataset_endpoint
         else:
@@ -234,7 +244,7 @@ class Task(
 
     def download_backup(
         self,
-        filename: str,
+        filename: StrPath,
         *,
         status_check_period: int = None,
         pbar: Optional[ProgressReporter] = None,
@@ -242,6 +252,8 @@ class Task(
         """
         Download a task backup
         """
+
+        filename = Path(filename)
 
         Downloader(self._client).prepare_and_download_file_from_endpoint(
             self.api.retrieve_backup_endpoint,
@@ -370,7 +382,7 @@ class TasksRepo(
 
     def create_from_backup(
         self,
-        filename: str,
+        filename: StrPath,
         *,
         status_check_period: int = None,
         pbar: Optional[ProgressReporter] = None,
@@ -378,10 +390,13 @@ class TasksRepo(
         """
         Import a task from a backup file
         """
+
+        filename = Path(filename)
+
         if status_check_period is None:
             status_check_period = self._client.config.status_check_period
 
-        params = {"filename": osp.basename(filename)}
+        params = {"filename": filename.name}
         url = self._client.api_map.make_endpoint_url(self.api.create_backup_endpoint.path)
         uploader = Uploader(self._client)
         response = uploader.upload_file(

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -5,8 +5,8 @@
 from __future__ import annotations
 
 import os
-import os.path as osp
 from contextlib import ExitStack, closing
+from pathlib import Path
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Sequence, Tuple
 
 import requests
@@ -144,7 +144,7 @@ class Uploader:
     def upload_file(
         self,
         url: str,
-        filename: str,
+        filename: Path,
         *,
         meta: Dict[str, Any],
         query_params: Dict[str, Any] = None,
@@ -207,15 +207,15 @@ class Uploader:
         )
 
     def _split_files_by_requests(
-        self, filenames: List[str]
-    ) -> Tuple[List[Tuple[List[str], int]], List[str], int]:
+        self, filenames: List[Path]
+    ) -> Tuple[List[Tuple[List[Path], int]], List[Path], int]:
         bulk_files: Dict[str, int] = {}
         separate_files: Dict[str, int] = {}
 
         # sort by size
         for filename in filenames:
-            filename = os.path.abspath(filename)
-            file_size = os.stat(filename).st_size
+            filename = filename.resolve()
+            file_size = filename.stat().st_size
             if MAX_REQUEST_SIZE < file_size:
                 separate_files[filename] = file_size
             else:
@@ -252,7 +252,7 @@ class Uploader:
         return _MyTusUploader(client=client, api_client=api_client, **kwargs)
 
     def _upload_file_data_with_tus(self, url, filename, *, meta=None, pbar=None, logger=None):
-        file_size = os.stat(filename).st_size
+        file_size = filename.stat().st_size
         if pbar is None:
             pbar = NullProgressReporter()
 
@@ -299,7 +299,7 @@ class AnnotationUploader(Uploader):
     def upload_file_and_wait(
         self,
         endpoint: Endpoint,
-        filename: str,
+        filename: Path,
         format_name: str,
         *,
         url_params: Optional[Dict[str, Any]] = None,
@@ -307,7 +307,7 @@ class AnnotationUploader(Uploader):
         status_check_period: Optional[int] = None,
     ):
         url = self._client.api_map.make_endpoint_url(endpoint.path, kwsub=url_params)
-        params = {"format": format_name, "filename": osp.basename(filename)}
+        params = {"format": format_name, "filename": filename.name}
         self.upload_file(
             url, filename, pbar=pbar, query_params=params, meta={"filename": params["filename"]}
         )
@@ -326,7 +326,7 @@ class DatasetUploader(Uploader):
     def upload_file_and_wait(
         self,
         endpoint: Endpoint,
-        filename: str,
+        filename: Path,
         format_name: str,
         *,
         url_params: Optional[Dict[str, Any]] = None,
@@ -334,7 +334,7 @@ class DatasetUploader(Uploader):
         status_check_period: Optional[int] = None,
     ):
         url = self._client.api_map.make_endpoint_url(endpoint.path, kwsub=url_params)
-        params = {"format": format_name, "filename": osp.basename(filename)}
+        params = {"format": format_name, "filename": filename.name}
         self.upload_file(
             url, filename, pbar=pbar, query_params=params, meta={"filename": params["filename"]}
         )
@@ -353,7 +353,7 @@ class DataUploader(Uploader):
     def upload_files(
         self,
         url: str,
-        resources: List[str],
+        resources: List[Path],
         *,
         pbar: Optional[ProgressReporter] = None,
         **kwargs,
@@ -370,7 +370,7 @@ class DataUploader(Uploader):
                 files = {}
                 for i, filename in enumerate(group):
                     files[f"client_files[{i}]"] = (
-                        filename,
+                        os.fspath(filename),
                         es.enter_context(closing(open(filename, "rb"))).read(),
                     )
                 response = self._client.api_client.rest_client.POST(
@@ -392,7 +392,7 @@ class DataUploader(Uploader):
             self._upload_file_data_with_tus(
                 url,
                 filename,
-                meta={"filename": osp.basename(filename)},
+                meta={"filename": filename.name},
                 pbar=pbar,
                 logger=self._client.logger.debug,
             )

--- a/tests/python/cli/test_cli.py
+++ b/tests/python/cli/test_cli.py
@@ -65,7 +65,7 @@ class TestCLI:
         backup_path = self.tmp_path / "backup.zip"
 
         fxt_new_task.import_annotations("COCO 1.0", filename=fxt_coco_file)
-        fxt_new_task.download_backup(str(backup_path))
+        fxt_new_task.download_backup(backup_path)
 
         yield backup_path
 
@@ -79,7 +79,7 @@ class TestCLI:
                 "labels": [{"name": "car"}, {"name": "person"}],
             },
             resource_type=ResourceType.LOCAL,
-            resources=list(map(os.fspath, files)),
+            resources=files,
         )
 
         return task

--- a/tests/python/sdk/test_issues_comments.py
+++ b/tests/python/sdk/test_issues_comments.py
@@ -42,7 +42,7 @@ class TestIssuesUsecases:
                 "labels": [{"name": "car"}, {"name": "person"}],
             },
             resource_type=ResourceType.LOCAL,
-            resources=[str(fxt_image_file)],
+            resources=[fxt_image_file],
             data_params={"image_quality": 80},
         )
 
@@ -162,7 +162,7 @@ class TestCommentsUsecases:
                 "labels": [{"name": "car"}, {"name": "person"}],
             },
             resource_type=ResourceType.LOCAL,
-            resources=[str(fxt_image_file)],
+            resources=[fxt_image_file],
             data_params={"image_quality": 80},
         )
 

--- a/tests/python/sdk/test_jobs.py
+++ b/tests/python/sdk/test_jobs.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 import io
-import os
 from logging import Logger
 from pathlib import Path
 from typing import Tuple
@@ -46,7 +45,7 @@ class TestJobUsecases:
                 "labels": [{"name": "car"}, {"name": "person"}],
             },
             resource_type=ResourceType.LOCAL,
-            resources=[str(fxt_image_file)],
+            resources=[fxt_image_file],
             data_params={"image_quality": 80},
         )
 
@@ -108,7 +107,7 @@ class TestJobUsecases:
         job = self.client.jobs.retrieve(job_id)
         job.export_dataset(
             format_name="CVAT for images 1.1",
-            filename=os.fspath(path),
+            filename=path,
             pbar=pbar,
             include_images=include_images,
         )
@@ -135,7 +134,7 @@ class TestJobUsecases:
         fxt_new_task.get_jobs()[0].download_frames(
             [0],
             quality=quality,
-            outdir=str(self.tmp_path),
+            outdir=self.tmp_path,
             filename_pattern="frame-{frame_id}{frame_ext}",
         )
 
@@ -147,7 +146,7 @@ class TestJobUsecases:
         pbar = make_pbar(file=pbar_out)
 
         fxt_new_task.get_jobs()[0].import_annotations(
-            format_name="COCO 1.0", filename=str(fxt_coco_file), pbar=pbar
+            format_name="COCO 1.0", filename=fxt_coco_file, pbar=pbar
         )
 
         assert "uploaded" in self.logger_stream.getvalue()


### PR DESCRIPTION
For user-facing functions, keep accepting `str` paths to maintain compatibility and flexibility, but add support for arbitrary path-like objects. For internal functions (in `downloading.py` and `uploading.py`), don't bother and require `pathlib.Path`.

The only code that isn't converted is build-time code (e.g. `setup.py`) and code that came from openapi-generator.

<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
`pathlib` enables simpler, more type-safe code. This also makes the API more convenient for users who are already using `pathlib` (or an alternative path library).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
