### PR TITLE
Splitted default queue to import/export, fixed django-rq admin page

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -133,7 +133,7 @@
             }
         },
         {
-            "name": "server: RQ - default",
+            "name": "server: RQ - import",
             "type": "python",
             "request": "launch",
             "stopOnEntry": false,
@@ -142,7 +142,26 @@
             "program": "${workspaceRoot}/manage.py",
             "args": [
                 "rqworker",
-                "default",
+                "import",
+                "--worker-class",
+                "cvat.rqworker.SimpleWorker",
+            ],
+            "django": true,
+            "cwd": "${workspaceFolder}",
+            "env": {},
+            "console": "internalConsole"
+        },
+        {
+            "name": "server: RQ - export",
+            "type": "python",
+            "request": "launch",
+            "stopOnEntry": false,
+            "justMyCode": false,
+            "python": "${command:python.interpreterPath}",
+            "program": "${workspaceRoot}/manage.py",
+            "args": [
+                "rqworker",
+                "export",
                 "--worker-class",
                 "cvat.rqworker.SimpleWorker",
             ],
@@ -161,6 +180,8 @@
             "program": "${workspaceRoot}/manage.py",
             "args": [
                 "rqscheduler",
+                "--queue",
+                "export"
             ],
             "django": true,
             "cwd": "${workspaceFolder}",
@@ -168,7 +189,7 @@
             "console": "internalConsole"
         },
         {
-            "name": "server: RQ - low",
+            "name": "server: RQ - annotation",
             "type": "python",
             "request": "launch",
             "justMyCode": false,
@@ -177,7 +198,7 @@
             "program": "${workspaceRoot}/manage.py",
             "args": [
                 "rqworker",
-                "low",
+                "annotation",
                 "--worker-class",
                 "cvat.rqworker.SimpleWorker",
             ],
@@ -379,8 +400,9 @@
             "name": "server: debug",
             "configurations": [
                 "server: django",
-                "server: RQ - default",
-                "server: RQ - low",
+                "server: RQ - import",
+                "server: RQ - export",
+                "server: RQ - annotation",
                 "server: RQ - webhooks",
                 "server: RQ - scheduler",
                 "server: git",

--- a/components/serverless/docker-compose.serverless.yml
+++ b/components/serverless/docker-compose.serverless.yml
@@ -28,6 +28,6 @@ services:
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
-  cvat_worker_low:
+  cvat_worker_annotation:
     extra_hosts:
       - "host.docker.internal:host-gateway"

--- a/cvat/apps/dataset_manager/views.py
+++ b/cvat/apps/dataset_manager/views.py
@@ -84,7 +84,7 @@ def export(dst_format, project_id=None, task_id=None, job_id=None, server_url=No
                 os.replace(temp_file, output_path)
 
             archive_ctime = osp.getctime(output_path)
-            scheduler = django_rq.get_scheduler(settings.CVAT_QUEUES.IMPORT_DATA.value)
+            scheduler = django_rq.get_scheduler(settings.CVAT_QUEUES.EXPORT_DATA.value)
             cleaning_job = scheduler.enqueue_in(time_delta=cache_ttl,
                 func=clear_export_cache,
                 file_path=output_path,

--- a/cvat/apps/dataset_manager/views.py
+++ b/cvat/apps/dataset_manager/views.py
@@ -11,6 +11,7 @@ import django_rq
 from datumaro.util.os_util import make_file_name
 from datumaro.util import to_snake_case
 from django.utils import timezone
+from django.conf import settings
 
 import cvat.apps.dataset_manager.task as task
 import cvat.apps.dataset_manager.project as project
@@ -83,7 +84,7 @@ def export(dst_format, project_id=None, task_id=None, job_id=None, server_url=No
                 os.replace(temp_file, output_path)
 
             archive_ctime = osp.getctime(output_path)
-            scheduler = django_rq.get_scheduler()
+            scheduler = django_rq.get_scheduler(settings.CVAT_QUEUES.IMPORT_DATA.value)
             cleaning_job = scheduler.enqueue_in(time_delta=cache_ttl,
                 func=clear_export_cache,
                 file_path=output_path,

--- a/cvat/apps/dataset_repo/dataset_repo.py
+++ b/cvat/apps/dataset_repo/dataset_repo.py
@@ -15,6 +15,7 @@ import django_rq
 import git
 from django.db import transaction
 from django.utils import timezone
+from django.conf import settings
 
 from cvat.apps.dataset_manager.formats.registry import format_for
 from cvat.apps.dataset_manager.task import export_task
@@ -427,7 +428,7 @@ def get(tid, user):
         response['url']['value'] = '{} [{}]'.format(db_git.url, db_git.path)
         try:
             rq_id = "git.push.{}".format(tid)
-            queue = django_rq.get_queue('default')
+            queue = django_rq.get_queue(settings.CVAT_QUEUES.EXPORT_DATA.value)
             rq_job = queue.fetch_job(rq_id)
             if rq_job is not None and (rq_job.is_queued or rq_job.is_started):
                 db_git.status = GitStatusChoice.SYNCING

--- a/cvat/apps/dataset_repo/views.py
+++ b/cvat/apps/dataset_repo/views.py
@@ -5,6 +5,7 @@ import http.client
 
 from django.http import HttpResponseBadRequest, HttpResponse
 from rules.contrib.views import permission_required, objectgetter
+from django.conf import settings
 
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -35,9 +36,9 @@ def _legacy_api_view(allowed_method_names=None):
     return decorator
 
 @_legacy_api_view()
-def check_process(request, rq_id):
+def check_process(_, rq_id):
     try:
-        queue = django_rq.get_queue('default')
+        queue = django_rq.get_queue(settings.CVAT_QUEUES.EXPORT_DATA.value)
         rq_job = queue.fetch_job(rq_id)
 
         if rq_job is not None:
@@ -65,7 +66,7 @@ def create(request: Request, tid):
         export_format = body.get("format")
         lfs = body["lfs"]
         rq_id = "git.create.{}".format(tid)
-        queue = django_rq.get_queue("default")
+        queue = django_rq.get_queue(settings.CVAT_QUEUES.EXPORT_DATA.value)
 
         queue.enqueue_call(func = CVATGit.initial_create, args = (tid, path, export_format, lfs, request.user), job_id = rq_id)
         return Response({ "rq_id": rq_id })
@@ -80,7 +81,7 @@ def push_repository(request: Request, tid):
         slogger.task[tid].info("push repository request")
 
         rq_id = "git.push.{}".format(tid)
-        queue = django_rq.get_queue('default')
+        queue = django_rq.get_queue(settings.CVAT_QUEUES.EXPORT_DATA.value)
         queue.enqueue_call(func = CVATGit.push, args = (tid, request.user, request.scheme, request.get_host()), job_id = rq_id)
 
         return Response({ "rq_id": rq_id })

--- a/cvat/apps/dataset_repo/views.py
+++ b/cvat/apps/dataset_repo/views.py
@@ -36,7 +36,7 @@ def _legacy_api_view(allowed_method_names=None):
     return decorator
 
 @_legacy_api_view()
-def check_process(_, rq_id):
+def check_process(request, rq_id):
     try:
         queue = django_rq.get_queue(settings.CVAT_QUEUES.EXPORT_DATA.value)
         rq_job = queue.fetch_job(rq_id)

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -259,7 +259,7 @@ class AnnotationMixin:
             field_name=StorageType.TARGET,
         )
 
-        rq_id = "/api/{}/{}/annotations/{}".format(self._object.__class__.__name__.lower(), pk, format_name)
+        rq_id = f"api-{self._object.__class__.__name__.lower()}-{pk}-annotations-{format_name}"
 
         if format_name:
             return export_func(db_instance=self._object,
@@ -316,13 +316,21 @@ class AnnotationMixin:
 class SerializeMixin:
     def serialize(self, request, export_func):
         db_object = self.get_object() # force to call check_object_permissions
-        return export_func(db_object, request)
+        return export_func(
+            db_object,
+            request,
+            queue_name=settings.CVAT_QUEUES.EXPORT_DATA.value,
+        )
 
     def deserialize(self, request, import_func):
         location = request.query_params.get("location", Location.LOCAL)
         if location == Location.CLOUD_STORAGE:
             file_name = request.query_params.get("filename", "")
-            return import_func(request, filename=file_name)
+            return import_func(
+                request,
+                queue_name=settings.CVAT_QUEUES.IMPORT_DATA.value,
+                filename=file_name,
+            )
         return self.upload_data(request)
 
 

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -246,7 +246,7 @@ class UploadMixin:
 
 class AnnotationMixin:
     def export_annotations(self, request, pk, db_obj, export_func, callback, get_data=None):
-        format_name = request.query_params.get("format")
+        format_name = request.query_params.get("format", "")
         action = request.query_params.get("action", "").lower()
         filename = request.query_params.get("filename", "")
 
@@ -259,7 +259,8 @@ class AnnotationMixin:
             field_name=StorageType.TARGET,
         )
 
-        rq_id = f"api-{self._object.__class__.__name__.lower()}-{pk}-annotations-{format_name}"
+        object_name = self._object.__class__.__name__.lower()
+        rq_id = f"export:annotations-for-{object_name}.id{pk}-in-{format_name.replace(' ', '_')}-format"
 
         if format_name:
             return export_func(db_instance=self._object,

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -40,9 +40,9 @@ from .cloud_provider import db_storage_to_storage_instance
 
 def create(tid, data):
     """Schedule the task"""
-    q = django_rq.get_queue('default')
+    q = django_rq.get_queue(settings.CVAT_QUEUES.IMPORT_DATA.value)
     q.enqueue_call(func=_create_thread, args=(tid, data),
-        job_id="/api/tasks/{}".format(tid))
+        job_id=f"api-tasks-{tid}")
 
 @transaction.atomic
 def rq_handler(job, exc_type, exc_value, traceback):

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -38,11 +38,11 @@ from .cloud_provider import db_storage_to_storage_instance
 
 ############################# Low Level server API
 
-def create(tid, data):
+def create(tid, data, username):
     """Schedule the task"""
     q = django_rq.get_queue(settings.CVAT_QUEUES.IMPORT_DATA.value)
     q.enqueue_call(func=_create_thread, args=(tid, data),
-        job_id=f"api-tasks-{tid}")
+        job_id=f"create:task.id{tid}-by-{username}")
 
 @transaction.atomic
 def rq_handler(job, exc_type, exc_value, traceback):

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -1238,7 +1238,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     def status(self, request, pk):
         self.get_object() # force to call check_object_permissions
         response = self._get_rq_response(
-            queue=settings.CVAT_QUEUES.EXPORT_DATA.value,
+            queue=settings.CVAT_QUEUES.IMPORT_DATA.value,
             job_id=f"api-tasks-{pk}"
         )
         serializer = RqStatusSerializer(data=response)

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -407,7 +407,7 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             resource_type_field_name=None
         ),
         responses={
-            '202': OpenApiResponse(description='Exporting has been started'),
+            '202': OpenApiResponse(description='Importing has been started'),
             '400': OpenApiResponse(description='Failed to import dataset'),
             '405': OpenApiResponse(description='Format is not available'),
         })
@@ -423,13 +423,13 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 db_obj=self._object,
                 import_func=_import_project_dataset,
                 rq_func=dm.project.import_dataset_as_project,
-                rq_id=f"/api/project/{pk}/dataset_import",
+                rq_id=f"api-project-{pk}-dataset-import",
             )
         else:
             action = request.query_params.get("action", "").lower()
             if action in ("import_status",):
-                queue = django_rq.get_queue("default")
-                rq_job = queue.fetch_job(f"/api/project/{pk}/dataset_import")
+                queue = django_rq.get_queue(settings.CVAT_QUEUES.IMPORT_DATA.value)
+                rq_job = queue.fetch_job(f"api-project-{pk}-dataset-import")
                 if rq_job is None:
                     return Response(status=status.HTTP_404_NOT_FOUND)
                 elif rq_job.is_finished:
@@ -449,7 +449,10 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                     )
                 else:
                     return Response(
-                        data=self._get_rq_response('default', f'/api/project/{pk}/dataset_import'),
+                        data=self._get_rq_response(
+                            settings.CVAT_QUEUES.IMPORT_DATA.value,
+                            f'api-project-{pk}-dataset-import'
+                        ),
                         status=status.HTTP_202_ACCEPTED
                     )
             else:
@@ -495,7 +498,7 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             return _import_project_dataset(
                 request=request,
                 filename=uploaded_file,
-                rq_id=f"/api/project/{self._object.pk}/dataset_import",
+                rq_id=f"api-project-{self._object.pk}-dataset-import",
                 rq_func=dm.project.import_dataset_as_project,
                 pk=self._object.pk,
                 format_name=format_name,
@@ -507,10 +510,14 @@ class ProjectViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 tmp_dir = backup.get_backup_dirname()
                 backup_file = os.path.join(tmp_dir, filename)
                 if os.path.isfile(backup_file):
-                    return backup.import_project(request, filename=backup_file)
+                    return backup.import_project(
+                        request,
+                        settings.CVAT_QUEUES.IMPORT_DATA.value,
+                        filename=backup_file,
+                    )
                 return Response(data='No such file were uploaded',
                         status=status.HTTP_400_BAD_REQUEST)
-            return backup.import_project(request)
+            return backup.import_project(request, settings.CVAT_QUEUES.IMPORT_DATA.value)
         return Response(data='Unknown upload was finished',
                         status=status.HTTP_400_BAD_REQUEST)
 
@@ -933,7 +940,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 return _import_annotations(
                         request=request,
                         filename=annotation_file,
-                        rq_id="{}@/api/tasks/{}/annotations/upload".format(request.user, self._object.pk),
+                        rq_id=f"{request.user}$-api-tasks-{self._object.pk}-annotations-upload",
                         rq_func=dm.task.import_task_annotations,
                         pk=self._object.pk,
                         format_name=format_name,
@@ -980,10 +987,14 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 tmp_dir = backup.get_backup_dirname()
                 backup_file = os.path.join(tmp_dir, filename)
                 if os.path.isfile(backup_file):
-                    return backup.import_task(request, filename=backup_file)
+                    return backup.import_task(
+                        request,
+                        settings.CVAT_QUEUES.IMPORT_DATA.value,
+                        filename=backup_file,
+                    )
                 return Response(data='No such file were uploaded',
                         status=status.HTTP_400_BAD_REQUEST)
-            return backup.import_task(request)
+            return backup.import_task(request, settings.CVAT_QUEUES.IMPORT_DATA.value)
         return Response(data='Unknown upload was finished',
                         status=status.HTTP_400_BAD_REQUEST)
 
@@ -1161,7 +1172,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 db_obj=self._object,
                 import_func=_import_annotations,
                 rq_func=dm.task.import_task_annotations,
-                rq_id = "{}@/api/tasks/{}/annotations/upload".format(request.user, pk)
+                rq_id = f"{request.user}$-api-tasks-{pk}-annotations-upload"
             )
         elif request.method == 'PUT':
             format_name = request.query_params.get('format')
@@ -1174,7 +1185,7 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 )
                 return _import_annotations(
                     request=request,
-                    rq_id="{}@/api/tasks/{}/annotations/upload".format(request.user, pk),
+                    rq_id=f"{request.user}$-api-tasks-{pk}-annotations-upload",
                     rq_func=dm.task.import_task_annotations,
                     pk=pk,
                     format_name=format_name,
@@ -1226,7 +1237,10 @@ class TaskViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
     @action(detail=True, methods=['GET'], serializer_class=RqStatusSerializer)
     def status(self, request, pk):
         self.get_object() # force to call check_object_permissions
-        response = self._get_rq_response(queue="default", job_id=f"/api/tasks/{pk}")
+        response = self._get_rq_response(
+            queue=settings.CVAT_QUEUES.EXPORT_DATA.value,
+            job_id=f"api-tasks-{pk}"
+        )
         serializer = RqStatusSerializer(data=response)
 
         if serializer.is_valid(raise_exception=True):
@@ -1437,7 +1451,7 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 return _import_annotations(
                         request=request,
                         filename=annotation_file,
-                        rq_id="{}@/api/jobs/{}/annotations/upload".format(request.user, self._object.pk),
+                        rq_id=f"{request.user}$-api-jobs-{self._object.pk}-annotations-upload",
                         rq_func=dm.task.import_job_annotations,
                         pk=self._object.pk,
                         format_name=format_name,
@@ -1550,7 +1564,7 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 db_obj=self._object.segment.task,
                 import_func=_import_annotations,
                 rq_func=dm.task.import_job_annotations,
-                rq_id = "{}@/api/jobs/{}/annotations/upload".format(request.user, pk)
+                rq_id = f"{request.user}$-api-jobs-{pk}-annotations-upload"
             )
 
         elif request.method == 'PUT':
@@ -1564,7 +1578,7 @@ class JobViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
                 )
                 return _import_annotations(
                     request=request,
-                    rq_id="{}@/api/jobs/{}/annotations/upload".format(request.user, pk),
+                    rq_id=f"{request.user}$-api-jobs-{pk}-annotations-upload",
                     rq_func=dm.task.import_job_annotations,
                     pk=pk,
                     format_name=format_name,
@@ -2248,7 +2262,7 @@ def _import_annotations(request, rq_id, rq_func, pk, format_name,
     elif not format_desc.ENABLED:
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    queue = django_rq.get_queue("default")
+    queue = django_rq.get_queue(settings.CVAT_QUEUES.IMPORT_DATA.value)
     rq_job = queue.fetch_job(rq_id)
 
     if not rq_job:
@@ -2329,7 +2343,7 @@ def _export_annotations(db_instance, rq_id, request, format_name, action, callba
     elif not format_desc.ENABLED:
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    queue = django_rq.get_queue("default")
+    queue = django_rq.get_queue(settings.CVAT_QUEUES.EXPORT_DATA.value)
     rq_job = queue.fetch_job(rq_id)
 
     if rq_job:
@@ -2420,7 +2434,7 @@ def _import_project_dataset(request, rq_id, rq_func, pk, format_name, filename=N
     elif not format_desc.ENABLED:
         return Response(status=status.HTTP_405_METHOD_NOT_ALLOWED)
 
-    queue = django_rq.get_queue("default")
+    queue = django_rq.get_queue(settings.CVAT_QUEUES.IMPORT_DATA.value)
     rq_job = queue.fetch_job(rq_id)
 
     if not rq_job:

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -364,8 +364,7 @@ class LambdaFunction:
 
 class LambdaQueue:
     def _get_queue(self):
-        QUEUE_NAME = "low"
-        return django_rq.get_queue(QUEUE_NAME)
+        return django_rq.get_queue(settings.CVAT_QUEUES.AUTO_ANNOTATION.value)
 
     def get_jobs(self):
         queue = self._get_queue()

--- a/cvat/apps/webhooks/signals.py
+++ b/cvat/apps/webhooks/signals.py
@@ -10,6 +10,7 @@ import json
 import django_rq
 import requests
 from django.dispatch import Signal, receiver
+from django.conf import settings
 
 from cvat.apps.engine.models import Project
 from cvat.apps.engine.serializers import BasicUserSerializer
@@ -75,7 +76,7 @@ def add_to_queue(webhook, payload, redelivery=False):
         response="",
     )
 
-    queue = django_rq.get_queue("webhooks")
+    queue = django_rq.get_queue(settings.CVAT_QUEUES.WEBHOOKS.value)
     queue.enqueue_call(func=send_webhook, args=(webhook, payload, delivery))
 
     return delivery

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -15,6 +15,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/2.0/ref/settings/
 """
 
+from enum import Enum
 import os
 import sys
 import fcntl
@@ -296,20 +297,32 @@ OLD_PASSWORD_FIELD_ENABLED = True
 # Django-RQ
 # https://github.com/rq/django-rq
 
+class CVAT_QUEUES(Enum):
+    IMPORT_DATA = 'import'
+    EXPORT_DATA = 'export'
+    AUTO_ANNOTATION = 'annotation'
+    WEBHOOKS = 'webhooks'
+
 RQ_QUEUES = {
-    'default': {
+    CVAT_QUEUES.IMPORT_DATA.value: {
         'HOST': 'localhost',
         'PORT': 6379,
         'DB': 0,
         'DEFAULT_TIMEOUT': '4h'
     },
-    'low': {
+    CVAT_QUEUES.EXPORT_DATA.value: {
+        'HOST': 'localhost',
+        'PORT': 6379,
+        'DB': 0,
+        'DEFAULT_TIMEOUT': '4h'
+    },
+    CVAT_QUEUES.AUTO_ANNOTATION.value: {
         'HOST': 'localhost',
         'PORT': 6379,
         'DB': 0,
         'DEFAULT_TIMEOUT': '24h'
     },
-    'webhooks': {
+    CVAT_QUEUES.WEBHOOKS.value: {
         'HOST': 'localhost',
         'PORT': 6379,
         'DB': 0,

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -16,7 +16,6 @@ services:
         CLAM_AV:
         INSTALL_SOURCES:
         CVAT_DEBUG_ENABLED:
-    command: '-c supervisord/server.conf'
     environment:
       CVAT_DEBUG_ENABLED: '${CVAT_DEBUG_ENABLED:-no}'
       CVAT_DEBUG_PORT: '9090'
@@ -25,8 +24,7 @@ services:
     ports:
       - '9090:9090'
 
-  cvat_worker_default:
-    command: -c supervisord/worker.default.conf
+  cvat_worker_export:
     environment:
       # For debugging, make sure to set 1 process
       # Due to the supervisord specifics, the extra processes will fail and
@@ -37,8 +35,18 @@ services:
     ports:
       - '9092:9092'
 
-  cvat_worker_low:
-    command: -c supervisord/worker.low.conf
+  cvat_worker_import:
+    environment:
+      # For debugging, make sure to set 1 process
+      # Due to the supervisord specifics, the extra processes will fail and
+      # after few attempts supervisord will give up restarting, leaving only 1 process
+      # NUMPROCS: 1
+      CVAT_DEBUG_ENABLED: '${CVAT_DEBUG_ENABLED:-no}'
+      CVAT_DEBUG_PORT: '9093'
+    ports:
+      - '9093:9093'
+
+  cvat_worker_annotation:
     environment:
       # For debugging, make sure to set 1 process
       # Due to the supervisord specifics, the extra processes will fail and

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -82,20 +82,19 @@ services:
     networks:
       - cvat
 
-  cvat_worker_default:
-    container_name: cvat_worker_default
+  cvat_worker_import:
+    container_name: cvat_worker_import
     image: cvat/server:${CVAT_VERSION:-dev}
     restart: always
     depends_on:
       - cvat_redis
       - cvat_db
-      - cvat_opa
     environment:
       CVAT_REDIS_HOST: 'cvat_redis'
       CVAT_POSTGRES_HOST: 'cvat_db'
       no_proxy: elasticsearch,kibana,logstash,nuclio,opa,${no_proxy:-}
       NUMPROCS: 2
-    command: -c supervisord/worker.default.conf
+    command: -c supervisord/worker.import.conf
     volumes:
       - cvat_data:/home/django/data
       - cvat_keys:/home/django/keys
@@ -103,8 +102,28 @@ services:
     networks:
       - cvat
 
-  cvat_worker_low:
-    container_name: cvat_worker_low
+  cvat_worker_export:
+    container_name: cvat_worker_export
+    image: cvat/server:${CVAT_VERSION:-dev}
+    restart: always
+    depends_on:
+      - cvat_redis
+      - cvat_db
+    environment:
+      CVAT_REDIS_HOST: 'cvat_redis'
+      CVAT_POSTGRES_HOST: 'cvat_db'
+      no_proxy: elasticsearch,kibana,logstash,nuclio,opa,${no_proxy:-}
+      NUMPROCS: 2
+    command: -c supervisord/worker.export.conf
+    volumes:
+      - cvat_data:/home/django/data
+      - cvat_keys:/home/django/keys
+      - cvat_logs:/home/django/logs
+    networks:
+      - cvat
+
+  cvat_worker_annotation:
+    container_name: cvat_worker_annotation
     image: cvat/server:${CVAT_VERSION:-dev}
     restart: always
     depends_on:
@@ -116,7 +135,7 @@ services:
       CVAT_POSTGRES_HOST: 'cvat_db'
       no_proxy: elasticsearch,kibana,logstash,nuclio,opa,${no_proxy:-}
       NUMPROCS: 1
-    command: -c supervisord/worker.low.conf
+    command: -c supervisord/worker.annotation.conf
     volumes:
       - cvat_data:/home/django/data
       - cvat_keys:/home/django/keys

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.2
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
@@ -1,0 +1,170 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-backend-worker-annotation
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: cvat-app
+    tier: backend
+    component: worker-annotation
+    {{- include "cvat.labels" . | nindent 4 }}
+    {{- with .Values.cvat.backend.worker.annotation.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.cvat.backend.worker.annotation.annotations }}
+  annotations:
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  replicas: {{ .Values.cvat.backend.worker.annotation.replicas }}
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "cvat.labels" . | nindent 6 }}
+      {{- with .Values.cvat.backend.worker.annotation.labels }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+      app: cvat-app
+      tier: backend
+      component: worker-annotation
+  template:
+    metadata:
+      labels:
+        app: cvat-app
+        tier: backend
+        component: worker-annotation
+        {{- include "cvat.labels" . | nindent 8 }}
+        {{- with .Values.cvat.backend.worker.annotation.labels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.cvat.backend.worker.annotation.annotations }}
+      annotations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      containers:
+        - name: cvat-app-backend-worker-annotation-container
+          image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
+          imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
+          {{- with .Values.cvat.backend.worker.annotation.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          args: ["-c", "supervisord/worker.annotation.conf"]
+          env:
+          {{- if .Values.redis.enabled }}
+          - name: CVAT_REDIS_HOST
+            value: "{{ .Release.Name }}-redis-master"
+          {{- else }}
+          - name: CVAT_REDIS_HOST
+            value: "{{ .Values.redis.external.host }}"
+          {{- end }}
+          - name: CVAT_REDIS_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ tpl (.Values.redis.secret.name) . }}"
+                key: redis-password
+         {{- if .Values.postgresql.enabled }}
+          - name: CVAT_POSTGRES_HOST
+            value: "{{ .Release.Name }}-postgresql"
+          - name: CVAT_POSTGRES_PORT
+            value: "{{ .Values.postgresql.service.ports.postgresql }}"
+          {{- else }}
+          - name: CVAT_POSTGRES_HOST
+            value: "{{ .Values.postgresql.external.host }}"
+          - name: CVAT_POSTGRES_PORT
+            value: "{{ .Values.postgresql.external.port }}"
+          {{- end }}
+          - name: CVAT_POSTGRES_USER
+            valueFrom:
+              secretKeyRef:
+                name: "{{ tpl (.Values.postgresql.secret.name) . }}"
+                key: username
+          - name: CVAT_POSTGRES_DBNAME
+            valueFrom:
+              secretKeyRef:
+                name: "{{ tpl (.Values.postgresql.secret.name) . }}"
+                key: database
+          - name: CVAT_POSTGRES_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                name: "{{ tpl (.Values.postgresql.secret.name) . }}"
+                key: password
+          {{- if .Values.nuclio }}
+          - name: CVAT_SERVERLESS
+            value: "1"
+          - name: CVAT_NUCLIO_HOST
+            value: "{{ .Release.Name }}-nuclio-dashboard"
+          {{- end }}
+          {{- with .Values.cvat.backend.worker.annotation.additionalEnv }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+          volumeMounts:
+          - mountPath: /home/django/data
+            name: cvat-backend-data
+            subPath: data
+          - mountPath: /home/django/keys
+            name: cvat-backend-data
+            subPath: keys
+          - mountPath: /home/django/logs
+            name: cvat-backend-data
+            subPath: logs
+          - mountPath: /home/django/models
+            name: cvat-backend-data
+            subPath: models
+          - mountPath: /home/django/tmp_storage
+            name: cvat-backend-data
+            subPath: tmp_storage
+          {{- with .Values.cvat.backend.worker.annotation.additionalVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+      initContainers:
+        {{- if .Values.cvat.backend.permissionFix.enabled }}
+        - name: user-data-permission-fix
+          image: busybox
+          command: ["/bin/chmod", "-R", "777", "/home/django"]
+          {{- with .Values.cvat.backend.worker.annotation.resources }}
+          resources:
+          {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+          {{- if .Values.cvat.backend.defaultStorage.enabled }}
+          - mountPath: /home/django/data
+            name: cvat-backend-data
+            subPath: data
+          - mountPath: /home/django/keys
+            name: cvat-backend-data
+            subPath: keys
+          - mountPath: /home/django/logs
+            name: cvat-backend-data
+            subPath: logs
+          - mountPath: /home/django/models
+            name: cvat-backend-data
+            subPath: models
+          {{- end }}
+          {{- with .Values.cvat.backend.worker.annotation.additionalVolumeMounts }}
+          {{- toYaml . | nindent 10 }}
+          {{- end }}
+        {{- end }}
+      {{- with .Values.cvat.backend.worker.annotation.affinity }}
+      affinity:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.cvat.backend.worker.annotation.tolerations }}
+      tolerations:
+      {{- toYaml . | nindent 8 }}
+      {{- end }}
+      volumes:
+        {{- if .Values.cvat.backend.defaultStorage.enabled }}
+        - name: cvat-backend-data
+          persistentVolumeClaim:
+            claimName: "{{ .Release.Name }}-backend-data"
+        {{- end }}
+        {{- with .Values.cvat.backend.worker.annotation.additionalVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/helm-chart/templates/cvat_backend/worker_export/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_export/deployment.yml
@@ -1,57 +1,57 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-backend-worker-default
+  name: {{ .Release.Name }}-backend-worker-export
   namespace: {{ .Release.Namespace }}
   labels:
     app: cvat-app
     tier: backend
-    component: worker-default
+    component: worker-export
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.default.labels }}
+    {{- with .Values.cvat.backend.worker.export.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.default.annotations }}
+  {{- with .Values.cvat.backend.worker.export.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.default.replicas }}
+  replicas: {{ .Values.cvat.backend.worker.export.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.default.labels }}
+      {{- with .Values.cvat.backend.worker.export.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      app: cvat-app-worker-default
+      app: cvat-app
       tier: backend
-      component: worker-default
+      component: worker-export
   template:
     metadata:
       labels:
-        app: cvat-app-worker-default
+        app: cvat-app
         tier: backend
-        component: worker-default
+        component: worker-export
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.default.labels }}
+        {{- with .Values.cvat.backend.worker.export.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.default.annotations }}
+      {{- with .Values.cvat.backend.worker.export.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-default-container
+        - name: cvat-app-backend-worker-export-container
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.default.resources }}
+          {{- with .Values.cvat.backend.worker.export.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
-          args: ["-c", "supervisord/worker.default.conf"]
+          args: ["-c", "supervisord/worker.export.conf"]
           env:
           {{- if .Values.redis.enabled }}
           - name: CVAT_REDIS_HOST
@@ -97,11 +97,9 @@ spec:
           - name: CVAT_NUCLIO_HOST
             value: "{{ .Release.Name }}-nuclio-dashboard"
           {{- end }}
-          {{- with .Values.cvat.backend.worker.default.additionalEnv }}
+          {{- with .Values.cvat.backend.worker.export.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          ports:
-          - containerPort: 8080
           volumeMounts:
           - mountPath: /home/django/data
             name: cvat-backend-data
@@ -118,7 +116,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with .Values.cvat.backend.worker.default.additionalVolumeMounts }}
+          {{- with .Values.cvat.backend.worker.export.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -126,7 +124,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with .Values.cvat.backend.worker.default.resources }}
+          {{- with .Values.cvat.backend.worker.export.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -145,15 +143,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with .Values.cvat.backend.worker.default.additionalVolumeMounts }}
+          {{- with .Values.cvat.backend.worker.export.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.default.affinity }}
+      {{- with .Values.cvat.backend.worker.export.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.default.tolerations }}
+      {{- with .Values.cvat.backend.worker.export.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -163,7 +161,7 @@ spec:
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-backend-data"
         {{- end }}
-        {{- with .Values.cvat.backend.worker.default.additionalVolumes }}
+        {{- with .Values.cvat.backend.worker.export.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_import/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_import/deployment.yml
@@ -1,57 +1,57 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ .Release.Name }}-backend-worker-low
+  name: {{ .Release.Name }}-backend-worker-import
   namespace: {{ .Release.Namespace }}
   labels:
     app: cvat-app
     tier: backend
-    component: worker-low
+    component: worker-import
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.low.labels }}
+    {{- with .Values.cvat.backend.worker.import.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.low.annotations }}
+  {{- with .Values.cvat.backend.worker.import.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.low.replicas }}
+  replicas: {{ .Values.cvat.backend.worker.import.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.low.labels }}
+      {{- with .Values.cvat.backend.worker.import.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
       tier: backend
-      component: worker-low
+      component: worker-import
   template:
     metadata:
       labels:
         app: cvat-app
         tier: backend
-        component: worker-low
+        component: worker-import
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.low.labels }}
+        {{- with .Values.cvat.backend.worker.import.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.low.annotations }}
+      {{- with .Values.cvat.backend.worker.import.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-low-container
+        - name: cvat-app-backend-worker-import-container
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.low.resources }}
+          {{- with .Values.cvat.backend.worker.import.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
-          args: ["-c", "supervisord/worker.low.conf"]
+          args: ["-c", "supervisord/worker.import.conf"]
           env:
           {{- if .Values.redis.enabled }}
           - name: CVAT_REDIS_HOST
@@ -65,7 +65,7 @@ spec:
               secretKeyRef:
                 name: "{{ tpl (.Values.redis.secret.name) . }}"
                 key: redis-password
-         {{- if .Values.postgresql.enabled }}
+          {{- if .Values.postgresql.enabled }}
           - name: CVAT_POSTGRES_HOST
             value: "{{ .Release.Name }}-postgresql"
           - name: CVAT_POSTGRES_PORT
@@ -97,11 +97,9 @@ spec:
           - name: CVAT_NUCLIO_HOST
             value: "{{ .Release.Name }}-nuclio-dashboard"
           {{- end }}
-          {{- with .Values.cvat.backend.worker.low.additionalEnv }}
+          {{- with .Values.cvat.backend.worker.import.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          ports:
-          - containerPort: 8080
           volumeMounts:
           - mountPath: /home/django/data
             name: cvat-backend-data
@@ -118,7 +116,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with .Values.cvat.backend.worker.low.additionalVolumeMounts }}
+          {{- with .Values.cvat.backend.worker.import.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -126,7 +124,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with .Values.cvat.backend.worker.low.resources }}
+          {{- with .Values.cvat.backend.worker.import.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -145,15 +143,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with .Values.cvat.backend.worker.low.additionalVolumeMounts }}
+          {{- with .Values.cvat.backend.worker.import.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.low.affinity }}
+      {{- with .Values.cvat.backend.worker.import.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.low.tolerations }}
+      {{- with .Values.cvat.backend.worker.import.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -163,7 +161,7 @@ spec:
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-backend-data"
         {{- end }}
-        {{- with .Values.cvat.backend.worker.low.additionalVolumes }}
+        {{- with .Values.cvat.backend.worker.import.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -32,7 +32,7 @@ cvat:
       additionalVolumes: []
       additionalVolumeMounts: []
     worker:
-      default:
+      export:
         replicas: 2
         labels: {}
         annotations: {}
@@ -42,7 +42,17 @@ cvat:
         additionalEnv: []
         additionalVolumes: []
         additionalVolumeMounts: []
-      low:
+      import:
+        replicas: 2
+        labels: {}
+        annotations: {}
+        resources: {}
+        affinity: {}
+        tolerations: []
+        additionalEnv: []
+        additionalVolumes: []
+        additionalVolumeMounts: []
+      annotation:
         replicas: 1
         labels: {}
         annotations: {}

--- a/supervisord/all.conf
+++ b/supervisord/all.conf
@@ -22,16 +22,22 @@ command=bash -c "rm /tmp/ssh-agent.sock -f && /usr/bin/ssh-agent -d -a /tmp/ssh-
 priority=1
 autorestart=true
 
-[program:rqworker_default]
+[program:rqworker_export]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic \
-    "exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 default"
+    "exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 export"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=2
 process_name=rqworker_default_%(process_num)s
 
-[program:rqworker_low]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic \
-    "exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 low"
+    "exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 import"
+environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
+numprocs=2
+process_name=rqworker_default_%(process_num)s
+
+[program:rqworker_annotation]
+command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic \
+    "exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 annotation"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=1
 
@@ -49,7 +55,7 @@ numprocs=1
 
 [program:rqscheduler]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic \
-    "python3 /opt/venv/bin/rqscheduler --host %(ENV_CVAT_REDIS_HOST)s -i 30"
+    "python3 /opt/venv/bin/rqscheduler --host %(ENV_CVAT_REDIS_HOST)s --password '%(ENV_CVAT_REDIS_PASSWORD)s' -i 30"
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=1
 

--- a/supervisord/worker.annotation.conf
+++ b/supervisord/worker.annotation.conf
@@ -22,7 +22,7 @@ command=bash -c "rm /tmp/ssh-agent.sock -f && /usr/bin/ssh-agent -d -a /tmp/ssh-
 priority=1
 autorestart=true
 
-[program:rqworker_low]
+[program:rqworker_annotation]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic " \
     exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 annotation \
         --worker-class cvat.rqworker.DefaultWorker \

--- a/supervisord/worker.annotation.conf
+++ b/supervisord/worker.annotation.conf
@@ -24,15 +24,8 @@ autorestart=true
 
 [program:rqworker_low]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic " \
-    exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 low \
+    exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 annotation \
         --worker-class cvat.rqworker.DefaultWorker \
     "
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=%(ENV_NUMPROCS)s
-
-[program:clamav_update]
-command=bash -c "if [ \"${CLAM_AV}\" = 'yes' ]; then /usr/bin/freshclam -d \
-    -l %(ENV_HOME)s/logs/freshclam.log --foreground=true; fi"
-numprocs=1
-
-environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"

--- a/supervisord/worker.export.conf
+++ b/supervisord/worker.export.conf
@@ -29,4 +29,4 @@ command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -i
     "
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=%(ENV_NUMPROCS)s
-process_name=rqworker_default_%(process_num)s
+process_name=rqworker_export_%(process_num)s

--- a/supervisord/worker.export.conf
+++ b/supervisord/worker.export.conf
@@ -22,7 +22,7 @@ command=bash -c "rm /tmp/ssh-agent.sock -f && /usr/bin/ssh-agent -d -a /tmp/ssh-
 priority=1
 autorestart=true
 
-[program:rqworker_default]
+[program:rqworker_export]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic " \
     exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 export \
         --worker-class cvat.rqworker.DefaultWorker \

--- a/supervisord/worker.export.conf
+++ b/supervisord/worker.export.conf
@@ -1,0 +1,32 @@
+[unix_http_server]
+file = /tmp/supervisord/supervisor.sock
+
+[supervisorctl]
+serverurl = unix:///tmp/supervisord/supervisor.sock
+
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisord]
+nodaemon=true
+logfile=%(ENV_HOME)s/logs/supervisord.log ; supervisord log file
+logfile_maxbytes=50MB       ; maximum size of logfile before rotation
+logfile_backups=10          ; number of backed up logfiles
+loglevel=debug              ; info, debug, warn, trace
+pidfile=/tmp/supervisord/supervisord.pid ; pidfile location
+childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
+
+[program:ssh-agent]
+command=bash -c "rm /tmp/ssh-agent.sock -f && /usr/bin/ssh-agent -d -a /tmp/ssh-agent.sock"
+priority=1
+autorestart=true
+
+[program:rqworker_default]
+command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic " \
+    exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 export \
+        --worker-class cvat.rqworker.DefaultWorker \
+    "
+environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
+numprocs=%(ENV_NUMPROCS)s
+process_name=rqworker_default_%(process_num)s

--- a/supervisord/worker.import.conf
+++ b/supervisord/worker.import.conf
@@ -22,7 +22,7 @@ command=bash -c "rm /tmp/ssh-agent.sock -f && /usr/bin/ssh-agent -d -a /tmp/ssh-
 priority=1
 autorestart=true
 
-[program:rqworker_default]
+[program:rqworker_import]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic " \
     exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 import \
         --worker-class cvat.rqworker.DefaultWorker \

--- a/supervisord/worker.import.conf
+++ b/supervisord/worker.import.conf
@@ -29,7 +29,7 @@ command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -i
     "
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=%(ENV_NUMPROCS)s
-process_name=rqworker_default_%(process_num)s
+process_name=rqworker_import_%(process_num)s
 
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 

--- a/supervisord/worker.import.conf
+++ b/supervisord/worker.import.conf
@@ -24,7 +24,7 @@ autorestart=true
 
 [program:rqworker_default]
 command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_REDIS_HOST)s:6379 -t 0 -- bash -ic " \
-    exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 default \
+    exec python3 %(ENV_HOME)s/manage.py rqworker -v 3 import \
         --worker-class cvat.rqworker.DefaultWorker \
     "
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"

--- a/tests/docker-compose.file_share.yml
+++ b/tests/docker-compose.file_share.yml
@@ -1,5 +1,5 @@
 services:
-  cvat_worker_default:
+  cvat_worker_import:
     volumes:
       - ./tests/mounted_file_share:/home/django/share:rw
   cvat_server:

--- a/tests/values.test.yaml
+++ b/tests/values.test.yaml
@@ -6,7 +6,7 @@ cvat:
         name: cvat-backend-data
         subPath: share
     worker:
-      export:
+      import:
         additionalVolumeMounts:
         - mountPath: /home/django/share
           name: cvat-backend-data

--- a/tests/values.test.yaml
+++ b/tests/values.test.yaml
@@ -6,7 +6,7 @@ cvat:
         name: cvat-backend-data
         subPath: share
     worker:
-      default:
+      export:
         additionalVolumeMounts:
         - mountPath: /home/django/share
           name: cvat-backend-data


### PR DESCRIPTION
<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
