### PR TITLE
Lock 'Ok' button when there is no selected file to upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,7 @@ Tracks can be exported/imported to/from Datumaro and Sly Pointcloud formats (<ht
 - Fix the type of the credentials parameter of make_client from the Python SDK
 - Reduced number of noisy information on ortho views for 3D canvas (<https://github.com/opencv/cvat/pull/5608>)
 - Clean up disk space after a project is removed (<https://github.com/opencv/cvat/pull/5632>)
+- Submit button is locked while file is not selected when importing a dataset (<https://github.com/opencv/cvat/pull/5757>)
 - \[Server API\] Various errors in the generated schema (<https://github.com/opencv/cvat/pull/5575>)
 - SiamMask and TransT serverless functions (<https://github.com/opencv/cvat/pull/5658>)
 - \[Server API\] Ability to rename label to an existing name (<https://github.com/opencv/cvat/pull/5662>)

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.49.0",
+  "version": "1.49.1",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/import-backup/import-backup-modal.tsx
+++ b/cvat-ui/src/components/import-backup/import-backup-modal.tsx
@@ -84,7 +84,7 @@ function ImportBackupModal(): JSX.Element {
         <Form.Item
             label={<Text strong>File name</Text>}
             name='fileName'
-            rules={[{ validator: validateFileName }]}
+            rules={[{ validator: validateFileName }, { required: true, message: 'Please, specify a name' }]}
         >
             <Input
                 placeholder='Backup file name'
@@ -131,15 +131,13 @@ function ImportBackupModal(): JSX.Element {
             <Modal
                 title={(
                     <Text strong>
-                        Create
-                        {instanceType}
-                        {' '}
-                        from backup
+                        {`Create ${instanceType} from backup`}
                     </Text>
                 )}
                 visible={modalVisible}
                 onCancel={closeModal}
                 onOk={() => form.submit()}
+                okButtonProps={{ disabled: selectedSourceStorage?.location === StorageLocation.LOCAL && file === null }}
                 className='cvat-modal-import-backup'
             >
                 <Form

--- a/cvat-ui/src/components/import-backup/import-backup-modal.tsx
+++ b/cvat-ui/src/components/import-backup/import-backup-modal.tsx
@@ -33,6 +33,7 @@ const initialValues: FormValues = {
 
 function ImportBackupModal(): JSX.Element {
     const [form] = Form.useForm();
+    const [formIsValid, setFormIsValid] = useState(false);
     const [file, setFile] = useState<File | null>(null);
     const instanceType = useSelector((state: CombinedState) => state.import.instanceType);
     const modalVisible = useSelector((state: CombinedState) => {
@@ -97,6 +98,7 @@ function ImportBackupModal(): JSX.Element {
         setSelectedSourceStorage({
             location: StorageLocation.LOCAL,
         });
+        setFormIsValid(false);
         setFile(null);
         dispatch(importActions.closeImportBackupModal(instanceType as 'project' | 'task'));
         form.resetFields();
@@ -137,13 +139,22 @@ function ImportBackupModal(): JSX.Element {
                 visible={modalVisible}
                 onCancel={closeModal}
                 onOk={() => form.submit()}
-                okButtonProps={{ disabled: selectedSourceStorage?.location === StorageLocation.LOCAL && file === null }}
+                okButtonProps={{
+                    disabled: !formIsValid || (
+                        selectedSourceStorage?.location === StorageLocation.LOCAL && file === null
+                    ),
+                }}
                 className='cvat-modal-import-backup'
             >
                 <Form
                     name={`Create ${instanceType} from backup file`}
                     form={form}
                     onFinish={handleImport}
+                    onChange={() => {
+                        form.validateFields()
+                            .then(() => setFormIsValid(true))
+                            .catch(() => setFormIsValid(false));
+                    }}
                     layout='vertical'
                     initialValues={initialValues}
                 >
@@ -153,6 +164,7 @@ function ImportBackupModal(): JSX.Element {
                         locationValue={selectedSourceStorage.location}
                         onChangeStorage={(value: StorageData) => setSelectedSourceStorage(new Storage(value))}
                         onChangeLocationValue={(value: StorageLocation) => {
+                            setFormIsValid(false);
                             setSelectedSourceStorage({
                                 location: value,
                             });

--- a/cvat-ui/src/components/import-backup/import-backup-modal.tsx
+++ b/cvat-ui/src/components/import-backup/import-backup-modal.tsx
@@ -69,7 +69,6 @@ function ImportBackupModal(): JSX.Element {
                     return false;
                 }}
                 onRemove={() => {
-                    form.setFieldsValue(form.getFieldsValue(true, (field) => !field.name.includes('dragger')));
                     setFile(null);
                 }}
             >

--- a/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
+++ b/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
@@ -179,9 +179,6 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                     return false;
                 }}
                 onRemove={() => {
-                    form.setFieldsValue(
-                        form.getFieldsValue(true, (field) => !field.name.includes('dragger')),
-                    );
                     setFile(null);
                 }}
             >

--- a/cvat-ui/src/components/import-dataset/styles.scss
+++ b/cvat-ui/src/components/import-dataset/styles.scss
@@ -17,10 +17,6 @@
     color: $text-color-secondary;
 }
 
-.cvat-modal-import-switch-use-default-storage {
-    display: table-cell;
-}
-
 .cvat-modal-import-dataset-status .ant-modal-body {
     display: flex;
     align-items: center;
@@ -33,6 +29,11 @@
     .ant-alert {
         width: 100%;
     }
+}
+
+.cvat-modal-import-switch-use-default-storage,
+.cvat-modal-import-switch-conv-mask-to-poly {
+    display: table-cell;
 }
 
 .cvat-modal-import-switch-use-default-storage-container,

--- a/cvat-ui/src/components/select-cloud-storage/select-cloud-storage.tsx
+++ b/cvat-ui/src/components/select-cloud-storage/select-cloud-storage.tsx
@@ -39,7 +39,7 @@ const searchCloudStoragesWrapper = debounce((phrase, setList) => {
     const filter = {
         filter: JSON.stringify({
             and: [{
-                '==': [{ var: 'display_name' }, phrase],
+                '==': [{ var: 'name' }, phrase],
             }],
         }),
     };


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved #5633
Also fixed storage selection when uploading a dataset

<img width="268" alt="image" src="https://user-images.githubusercontent.com/40690378/220912019-b0596c2d-94f4-4b8f-a26f-18b0cfb6efa4.png">



### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
