### PR TITLE
Minor CI improvements

### DIFF
--- a/cvat/settings/testing.py
+++ b/cvat/settings/testing.py
@@ -95,3 +95,7 @@ class PatchedDiscoverRunner(DiscoverRunner):
             config["ASYNC"] = False
 
         super().__init__(*args, **kwargs)
+
+# No need to profile unit tests
+INSTALLED_APPS.remove('silk')
+MIDDLEWARE.remove('silk.middleware.SilkyMiddleware')

--- a/cvat/settings/testing_rest.py
+++ b/cvat/settings/testing_rest.py
@@ -17,3 +17,9 @@ PASSWORD_HASHERS = [
 QUALITY_CHECK_JOB_DELAY = 10000
 
 IMPORT_CACHE_CLEAN_DELAY = timedelta(seconds=30)
+
+# The tests should not fail due to high disk utilization of CI infrastructure that we have no control over
+# But let's keep this check enabled
+HEALTH_CHECK = {
+    'DISK_USAGE_MAX': 100,  # percent
+}


### PR DESCRIPTION
Disable silk progiler for unit tests, adjust disk utilization threshold for rest tests

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
rest api test fail by disk usage threshold
https://github.com/opencv/cvat/actions/runs/5599104736/jobs/10259789498
unit tests take 50 min vs 25 min without profiling
https://github.com/opencv/cvat/actions/runs/5599991927/jobs/10248711685

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
