### PR TITLE
Add FAIRs SAM as serverless AI interactor

### DIFF
--- a/serverless/pytorch/facebookresearch/sam/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/function-gpu.yaml
@@ -1,0 +1,67 @@
+metadata:
+  name: pth.facebookresearch.sam.vit_h
+  namespace: cvat
+  annotations:
+    name: vit_h
+    version: 2
+    type: interactor
+    spec:
+    framework: pytorch
+    min_pos_points: 1
+    min_neg_points: 0
+    animated_gif: https://raw.githubusercontent.com/opencv/cvat/0fbb19ae3846a017853d52e187f0ce149adced7d/site/content/en/images/iog_example.gif
+    help_message: The interactor allows to get a mask of an object using at least one positive, and any negative points inside it
+
+spec:
+  description: Interactive Object Segmentation with Segment-Anything
+  runtime: 'python:3.8'
+  handler: main:handler
+  eventTimeout: 30s
+  env:
+    - name: PYTHONPATH
+      value: /opt/nuclio/sam
+
+  build:
+    image: cvat.pth.facebookresearch.sam.vit_h
+    baseImage: ubuntu:22.04
+
+    directives:
+      preCopy:
+      # disable interactive frontend
+        - kind: ENV
+          value: DEBIAN_FRONTEND=noninteractive
+      # set workdir
+        - kind: WORKDIR
+          value: /opt/nuclio/sam
+      # install basic deps
+        - kind: RUN
+          value: apt-get update && apt-get -y install curl git python3 python3-pip ffmpeg libsm6 libxext6
+      # install sam deps
+        - kind: RUN
+          value: pip3 install torch torchvision torchaudio opencv-python pycocotools matplotlib onnxruntime onnx debugpy
+      # install sam code
+        - kind: RUN
+          value: pip3 install git+https://github.com/facebookresearch/segment-anything.git
+      # download sam weights
+        - kind: RUN
+          value: curl -O https://dl.fbaipublicfiles.com/segment_anything/sam_vit_h_4b8939.pth
+      # map pip3 and python3 to pip and python
+        - kind: RUN
+          value: ln -s /usr/bin/pip3 /usr/local/bin/pip && ln -s /usr/bin/python3 /usr/bin/python
+  triggers:
+    myHttpTrigger:
+      maxWorkers: 1
+      kind: 'http'
+      workerAvailabilityTimeoutMilliseconds: 10000
+      attributes:
+        maxRequestBodySize: 33554432 # 32MB
+  resources:
+    limits:
+      nvidia.com/gpu: 1
+
+  platform:
+    attributes:
+      restartPolicy:
+        name: always
+        maximumRetryCount: 3
+      mountMode: volume

--- a/serverless/pytorch/facebookresearch/sam/nuclio/main.py
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/main.py
@@ -1,0 +1,32 @@
+import json
+import base64
+from PIL import Image
+import io
+from model_handler import ModelHandler
+import debugpy
+debugpy.listen(5678)
+
+def init_context(context):
+    context.logger.info("Init context...  0%")
+    model = ModelHandler()
+    context.user_data.model = model
+    context.logger.info("Init context...100%")
+
+def handler(context, event):
+    context.logger.info("call handler")
+    data = event.body
+    pos_points = data["pos_points"]
+    neg_points = data["neg_points"]
+    #obj_bbox = data.get("obj_bbox", None)
+    buf = io.BytesIO(base64.b64decode(data["image"]))
+    image = Image.open(buf)
+    image = image.convert("RGB")  #  to make sure image comes in RGB
+    mask, polygon = context.user_data.model.handle(image, pos_points, neg_points)
+    return context.Response(body=json.dumps({
+            'points': polygon,
+            'mask': mask.tolist(),
+        }),
+        headers={},
+        content_type='application/json',
+        status_code=200
+    )

--- a/serverless/pytorch/facebookresearch/sam/nuclio/model_handler.py
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/model_handler.py
@@ -1,0 +1,96 @@
+import numpy as np
+import cv2
+import torch
+from segment_anything import sam_model_registry, SamPredictor
+
+
+def convert_mask_to_polygon(mask):
+    contours = None
+    if int(cv2.__version__.split('.')[0]) > 3:
+        contours = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_TC89_KCOS)[0]
+    else:
+        contours = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_TC89_KCOS)[1]
+
+    contours = max(contours, key=lambda arr: arr.size)
+    if contours.shape.count(1):
+        contours = np.squeeze(contours)
+    if contours.size < 3 * 2:
+        raise Exception('Less then three point have been detected. Can not build a polygon.')
+
+    polygon = []
+    for point in contours:
+        polygon.append([int(point[0]), int(point[1])])
+
+    return polygon
+
+class ModelHandler:
+    def __init__(self):
+        sam_weights = "/opt/nuclio/sam/sam_vit_h_4b8939.pth"
+        device = "cuda"
+        model_type = "default"
+        sam_model = sam_model_registry[model_type](checkpoint=sam_weights)
+        sam_model.to(device=device)
+        self.predictor = SamPredictor
+
+    def handle(self, image, pos_points, neg_points):
+        self.predictor.set_image(image)
+        # we assume that pos_points and neg_points are of type:
+        # np.array[[x, y], [x, y], ...]
+        pos_points = np.array(pos_points)
+        neg_points = np.array(neg_points)
+        assert type(pos_points) == np.ndarray, f"found {type(pos_points)}"
+        assert type(neg_points) == np.ndarray, f"found {type(neg_points)}"
+        # the pos_points get label 1, the neg_points get label 0. Labels in input_labels must be in same order as points in input_points
+
+        input_points = np.concatenate([pos_points, neg_points], axis=0)
+        input_labels = np.concatenate([np.array([1]*len(pos_points)), np.array([0]*len(neg_points))])
+        masks, _, _ = self.predictor.predict(point_coords=input_points, point_labels=input_labels, multimask_output=False)
+        polygon = convert_mask_to_polygon(masks)
+        return masks, polygon
+
+
+
+        # with torch.no_grad():
+        #     # Create IOG image
+        #     pos_gt = np.zeros(shape=input_crop.shape[:2], dtype=np.float64)
+        #     neg_gt = np.zeros(shape=input_crop.shape[:2], dtype=np.float64)
+        #     for p in pos_points:
+        #         pos_gt = np.maximum(pos_gt, helpers.make_gaussian(pos_gt.shape, center=p))
+        #     for p in neg_points:
+        #         neg_gt = np.maximum(neg_gt, helpers.make_gaussian(neg_gt.shape, center=p))
+        #     iog_image = np.stack((pos_gt, neg_gt), axis=2).astype(dtype=input_crop.dtype)
+
+        #     # Convert iog_image to an image (0-255 values)
+        #     cv2.normalize(iog_image, iog_image, 0, 255, cv2.NORM_MINMAX)
+
+        #     # Concatenate input crop and IOG image
+        #     input_blob = np.concatenate((input_crop, iog_image), axis=2)
+
+        #     # numpy image: H x W x C
+        #     # torch image: C X H X W
+        #     input_blob = input_blob.transpose((2, 0, 1))
+        #     # batch size is 1
+        #     input_blob = np.array([input_blob])
+        #     input_tensor = torch.from_numpy(input_blob)
+
+        #     input_tensor = input_tensor.to(self.device)
+        #     output_mask = self.net.forward(input_tensor)[4]
+        #     output_mask = output_mask.to(self.device)
+        #     pred = np.transpose(output_mask.data.numpy()[0, :, :, :], (1, 2, 0))
+        #     pred = pred > threshold
+        #     pred = np.squeeze(pred)
+
+        #     # Convert a mask to a polygon
+        #     pred = np.array(pred, dtype=np.uint8)
+        #     pred = cv2.resize(pred, dsize=(crop_shape[0], crop_shape[1]),
+        #         interpolation=cv2.INTER_CUBIC)
+        #     cv2.normalize(pred, pred, 0, 255, cv2.NORM_MINMAX)
+
+        #     mask = np.zeros((image.height, image.width), dtype=np.uint8)
+        #     x = int(crop_bbox[0])
+        #     y = int(crop_bbox[1])
+        #     mask[y : y + crop_shape[1], x : x + crop_shape[0]] = pred
+
+        #     polygon = convert_mask_to_polygon(mask)
+
+        #     return mask, polygon


### PR DESCRIPTION
I'm not affiliated with FAIR or Meta in any way. Just thought that including it as an interactor would be extremely helpful considering SAMs outstanding performance.

I just added a new interactor under serverless/pytorch/facebookresearch/

Currently this is not ready.
When trying to set a positive or negative point,  I'm getting:
Error: Request failed with status code 503. "('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))"
or 
cvat Error: Request failed with status code 503. "HTTPConnectionPool(host='host.docker.internal', port=32857): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f96c8e88460>: Failed to establish a new connection: [Errno 111] Connection refused'))".

And I'm not sure why this happens.
If anyone has an idea feel free to help out. I might get back to it after the weekend maybe?
### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] ~~I have increased versions of npm packages if it is necessary~~
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
