### PR TITLE
tests: fix long shutdown times for the webhook_receiver container

### DIFF
--- a/tests/docker-compose.test_servers.yml
+++ b/tests/docker-compose.test_servers.yml
@@ -1,10 +1,11 @@
-version: '3.3'
+version: '3.7'
 
 services:
   webhook_receiver:
     image: python:3.9-slim
     restart: always
     command: python3 /tmp/server.py
+    init: true
     env_file:
       - ./tests/python/webhook_receiver/.env
     expose:


### PR DESCRIPTION
Currently, `server.py` runs as PID 1, which means that it won't be terminated by a `SIGTERM` signal unless it explicitly handles it (which it doesn't). So when Docker tries to shut the container down, it sends the server a `SIGTERM`, which gets ignored, and then sits there for 10 seconds before sending it a `SIGKILL`.

To work around this, enable the built-in Docker init program, which forwards signals to the Python server. Since the Python server is no longer PID 1, `SIGTERM` will now shut it down immediately.

The `init` option is supported starting from the Compose format version 3.7, so bump the version.

<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
I noticed that `webhook_receiver` takes the longest of all test containers to shut down, even though it's a trivial server.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
`time docker container stop test_webhook_receiver_1`

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
