### PR TITLE
Fix BrowsableAPIRenderer for server viewset

### DIFF
--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -194,13 +194,13 @@ class ServerViewSet(viewsets.ViewSet):
         })
     @action(detail=False, methods=['GET'], url_path='plugins', serializer_class=PluginsSerializer)
     def plugins(request):
-        response = {
+        data = {
             'GIT_INTEGRATION': apps.is_installed('cvat.apps.dataset_repo'),
             'ANALYTICS': strtobool(os.environ.get("CVAT_ANALYTICS", '0')),
             'MODELS': strtobool(os.environ.get("CVAT_SERVERLESS", '0')),
             'PREDICT': False, # FIXME: it is unused anymore (for UI only)
         }
-        return Response(response)
+        return Response(PluginsSerializer(data).data)
 
 @extend_schema(tags=['projects'])
 @extend_schema_view(

--- a/cvat/apps/iam/permissions.py
+++ b/cvat/apps/iam/permissions.py
@@ -62,7 +62,7 @@ def get_organization(request, obj):
         except AttributeError as exc:
             # Skip initialization of organization for those objects that don't related with organization
             view = request.parser_context.get('view')
-            if view and view.basename in ('user', 'function', 'request',):
+            if view and view.basename in ('user', 'function', 'request', 'server'):
                 return request.iam_context['organization']
 
             raise exc


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context

Resolved #6550 

<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
```python
ERROR:django.request:Internal Server Error: /api/server/annotation/formats
Traceback (most recent call last):
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/django/core/handlers/base.py", line 220, in _get_response
    response = response.render()
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/django/template/response.py", line 114, in render
    self.content = self.rendered_content
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/rest_framework/response.py", line 70, in rendered_content
    ret = renderer.render(self.data, accepted_media_type, context)
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/rest_framework/renderers.py", line 723, in render
    context = self.get_context(data, accepted_media_type, renderer_context)
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/rest_framework/renderers.py", line 697, in get_context
    'options_form': self.get_rendered_html_form(data, view, 'OPTIONS', request),
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/rest_framework/renderers.py", line 475, in get_rendered_html_form
    if not self.show_form_for_method(view, method, request, instance):
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/rest_framework/renderers.py", line 432, in show_form_for_method
    view.check_object_permissions(request, obj)
  File "/home/andrey/workspace/cvat.ai/cvat/.env/lib/python3.10/site-packages/rest_framework/views.py", line 345, in check_object_permissions
    if not permission.has_object_permission(request, self, obj):
  File "/home/andrey/workspace/cvat.ai/cvat/cvat/apps/iam/permissions.py", line 2015, in has_object_permission
    return self.check_permission(request, view, obj)
  File "/home/andrey/workspace/cvat.ai/cvat/cvat/apps/iam/permissions.py", line 1990, in check_permission
    iam_context = get_iam_context(request, obj)
  File "/home/andrey/workspace/cvat.ai/cvat/cvat/apps/iam/permissions.py", line 88, in get_iam_context
    organization = get_organization(request, obj)
  File "/home/andrey/workspace/cvat.ai/cvat/cvat/apps/iam/permissions.py", line 68, in get_organization
    raise exc
  File "/home/andrey/workspace/cvat.ai/cvat/cvat/apps/iam/permissions.py", line 61, in get_organization
    organization_id = getattr(obj, 'organization_id')
AttributeError: 'dict' object has no attribute 'organization_id'
````

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
```terminal
curl --header "Accept: text/html"  --user "user:pass" http://localhost:8080/api/server/annotation/formats
```

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
