### PR TITLE
Fix typing of credentials parameter of make_client in the Python SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed HRNet serverless function runtime error on images with alpha channel (<https://github.com/opencv/cvat/pull/5570>)
 - Preview & chunk cache settings are ignored (<https://github.com/opencv/cvat/pull/5569>)
 - Export annotations to Azure container (<https://github.com/opencv/cvat/pull/5596>)
+- Fix the type of the credentials parameter of make_client from the Python SDK
 
 ### Security
 - Fixed vulnerability with social authentication (<https://github.com/opencv/cvat/pull/5521>)

--- a/cvat-sdk/cvat_sdk/core/client.py
+++ b/cvat-sdk/cvat_sdk/core/client.py
@@ -319,7 +319,7 @@ class CVAT_API_V2:
 
 
 def make_client(
-    host: str, *, port: Optional[int] = None, credentials: Optional[Tuple[int, int]] = None
+    host: str, *, port: Optional[int] = None, credentials: Optional[Tuple[str, str]] = None
 ) -> Client:
     url = host.rstrip("/")
     if port:


### PR DESCRIPTION
### Motivation and context
This is a very simple pull request. The type of the credentials parameter of `make_client` is currently `Optional[Tuple[int, int]]`, but it should be `Optional[Tuple[str, str]]` as used by `Client#login`. This PR makes that change.

### How has this been tested?
The typing does not affect the functionality of the code (just the warnings I get in an IDE).

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
~~- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
~~- [ ] I have added tests to cover my changes~~
~~- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
~~- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
