### PR TITLE
Fix bugs the public key is not available of cuda while deploy gpu model Mask-RCNN to serverless nuclio.

### DIFF
--- a/serverless/tensorflow/matterport/mask_rcnn/nuclio/function-gpu.yaml
+++ b/serverless/tensorflow/matterport/mask_rcnn/nuclio/function-gpu.yaml
@@ -107,6 +107,16 @@ spec:
         - kind: WORKDIR
           value: /opt/nuclio
         - kind: RUN
+          value: apt-get install gcc
+        - kind: RUN
+          value: apt-get install wget
+        - kind: RUN
+          value: rm /etc/apt/sources.list.d/cuda.list
+        - kind: RUN
+          value: apt-key del 7fa2af80 && distribution=$(. /etc/os-release;echo $ID$VERSION_ID | sed -e 's/\.//g') && wget https://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_64/cuda-keyring_1.0-1_all.deb
+        - kind: RUN
+          value: dpkg -i cuda-keyring_1.0-1_all.deb
+        - kind: RUN
           value: apt update && apt install --no-install-recommends -y git curl
         - kind: RUN
           value: git clone --depth 1 https://github.com/matterport/Mask_RCNN.git


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Fix bugs the public key is not available of cuda while deploy gpu model Mask-RCNN to serverless nuclio

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

- Run command: 
serverless/deploy_gpu.sh serverless/tensorflow/matterport/mask_rcnn => Result: Deploy successful.
- Run command: 
nuctl deploy --project-name cvat \
  --path serverless/tensorflow/matterport/mask_rcnn/nuclio \
  --platform local --base-image tensorflow/tensorflow:1.15.5-gpu-py3 \
  --desc "GPU based implementation of Mask RCNN on Python 3, Keras, and TensorFlow." \
  --image cvat/tf.matterport.mask_rcnn_gpu \
  --triggers '{"myHttpTrigger": {"maxWorkers": 1}}' \
  --resource-limit nvidia.com/gpu=1  => Result: Deploy fail. Solution: Fix in file function.yaml.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
