### PR TITLE
Select all text in attributes

### DIFF
--- a/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-attribute.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/objects-side-bar/object-item-attribute.tsx
@@ -124,6 +124,14 @@ function ItemAttributeComponent(props: Props): JSX.Element {
     }
 
     if (attrInputType === 'number') {
+        const id = String(Math.floor(Math.random() * 999999));
+
+        // eslint-disable-next-line no-inner-declarations,@typescript-eslint/explicit-function-return-type
+        function selectAllNumbers() {
+            const input = document.getElementById(id) as HTMLInputElement;
+            input.focus();
+            input.select();
+        }
         const [min, max, step] = attrValues.map((value: string): number => +value);
         return (
             <>
@@ -132,6 +140,8 @@ function ItemAttributeComponent(props: Props): JSX.Element {
                 </Col>
                 <Col span={16}>
                     <InputNumber
+                        id={id}
+                        onClick={() => selectAllNumbers()}
                         disabled={readonly}
                         size='small'
                         onChange={(value: number | undefined | string): void => {
@@ -176,6 +186,7 @@ function ItemAttributeComponent(props: Props): JSX.Element {
             </Col>
             <Col span={16}>
                 <Input
+                    onClick={() => { ref.current?.select(); }}
                     ref={ref}
                     size='small'
                     disabled={readonly}


### PR DESCRIPTION
### Motivation and context
Currently user have to delete current attribute value and enter needed one, then press enter.
With this change, when user click on InputNumber/Number, this field selects all innerText so user may just enter new 
value.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
It was tested manually

It is partially related to [this](https://github.com/opencv/cvat/pull/5657) PR
### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.

![2023-02-15_17-23](https://user-images.githubusercontent.com/57707673/219054194-45869c2c-bb75-404f-99c3-6c5469589d45.png)


