### PR TITLE
Error while enabling SAM on CPU

### DIFF
--- a/serverless/deploy_cpu.sh
+++ b/serverless/deploy_cpu.sh
@@ -24,7 +24,8 @@ do
     fi
 
     echo "Deploying $func_rel_path function..."
-    nuctl deploy --project-name cvat --path "$func_root" --file "$func_config" --platform local
+    nuctl deploy --project-name cvat --path "$func_root" \
+        --file "$func_config" --platform local
 done
 
 nuctl get function --platform local

--- a/serverless/deploy_cpu.sh
+++ b/serverless/deploy_cpu.sh
@@ -24,7 +24,7 @@ do
     fi
 
     echo "Deploying $func_rel_path function..."
-    nuctl deploy --project-name cvat --path "$func_root" --platform local
+    nuctl deploy --project-name cvat --path "$func_root" --file "$func_config" --platform local
 done
 
 nuctl get function --platform local


### PR DESCRIPTION
This PR solves issue #6247 "Error while enabling SAM on CPU".

It looks like the `--file` argument to `nuctl deploy` was inadvertently removed in the most recent release. This causes the process to fail with `**Error - Function name cannot be empty`. I was able to reproduce this error on my own system.

### Motivation and context

This change fixes a minor error.

### How has this been tested?

I tested this by reproducing the bug with the command from the `cvat/components` directory:

`nuctl deploy --project-name cvat --path "./serverless/pytorch/foolwood/siammask/nuclio" --platform local`

I then edited the `deploy_cpu.sh` file, executed the same command, and completed a successful deployment, which I verified with `nuctl get functions`.

### Checklist

- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary~~
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
