### PR TITLE
URL-escape the filter in the generated URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Nuclio function invocations when deployed via the Helm chart
   (<https://github.com/opencv/cvat/issues/5626>)
 - Export of a job from a task with multiple jobs (<https://github.com/opencv/cvat/pull/5928>)
+- Escaping in the `filter` parameter in generated URLs
+  (<https://github.com/opencv/cvat/issues/5566>)
 
 ### Security
 - TDB

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.50.4",
+  "version": "1.50.5",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/resource-sorting-filtering/index.ts
+++ b/cvat-ui/src/components/resource-sorting-filtering/index.ts
@@ -22,7 +22,7 @@ function updateHistoryFromQuery(query: Indexable): string {
         ...(query.page ? { page: `${query.page}` } : {}),
     });
 
-    return decodeURIComponent(search.toString());
+    return search.toString();
 }
 
 export {

--- a/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
+++ b/tests/cypress/e2e/issues_prs/issue_5566_filter_url.js
@@ -1,0 +1,64 @@
+// Copyright (C) 2023 CVAT.ai Corporation
+//
+// SPDX-License-Identifier: MIT
+
+const issueId = '5566';
+
+const project = {
+    // Ampersand in the name ensures that the query string will be incorrect
+    // if the UI fails to escape the filter value.
+    name: 'A & B',
+    label: 'Tree',
+    attrName: 'Kind',
+    attrVaue: 'Oak',
+};
+
+context('The filter in the URL is correctly escaped', () => {
+    let projectID;
+
+    function getProjectID() {
+        cy.contains('.cvat-project-name', project.name)
+            .parents('.cvat-project-details')
+            .should('have.attr', 'data-cvat-project-id')
+            .then(($projectID) => {
+                projectID = $projectID;
+            });
+    }
+
+    before(() => {
+        cy.visit('/');
+        cy.login();
+
+        cy.goToProjectsList();
+        cy.createProjects(project.name, project.label, project.attrName, project.attrVaue);
+        cy.openProject(project.name);
+        getProjectID();
+        cy.goToProjectsList();
+    });
+
+    after(() => {
+        cy.deleteProject(project.name, projectID);
+    });
+
+    describe(`Testing issue "${issueId}"`, () => {
+        it('Set a filter for the project name', () => {
+            cy.contains('.cvat-switch-filters-constructor-button', 'Filter').click();
+            cy.get('.cvat-resource-page-filters-builder').within(() => {
+                cy.contains('button', 'Add rule').click();
+                cy.contains('.ant-select-selector', 'Select field').get('input').type('Name{enter}');
+                cy.get('input[placeholder="Enter string"]').type(project.name);
+                cy.contains('button', 'Apply').click();
+            });
+        });
+
+        it('Filter in the URL is valid JSON', () => {
+            cy.location().should((loc) => {
+                const params = new URLSearchParams(loc.search);
+                const filter = params.get('filter');
+                expect(filter).to.be.a('string');
+                const filterObj = JSON.parse(filter);
+                expect(filterObj).to.be.an('object');
+            });
+        });
+    });
+});


### PR DESCRIPTION
Or rather, just don't needlessly unescape it.

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Fixes #5566.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Cypress test.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
