### PR TITLE
CVAT v2.3.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ on:
 
 env:
   CYPRESS_VERIFY_TIMEOUT: 180000 # https://docs.cypress.io/guides/guides/command-line#cypress-verify
+  CVAT_VERSION: "local"
 
 jobs:
   search_cache:
@@ -158,8 +159,8 @@ jobs:
         run: |
           docker load --input /tmp/cvat_server/image.tar
           docker load --input /tmp/cvat_ui/image.tar
-          docker tag cvat/server:latest cvat/server:dev
-          docker tag cvat/ui:latest cvat/ui:dev
+          docker tag cvat/server:latest cvat/server:${CVAT_VERSION}
+          docker tag cvat/ui:latest cvat/ui:${CVAT_VERSION}
           docker image ls -a
 
       - name: Running REST API and SDK tests
@@ -204,7 +205,7 @@ jobs:
       - name: Load Docker server image
         run: |
           docker load --input /tmp/cvat_server/image.tar
-          docker tag cvat/server:latest cvat/server:dev
+          docker tag cvat/server:latest cvat/server:${CVAT_VERSION}
           docker image ls -a
 
       - name: Running OPA tests
@@ -285,8 +286,8 @@ jobs:
         run: |
           docker load --input /tmp/cvat_server/image.tar
           docker load --input /tmp/cvat_ui/image.tar
-          docker tag cvat/server:latest cvat/server:dev
-          docker tag cvat/ui:latest cvat/ui:dev
+          docker tag cvat/server:latest cvat/server:${CVAT_VERSION}
+          docker tag cvat/ui:latest cvat/ui:${CVAT_VERSION}
           docker image ls -a
 
       - name: Run CVAT instance


### PR DESCRIPTION
## \[2.3.0] - Unreleased
### Added
- SDK section in docs (<https://github.com/opencv/cvat/pull/4928>)
- An option to enable or disable host certificate checking in CLI (<https://github.com/opencv/cvat/pull/4928>)
- REST API tests with skeletons (<https://github.com/opencv/cvat/pull/4987>)
- Host schema auto-detection in SDK (<https://github.com/opencv/cvat/pull/4910>)
- Server compatibility checks in SDK (<https://github.com/opencv/cvat/pull/4935>)
- Objects sorting option in the sidebar, by z order. Additional visualization when the sorting is applied
(<https://github.com/opencv/cvat/pull/5145>)
- Added YOLOv5 serverless function NVIDIA GPU support (<https://github.com/opencv/cvat/pull/4960>)
- Mask tools are supported now (brush, eraser, polygon-plus, polygon-minus, returning masks
from online detectors & interactors) (<https://github.com/opencv/cvat/pull/4543>)
- Added Webhooks (<https://github.com/opencv/cvat/pull/4863>)
- Authentication with social accounts google & github (<https://github.com/opencv/cvat/pull/5147>, <https://github.com/opencv/cvat/pull/5181>, <https://github.com/opencv/cvat/pull/5295>)
- REST API tests to export job datasets & annotations and validate their structure  (<https://github.com/opencv/cvat/pull/5160>)
- Propagation backward on UI (<https://github.com/opencv/cvat/pull/5355>)
- A PyTorch dataset adapter layer in the SDK
  (<https://github.com/opencv/cvat/pull/5417>)
- A way to debug the server deployed with Docker (<https://github.com/opencv/cvat/issues/5327>)

### Changed
- `api/docs`, `api/swagger`, `api/schema`, `server/about` endpoints now allow unauthorized access (<https://github.com/opencv/cvat/pull/4928>, <https://github.com/opencv/cvat/pull/4935>)
- 3D canvas now can be dragged in IDLE mode (<https://github.com/opencv/cvat/pull/5385>)
- Datumaro version is upgraded to 0.3 (dev) (<https://github.com/opencv/cvat/pull/4984>)
- Allowed trailing slashes in the SDK host address (<https://github.com/opencv/cvat/pull/5057>)
- Adjusted initial camera position, enabled 'Reset zoom' option for 3D canvas (<https://github.com/opencv/cvat/pull/5395>)
- Enabled authentication via email (<https://github.com/opencv/cvat/pull/5037>)
- Unify error handling with the cloud storage (<https://github.com/opencv/cvat/pull/5389>)
- In the SDK, functions taking paths as strings now also accept path-like objects
  (<https://github.com/opencv/cvat/pull/5435>)

### Deprecated
- TDB

### Removed
- The `--https` option of CLI (<https://github.com/opencv/cvat/pull/4910>)

### Fixed
- Significantly optimized access to DB for api/jobs, api/tasks, and api/projects.
- Removed a possibly duplicated encodeURI() calls in `server-proxy.ts` to prevent doubly encoding
non-ascii paths while adding files from "Connected file share" (issue #4428)
- Removed unnecessary volumes defined in docker-compose.serverless.yml
(<https://github.com/openvinotoolkit/cvat/pull/4659>)
- Project import/export with skeletons (<https://github.com/opencv/cvat/pull/4867>,
  <https://github.com/opencv/cvat/pull/5004>)
- Shape color is not changed on canvas after changing a label (<https://github.com/opencv/cvat/pull/5045>)
- Unstable e2e restore tests (<https://github.com/opencv/cvat/pull/5010>)
- IOG and f-BRS serverless function (<https://github.com/opencv/cvat/pull/5039>)
- Invisible label item in label constructor when label color background is white,
 or close to it (<https://github.com/opencv/cvat/pull/5041>)
- Fixed cvat-core ESlint problems (<https://github.com/opencv/cvat/pull/5027>)
- Fixed task creation with non-local files via the SDK/CLI
  (<https://github.com/opencv/cvat/issues/4962>)
- HRNET serverless function (<https://github.com/opencv/cvat/pull/4944>)
- Invalid export of segmentation masks when the `background` label gets nonzero id (<https://github.com/opencv/cvat/pull/5056>)
- A trailing slash in hostname does't allow SDK to send some requests
  (<https://github.com/opencv/cvat/pull/5057>)
- Double modal export/backup a task/project (<https://github.com/opencv/cvat/pull/5075>)
- Fixed bug of computing Job's unsolved/resolved issues numbers (<https://github.com/opencv/cvat/pull/5101>)
- Dataset export for job (<https://github.com/opencv/cvat/pull/5052>)
- Angle is not propagated when use ``propagate`` feature (<https://github.com/opencv/cvat/pull/5139>)
- Could not fetch task in a corner case (<https://github.com/opencv/cvat/pull/5163>)
- Restoring CVAT in case of React-renderning fail (<https://github.com/opencv/cvat/pull/5134>)
- Deleted frames become restored if a user deletes frames from another job of the same task
(<https://github.com/opencv/cvat/pull/5138>)
- Wrong issue position when create a quick issue on a rotated shape (<https://github.com/opencv/cvat/pull/5162>)
- Extra rerenders of different pages with each click (<https://github.com/opencv/cvat/pull/5178>)
- Skeleton points exported out of order in the COCO Keypoints format
  (<https://github.com/opencv/cvat/issues/5048>)
- PASCAL VOC 1.1 can't import dataset (<https://github.com/opencv/cvat/pull/4647>)
- Changing an object causes current z layer to be set to the maximum (<https://github.com/opencv/cvat/pull/5145>)
- Job assignee can not resolve an issue (<https://github.com/opencv/cvat/pull/5167>)
- Create manifest with cvat/server docker container command (<https://github.com/opencv/cvat/pull/5172>)
- Cannot assign a resource to a user who has an organization (<https://github.com/opencv/cvat/pull/5218>)
- Logs and annotations are not saved when logout from a job page (<https://github.com/opencv/cvat/pull/5266>)
- Added "type" field for all the labels, allows to reduce number of controls on annotation view (<https://github.com/opencv/cvat/pull/5273>)
- Occluded not applied on canvas instantly for a skeleton elements (<https://github.com/opencv/cvat/pull/5259>)
- Oriented bounding boxes broken with COCO format ss(<https://github.com/opencv/cvat/pull/5219>)
- Can't dump annotations with objects type is track from several jobs (<https://github.com/opencv/cvat/pull/5250>)
- Fixed upload resumption in production environments
  (<https://github.com/opencv/cvat/issues/4839>)
- Fixed job exporting (<https://github.com/opencv/cvat/pull/5282>)
- Visibility and ignored information fail to be loaded (MOT dataset format) (<https://github.com/opencv/cvat/pull/5270>)
- Added force logout on CVAT app start if token is missing (<https://github.com/opencv/cvat/pull/5331>)
- Drawing issues on 3D canvas (<https://github.com/opencv/cvat/pull/5410>)
- Missed token with using social account authentication (<https://github.com/opencv/cvat/pull/5344>)
- The same object on 3D scene or `null` selected each click (PERFORMANCE) (<https://github.com/opencv/cvat/pull/5411>)
- An exception when run export for an empty task (<https://github.com/opencv/cvat/pull/5396>)
- Fixed FBRS serverless function runtime error on images with alpha channel (<https://github.com/opencv/cvat/pull/5384>)
- Attaching manifest with custom name (<https://github.com/opencv/cvat/pull/5377>)
- Uploading non-zip annotaion files (<https://github.com/opencv/cvat/pull/5386>)
- Loss of rotation in CVAT format (<https://github.com/opencv/cvat/pull/5407>)
- A permission problem with interactive model launches for workers in orgs (<https://github.com/opencv/cvat/issues/4996>)
- Fix chart not being upgradable (<https://github.com/opencv/cvat/pull/5371>)
- Broken helm chart - if using custom release name (<https://github.com/opencv/cvat/pull/5403>)
- Missing source tag in project annotations (<https://github.com/opencv/cvat/pull/5408>)
- Creating a task with a Git repository via the SDK
  (<https://github.com/opencv/cvat/issues/4365>)

### Security
- TDB
