### PR TITLE
Fix webhook signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/opencv/cvat/pull/5557>)
 - Windows Installation Instructions adjusted to work around <https://github.com/nuclio/nuclio/issues/1821>
 - The contour detection function for semantic segmentation (<https://github.com/opencv/cvat/pull/4665>)
+- Delete newline character when generating a webhook signature (<https://github.com/opencv/cvat/pull/5622>)
 
 ### Deprecated
 - TDB

--- a/cvat/apps/webhooks/signals.py
+++ b/cvat/apps/webhooks/signals.py
@@ -36,7 +36,7 @@ def send_webhook(webhook, payload, delivery):
             "sha256="
             + hmac.new(
                 webhook.secret.encode("utf-8"),
-                (json.dumps(payload) + "\n").encode("utf-8"),
+                json.dumps(payload).encode("utf-8"),
                 digestmod=hashlib.sha256,
             ).hexdigest()
         )

--- a/site/content/en/docs/administration/advanced/webhooks.md
+++ b/site/content/en/docs/administration/advanced/webhooks.md
@@ -301,6 +301,30 @@ Example of header value for empty request body and `secret = mykey`:
 X-Signature-256: e1b24265bf2e0b20c81837993b4f1415f7b68c503114d100a40601eca6a2745f
 ```
 
+Here is an example of how you can verify a webhook signature in your webhook receiver service:
+
+```python
+# webhook_receiver.py
+
+import hmac
+from hashlib import sha256
+from flask import Flask, request
+
+app = Flask(__name__)
+
+@app.route("/webhook", methods=["POST"])
+def webhook():
+    signature = (
+        "sha256="
+        + hmac.new("mykey".encode("utf-8"), request.data, digestmod=sha256).hexdigest()
+    )
+
+    if hmac.compare_digest(request.headers["X-Signature-256"], signature):
+        return app.response_class(status=200)
+
+    raise app.response_class(status=500, response="Signatures didn't match!")
+```
+
 ## Ping Webhook
 
 To check that webhook configured well and CVAT can connect with target URL you can use `ping` webhook.


### PR DESCRIPTION
### Motivation and context

- [ ] Delete necessary newline during generation of webhook signature
- [ ] Update documentation about webhooks secrets

### How has this been tested?
Run code snippet that verifies webhook signature (see webhook documentation)

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable by a reason then ~~explicitly strikethrough~~ the whole
line. If you don't do that github will show an incorrect process for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into [CHANGELOG](https://github.com/cvat-ai/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the [documentation](
  https://github.com/cvat-ai/cvat/blob/develop/README.md#documentation) accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues ([read github docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
[cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning), [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
  
