### PR TITLE
Fix a CI issue that causes unit tests to run against the wrong version of CVAT

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -135,9 +135,6 @@ jobs:
         with:
           python-version: '3.8'
 
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
-
       - name: Download CVAT server image
         uses: actions/download-artifact@v3
         with:
@@ -194,9 +191,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
 
       - name: Download CVAT server image
         uses: actions/download-artifact@v3
@@ -264,9 +258,6 @@ jobs:
                 'canvas3d_functionality_2', 'issues_prs', 'issues_prs2', 'masks', 'skeletons']
     steps:
       - uses: actions/checkout@v3
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
 
       - uses: actions/setup-node@v3
         with:

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,4 +1,4 @@
-FROM cvat/server
+FROM cvat/server:local
 
 ENV DJANGO_CONFIGURATION=testing
 USER root

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -20,7 +20,7 @@ from cvat.apps.engine.cloud_provider import get_cloud_storage_instance, Credenti
 from cvat.apps.engine.log import slogger
 from cvat.apps.engine.utils import parse_specific_attributes
 
-from drf_spectacular.utils import OpenApiExample, extend_schema_serializer
+from drf_spectacular.utils import OpenApiExample, extend_schema_field, extend_schema_serializer
 
 class BasicUserSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
@@ -925,6 +925,13 @@ class FrameMetaSerializer(serializers.Serializer):
     height = serializers.IntegerField()
     name = serializers.CharField(max_length=1024)
     related_files = serializers.IntegerField()
+
+    # for compatibility with version 2.3.0
+    has_related_context = serializers.SerializerMethodField()
+
+    @extend_schema_field(serializers.BooleanField)
+    def get_has_related_context(self, obj: dict) -> bool:
+        return obj['related_files'] != 0
 
 class PluginsSerializer(serializers.Serializer):
     GIT_INTEGRATION = serializers.BooleanField()

--- a/cvat/apps/iam/tests/test_rest_api.py
+++ b/cvat/apps/iam/tests/test_rest_api.py
@@ -150,7 +150,7 @@ class TestIamApi(APITestCase):
                 ForceLogin(user=self.user, client=self.client):
             response = self.client.get(self.ENDPOINT_WITH_AUTH)
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertEqual(response.json(), expected_reasons)
+            self.assertTrue(all([reason in str(response.content) for reason in expected_reasons]))
 
     def test_can_report_merged_denial_reasons(self):
         expected_reasons = [["hello", "world"], ["hi", "there"]]
@@ -159,7 +159,14 @@ class TestIamApi(APITestCase):
                 ForceLogin(user=self.user, client=self.client):
             response = self.client.get(self.ENDPOINT_WITH_AUTH)
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertEqual(response.json(), list(itertools.chain.from_iterable(expected_reasons)))
+            self.assertTrue(
+                all(
+                    [
+                        reason in str(response.content)
+                        for reason in itertools.chain(*expected_reasons)
+                    ]
+                )
+            )
 
     def test_can_allow_if_no_permission_matches(self):
         with self._mock_permissions(), ForceLogin(user=self.user, client=self.client):
@@ -179,4 +186,4 @@ class TestIamApi(APITestCase):
                 ForceLogin(user=self.user, client=self.client):
             response = self.client.get(self.ENDPOINT_WITH_AUTH)
             self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
-            self.assertEqual(response.json(), expected_reasons)
+            self.assertTrue(all([reason in str(response.content) for reason in expected_reasons]))


### PR DESCRIPTION
There seems to be a bug somewhere in the Docker ecosystem (it's probably either Docker Compose, Docker Buildx or BuildKit) that causes `docker compose build` to ignore base images that are already present in the system, and instead fetch them from Docker Hub, if there's a custom Buildx builder configured. There's a bug report here:
<https://github.com/docker/compose/issues/9939>.

This bug means that when the build pipeline builds the `cvat_ci` image, it's based on the latest release of `cvat/server` from Docker Hub instead of the version that we just built. Consequently, we run the unit tests against that release instead of the development version.

Fortunately, we don't actually need to set up a Buildx builder in most jobs (including the `unit_testing` job), so just don't do that.

Also, use `cvat/server:local` as the base image in `Dockerfile.ci`. This will prevent a similar bug from reoccurring in the future, since the `local` tag should never be uploaded to Docker Hub.

<!-- Raised an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [CONTRIBUTION](https://github.com/cvat-ai/cvat/blob/develop/CONTRIBUTING.md)
guide. -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
I saw a unit test that should fail due to a regression since 2.3.0, yet it still succeeds on CI. This should prevent cases like that.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I only changed the build pipelines, so I can't test this myself. 🙂 

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
