### PR TITLE
Git sync fix

### DIFF
--- a/supervisord/server.conf
+++ b/supervisord/server.conf
@@ -21,6 +21,13 @@ childlogdir=%(ENV_HOME)s/logs/            ; where child log files will live
 command=bash -c "if [ \"${CLAM_AV}\" = 'yes' ]; then /usr/bin/freshclam -d \
     -l %(ENV_HOME)s/logs/freshclam.log --foreground=true; fi"
 
+
+[program:ssh-agent]
+command=bash -c "rm /tmp/ssh-agent.sock -f && /usr/bin/ssh-agent -d -a /tmp/ssh-agent.sock"
+priority=1
+autorestart=true
+
+
 [program:runserver]
 ; Here need to run a couple of commands to initialize DB and copy static files.
 ; We cannot initialize DB on build because the DB should be online. Also some
@@ -34,4 +41,7 @@ command=%(ENV_HOME)s/wait-for-it.sh %(ENV_CVAT_POSTGRES_HOST)s:5432 -t 0 -- bash
     --limit-request-body 1073741824 --log-level INFO --include-file ~/mod_wsgi.conf \
     %(ENV_DJANGO_MODWSGI_EXTRA_ARGS)s --locale %(ENV_LC_ALL)s \
     --server-root /tmp/cvat-server"
+
+
+environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock"
 numprocs=%(ENV_NUMPROCS)s


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Currently when user try to open the task with git repository connected he will see this (screenshot)
![2023-02-27_17-01](https://user-images.githubusercontent.com/57707673/221584442-329c8592-6524-4715-9c76-7631553dc135.png)
This happens after first synchronization and reloading the page. The cause of this is ssh-agent, that is not running in cvat_server container.
This PR will enable ssh-agent on cvat_server so this issue disappears.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
It was tested manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
