### PR TITLE
CLI: don't set `discard_unknown_keys`

### DIFF
--- a/cvat-cli/src/cvat_cli/cli.py
+++ b/cvat-cli/src/cvat_cli/cli.py
@@ -17,10 +17,6 @@ class CLI:
     def __init__(self, client: Client, credentials: Tuple[str, str]):
         self.client = client
 
-        # allow arbitrary kwargs in models
-        # TODO: will silently ignore invalid args, so remove this ASAP
-        self.client.api_client.configuration.discard_unknown_keys = True
-
         self.client.login(credentials)
 
         self.client.check_server_version(fail_if_unsupported=False)
@@ -51,11 +47,21 @@ class CLI:
         """
         Create a new task with the given name and labels JSON and add the files to it.
         """
+
+        task_params = {}
+        data_params = {}
+
+        for k, v in kwargs.items():
+            if k in models.DataRequest.attribute_map or k == "frame_step":
+                data_params[k] = v
+            else:
+                task_params[k] = v
+
         task = self.client.tasks.create_from_data(
-            spec=models.TaskWriteRequest(name=name, labels=labels, **kwargs),
+            spec=models.TaskWriteRequest(name=name, labels=labels, **task_params),
             resource_type=resource_type,
             resources=resources,
-            data_params=kwargs,
+            data_params=data_params,
             annotation_path=annotation_path,
             annotation_format=annotation_format,
             status_check_period=status_check_period,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
For unclear reasons, when this setting is enabled, the OpenAPI Generator runtime becomes unable to parse `AnnotationsRead` values from JSON.

Specifically, it thinks that the JSON value is ambiguous, because it can be parsed both as `LabeledData` and as `IOBase`. The former makes sense, but the latter does not. I think it's just a bug in the runtime.

This line is why the issue only occurs when `discard_unknown_keys` is set:

https://github.com/OpenAPITools/openapi-generator/blob/v6.0.1/modules/openapi-generator/src/main/resources/python/model_utils.mustache#L1139

The CLI currently doesn't parse `AnnotationRead` anywhere, so this patch doesn't have any user-visible effects. However, I'm prototyping a new CLI command which will need to parse annotations.

Change `tasks_create` so that it routes kwargs to the appropriate destinations instead of passing all of them both to `TaskWriteRequest` and `create_from_data`. I don't think this is _really_ necessary (the extra arguments should just be ignored), but it makes the code more illustrative.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
