### PR TITLE
Fix Yolov7 nuctl function deploy failure

### DIFF
--- a/serverless/onnx/WongKinYiu/yolov7/nuclio/function-gpu.yaml
+++ b/serverless/onnx/WongKinYiu/yolov7/nuclio/function-gpu.yaml
@@ -103,7 +103,7 @@ spec:
         - kind: USER
           value: root
         - kind: RUN
-          value: apt update && apt install --no-install-recommends -y libglib2.0-0
+          value: apt update && apt install --no-install-recommends -y libglib2.0-0 wget
         - kind: WORKDIR
           value: /opt/nuclio
         - kind: RUN


### PR DESCRIPTION
- adds wget installation to build directives in yolov7 function-gpu.yaml
-  the deployment fails because it tries to download the onnx model using wget, but is not installed in the base image ultralytics/yolov5:latest


### Motivation and context
Fix issue #5730 

### How has this been tested?
By running the nuctl
```
#!/bin/bash
# Sample commands to deploy nuclio functions on GPU

SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
FUNCTIONS_DIR=${1:-$SCRIPT_DIR}

nuctl create project cvat

shopt -s globstar

func_config="$FUNCTIONS_DIR/onnx/WongKinYiu/yolov7/nuclio/function-gpu.yaml"

echo "$func_config"
func_root=$(dirname "$func_config")
echo "Deploying $(dirname "$func_root") function..."
nuctl deploy --project-name cvat --path "$func_root" \
    --volume "$SCRIPT_DIR/common:/opt/nuclio/common" \
    --file "$func_config" --platform local


nuctl get function
```

### Checklist
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
