### PR TITLE
Dockerfile: retain the pip download cache between builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,14 +44,16 @@ RUN curl -sL https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 --outp
 # Build wheels for all dependencies
 ARG PIP_VERSION
 ARG PIP_DISABLE_PIP_VERSION_CHECK=1
-RUN python3 -m pip install -U pip==${PIP_VERSION}
+RUN --mount=type=cache,target=/root/.cache/pip/http \
+    python3 -m pip install -U pip==${PIP_VERSION}
 COPY cvat/requirements/ /tmp/requirements/
 COPY utils/dataset_manifest/ /tmp/dataset_manifest/
 
 # The server implementation depends on the dataset_manifest utility
 # so we need to build its dependencies too
 # https://github.com/opencv/cvat/issues/5096
-RUN DATUMARO_HEADLESS=1 python3 -m pip wheel --no-cache-dir \
+RUN --mount=type=cache,target=/root/.cache/pip/http \
+    DATUMARO_HEADLESS=1 python3 -m pip wheel \
     -r /tmp/requirements/${DJANGO_CONFIGURATION}.txt \
     -r /tmp/dataset_manifest/requirements.txt \
     -w /tmp/wheelhouse

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,6 +43,7 @@ RUN curl -sL https://ffmpeg.org/releases/ffmpeg-${FFMPEG_VERSION}.tar.bz2 --outp
 
 # Build wheels for all dependencies
 ARG PIP_VERSION
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
 RUN python3 -m pip install -U pip==${PIP_VERSION}
 COPY cvat/requirements/ /tmp/requirements/
 COPY utils/dataset_manifest/ /tmp/dataset_manifest/
@@ -146,6 +147,8 @@ COPY --from=build-image /tmp/openh264/openh264*.tar.gz /tmp/ffmpeg/ffmpeg*.tar.g
 RUN python3 -m venv /opt/venv
 ENV PATH="/opt/venv/bin:${PATH}"
 ARG PIP_VERSION
+ARG PIP_DISABLE_PIP_VERSION_CHECK=1
+
 RUN python -m pip install -U pip==${PIP_VERSION}
 RUN --mount=type=bind,from=build-image,source=/tmp/wheelhouse,target=/mnt/wheelhouse \
     python -m pip install --no-index /mnt/wheelhouse/*.whl


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This speeds up the build when the entire step can't be cached (e.g. the requirements file changed), but the package list remains mostly the same.

The savings are... rather underwhelming, actually. I have observed about a minute in savings, although it obviously depends on the network connection speed. I think this is because pip is inefficient at loading from its own cache (I have observed it loading the entire cached file into memory, for example).

Still, savings are savings, and we're getting them basically for free, so why not.

Note that I only persist the HTTP cache, and not the wheel cache. That's because any wheels that pip builds could depend on the system packages, and I don't want old wheels to be reused if the system packages change.

Also, disable the pip autoupdate checks, which isn't much of an optimization, but it gets rid of some pointless warnings.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
`docker build`

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
