### PR TITLE
Fix tus loading if multiple apache processes are used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Server micro version support check in SDK/CLI (<https://github.com/opencv/cvat/pull/5991>)
 - \[SDK\] Compatibility with upcoming urllib 2.1.0
   (<https://github.com/opencv/cvat/pull/6002>)
+- Fix TUS file uploading if multiple apache processes are used (<https://github.com/opencv/cvat/pull/6006>)
 
 ### Security
 - TDB

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -3,21 +3,22 @@
 #
 # SPDX-License-Identifier: MIT
 
-import os
 import base64
-from unittest import mock
-import uuid
 import json
-from dataclasses import dataclass, asdict
+import os
+import uuid
+from dataclasses import asdict, dataclass
+from distutils.util import strtobool
+from unittest import mock
 
 from django.conf import settings
-from distutils.util import strtobool
-from rest_framework import status, mixins
+from rest_framework import mixins, status
 from rest_framework.response import Response
 
-from cvat.apps.engine.models import Location
 from cvat.apps.engine.location import StorageType, get_location_configuration
+from cvat.apps.engine.models import Location
 from cvat.apps.engine.serializers import DataSerializer
+
 
 class TusFile:
     @dataclass

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -23,8 +23,9 @@ from cvat.apps.engine.serializers import DataSerializer
 class TusFile:
     @dataclass
     class TusMeta:
-        filename: str = ""
-        file_size: int = 0
+        metadata: dict
+        filename: str
+        file_size: int
         offset: int = 0
 
     class TusMetaFile():
@@ -53,7 +54,7 @@ class TusFile:
                 with open(self._path, "w") as fp:
                     json.dump(asdict(self._meta), fp)
 
-        def is_exist(self):
+        def exists(self):
             return os.path.exists(self._path)
 
         def delete(self):
@@ -80,8 +81,8 @@ class TusFile:
     def offset(self):
         return self.meta_file.meta.offset
 
-    def is_exist(self):
-        return self.meta_file.is_exist()
+    def exists(self):
+        return self.meta_file.exists()
 
     @staticmethod
     def _get_tus_meta_file_path(file_id, upload_dir):
@@ -130,6 +131,7 @@ class TusFile:
                 filename=filename,
                 file_size=file_size,
                 offset=0,
+                metadata=metadata,
             ),
         )
         tus_file.init_file()
@@ -242,7 +244,7 @@ class UploadMixin:
     def append_tus_chunk(self, request, file_id):
         tus_file = TusFile(str(file_id), self.get_upload_dir())
         if request.method == 'HEAD':
-            if tus_file.is_exist():
+            if tus_file.exists():
                 return self._tus_response(status=status.HTTP_200_OK, extra_headers={
                                'Upload-Offset': tus_file.offset,
                                'Upload-Length': tus_file.file_size})


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manually by set `--processes 3` for `mod_wsgi` settings

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
