### PR TITLE
SDK: fix `Project.import_dataset` incorrectly waiting for completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,8 @@ non-ascii paths while adding files from "Connected file share" (issue #4428)
 - Missing source tag in project annotations (<https://github.com/opencv/cvat/pull/5408>)
 - Creating a task with a Git repository via the SDK
   (<https://github.com/opencv/cvat/issues/4365>)
+- `Project.import_dataset` not waiting for completion correctly
+  (<https://github.com/opencv/cvat/pull/5459>)
 
 ### Security
 - TDB

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -54,6 +54,7 @@ class Project(
 
         DatasetUploader(self._client).upload_file_and_wait(
             self.api.create_dataset_endpoint,
+            self.api.retrieve_dataset_endpoint,
             filename,
             format_name,
             url_params={"id": self.id},

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -325,7 +325,8 @@ class AnnotationUploader(Uploader):
 class DatasetUploader(Uploader):
     def upload_file_and_wait(
         self,
-        endpoint: Endpoint,
+        upload_endpoint: Endpoint,
+        retrieve_endpoint: Endpoint,
         filename: Path,
         format_name: str,
         *,
@@ -333,12 +334,14 @@ class DatasetUploader(Uploader):
         pbar: Optional[ProgressReporter] = None,
         status_check_period: Optional[int] = None,
     ):
-        url = self._client.api_map.make_endpoint_url(endpoint.path, kwsub=url_params)
+        url = self._client.api_map.make_endpoint_url(upload_endpoint.path, kwsub=url_params)
         params = {"format": format_name, "filename": filename.name}
         self.upload_file(
             url, filename, pbar=pbar, query_params=params, meta={"filename": params["filename"]}
         )
 
+        url = self._client.api_map.make_endpoint_url(retrieve_endpoint.path, kwsub=url_params)
+        params = {"action": "import_status"}
         self._wait_for_completion(
             url,
             success_status=201,


### PR DESCRIPTION
You have to use the `import_status` action in order to query the input status. Otherwise, the `/api/projects/{id}/dataset/` endpoint initiates a dataset export. Currently, `import_dataset` inadvertently monitors the status of that export, not the original import.

<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This bug breaks the CI run for #5456. I've no idea why it hadn't caused the test suite to fail before...

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
