### PR TITLE
docs: Describe changing default OPA permissions

### DIFF
--- a/site/content/en/docs/administration/advanced/iam_system_roles.md
+++ b/site/content/en/docs/administration/advanced/iam_system_roles.md
@@ -7,4 +7,17 @@ weight: 70
 <!--lint disable heading-style-->
 
 ## System roles
+
+By default CVAT users can be assigned to one of the following groups: `admin`, `business`, `user` and `worker`.
+
+Each of these groups gives a set of permissions.
 TBD
+
+## Changing permissions
+
+System permissions are defined using `.rego` files stored in `cvat/apps/iam/rules/`.
+Rego is a declarative language used for defining OPA policies.
+It's syntax is defined in [OPA docs](https://www.openpolicyagent.org/docs/latest/policy-language/).
+
+After changing the `.rego` files, you need to rebuilt and restart the docker compose for the changes to take effect.
+In this case you need to include `docker-compose.dev.yml` compose config file to `docker compose` command.


### PR DESCRIPTION
Followup to discussion from: https://github.com/opencv/cvat/issues/6224

This issue is linked with: https://github.com/opencv/cvat/pull/3788 which introduced IAM, but not docummented some aspets.

### Motivation and context

This is my small attempt to fill part of docs which describes how to change default permissions.

It would be great if @nmanovic would also fill part describing default groups.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
