### PR TITLE
Fix HRNet dimension error on images with alpha channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Helm: Empty password for Redis (<https://github.com/opencv/cvat/pull/5520>)
+- Fixed HRNet serverless function runtime error on images with alpha channel (<https://github.com/opencv/cvat/pull/5570>)
 
 ### Security
 - Fixed vulnerability with social authentication (<https://github.com/opencv/cvat/pull/5521>)

--- a/serverless/pytorch/saic-vul/hrnet/nuclio/main.py
+++ b/serverless/pytorch/saic-vul/hrnet/nuclio/main.py
@@ -24,7 +24,7 @@ def handler(context, event):
     neg_points = data["neg_points"]
     threshold = data.get("threshold", 0.5)
     buf = io.BytesIO(base64.b64decode(data["image"]))
-    image = Image.open(buf)
+    image = Image.open(buf).convert('RGB')
 
     mask, polygon = context.user_data.model.handle(image, pos_points,
         neg_points, threshold)


### PR DESCRIPTION
This is pretty much the same fix applied to f-BRS in #5384. We've been using HRNet for a while and now an then we receive "500 errors" just as reported in #5299 when someone forgets to drop the alpha-channel from our images.

### Motivation and context
The RuntimeError is a little bit different, but comes from the same issue: RGBA instead of RGB images:
> RuntimeError: Given groups=1, weight of size [16, 3, 1, 1], expected input[*, 4, *, *] to have 3 channels, but got 4 channels instead.

### How has this been tested?
I created a task with images with and w/o alpha channel, and the interactor works on both now.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
~~I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
~~I have added tests to cover my changes~~
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
~~I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
