### PR TITLE
Little UX improvements in CLI

### DIFF
--- a/cvat-cli/src/cvat_cli/parser.py
+++ b/cvat-cli/src/cvat_cli/parser.py
@@ -122,7 +122,7 @@ def make_cmdline_parser() -> argparse.ArgumentParser:
     task_create_parser.add_argument(
         "--completion_verification_period",
         dest="status_check_period",
-        default=20,
+        default=2,
         type=float,
         help="""number of seconds to wait until checking
                 if data compression finished (necessary before uploading annotations)""",
@@ -261,7 +261,7 @@ def make_cmdline_parser() -> argparse.ArgumentParser:
     dump_parser.add_argument(
         "--completion_verification_period",
         dest="status_check_period",
-        default=3,
+        default=2,
         type=float,
         help="number of seconds to wait until checking if dataset building finished",
     )
@@ -298,7 +298,7 @@ def make_cmdline_parser() -> argparse.ArgumentParser:
     export_task_parser.add_argument(
         "--completion_verification_period",
         dest="status_check_period",
-        default=3,
+        default=2,
         type=float,
         help="time interval between checks if archive building has been finished, in seconds",
     )
@@ -311,7 +311,7 @@ def make_cmdline_parser() -> argparse.ArgumentParser:
     import_task_parser.add_argument(
         "--completion_verification_period",
         dest="status_check_period",
-        default=3,
+        default=2,
         type=float,
         help="time interval between checks if archive proessing was finished, in seconds",
     )

--- a/cvat-cli/src/cvat_cli/parser.py
+++ b/cvat-cli/src/cvat_cli/parser.py
@@ -313,7 +313,7 @@ def make_cmdline_parser() -> argparse.ArgumentParser:
         dest="status_check_period",
         default=2,
         type=float,
-        help="time interval between checks if archive proessing was finished, in seconds",
+        help="time interval between checks if archive processing was finished, in seconds",
     )
 
     return parser


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

- Reduced request status checks period to 2 sec.
- Fixed parameter help message

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
