### PR TITLE
Revamp the progress reporting API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## \[Unreleased]
 ### Added
 
-- TDB
+- \[SDK\] A `TqdmProgressReporter2` class was added, which doesn't have glitchy output
+  like `TqdmProgressReporter` in certain circumstances
+  (<https://github.com/opencv/cvat/pull/6556>)
 
 ### Changed
 
-- TDB
+- \[SDK\] Custom `ProgressReporter` implementations should now override `start2` instead of `start`
+  (<https://github.com/opencv/cvat/pull/6556>)
 
 ### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## \[Unreleased]
 ### Added
 
-- \[SDK\] A `TqdmProgressReporter2` class was added, which doesn't have glitchy output
+- \[SDK\] A `DeferredTqdmProgressReporter` class, which doesn't have glitchy output
   like `TqdmProgressReporter` in certain circumstances
   (<https://github.com/opencv/cvat/pull/6556>)
 

--- a/cvat-cli/src/cvat_cli/cli.py
+++ b/cvat-cli/src/cvat_cli/cli.py
@@ -8,7 +8,7 @@ import json
 from typing import Dict, List, Sequence, Tuple
 
 from cvat_sdk import Client, models
-from cvat_sdk.core.helpers import TqdmProgressReporter2
+from cvat_sdk.core.helpers import DeferredTqdmProgressReporter
 from cvat_sdk.core.proxies.tasks import ResourceType
 
 
@@ -66,7 +66,7 @@ class CLI:
             status_check_period=status_check_period,
             dataset_repository_url=dataset_repository_url,
             use_lfs=lfs,
-            pbar=TqdmProgressReporter2(),
+            pbar=DeferredTqdmProgressReporter(),
         )
         print("Created task id", task.id)
 
@@ -108,7 +108,7 @@ class CLI:
         self.client.tasks.retrieve(obj_id=task_id).export_dataset(
             format_name=fileformat,
             filename=filename,
-            pbar=TqdmProgressReporter2(),
+            pbar=DeferredTqdmProgressReporter(),
             status_check_period=status_check_period,
             include_images=include_images,
         )
@@ -122,17 +122,21 @@ class CLI:
             format_name=fileformat,
             filename=filename,
             status_check_period=status_check_period,
-            pbar=TqdmProgressReporter2(),
+            pbar=DeferredTqdmProgressReporter(),
         )
 
     def tasks_export(self, task_id: str, filename: str, *, status_check_period: int = 2) -> None:
         """Download a task backup"""
         self.client.tasks.retrieve(obj_id=task_id).download_backup(
-            filename=filename, status_check_period=status_check_period, pbar=TqdmProgressReporter2()
+            filename=filename,
+            status_check_period=status_check_period,
+            pbar=DeferredTqdmProgressReporter(),
         )
 
     def tasks_import(self, filename: str, *, status_check_period: int = 2) -> None:
         """Import a task from a backup file"""
         self.client.tasks.create_from_backup(
-            filename=filename, status_check_period=status_check_period, pbar=TqdmProgressReporter2()
+            filename=filename,
+            status_check_period=status_check_period,
+            pbar=DeferredTqdmProgressReporter(),
         )

--- a/cvat-cli/src/cvat_cli/cli.py
+++ b/cvat-cli/src/cvat_cli/cli.py
@@ -7,9 +7,8 @@ from __future__ import annotations
 import json
 from typing import Dict, List, Sequence, Tuple
 
-import tqdm
 from cvat_sdk import Client, models
-from cvat_sdk.core.helpers import TqdmProgressReporter
+from cvat_sdk.core.helpers import TqdmProgressReporter2
 from cvat_sdk.core.proxies.tasks import ResourceType
 
 
@@ -67,7 +66,7 @@ class CLI:
             status_check_period=status_check_period,
             dataset_repository_url=dataset_repository_url,
             use_lfs=lfs,
-            pbar=self._make_pbar(),
+            pbar=TqdmProgressReporter2(),
         )
         print("Created task id", task.id)
 
@@ -109,7 +108,7 @@ class CLI:
         self.client.tasks.retrieve(obj_id=task_id).export_dataset(
             format_name=fileformat,
             filename=filename,
-            pbar=self._make_pbar(),
+            pbar=TqdmProgressReporter2(),
             status_check_period=status_check_period,
             include_images=include_images,
         )
@@ -123,22 +122,17 @@ class CLI:
             format_name=fileformat,
             filename=filename,
             status_check_period=status_check_period,
-            pbar=self._make_pbar(),
+            pbar=TqdmProgressReporter2(),
         )
 
     def tasks_export(self, task_id: str, filename: str, *, status_check_period: int = 2) -> None:
         """Download a task backup"""
         self.client.tasks.retrieve(obj_id=task_id).download_backup(
-            filename=filename, status_check_period=status_check_period, pbar=self._make_pbar()
+            filename=filename, status_check_period=status_check_period, pbar=TqdmProgressReporter2()
         )
 
     def tasks_import(self, filename: str, *, status_check_period: int = 2) -> None:
         """Import a task from a backup file"""
         self.client.tasks.create_from_backup(
-            filename=filename, status_check_period=status_check_period, pbar=self._make_pbar()
-        )
-
-    def _make_pbar(self, title: str = None) -> TqdmProgressReporter:
-        return TqdmProgressReporter(
-            tqdm.tqdm(unit_scale=True, unit="B", unit_divisor=1024, desc=title)
+            filename=filename, status_check_period=status_check_period, pbar=TqdmProgressReporter2()
         )

--- a/cvat-sdk/cvat_sdk/core/helpers.py
+++ b/cvat-sdk/cvat_sdk/core/helpers.py
@@ -66,11 +66,11 @@ class TqdmProgressReporter(_BaseTqdmProgressReporter):
 
         self.tqdm = instance
 
-    def start2(self, **kwargs) -> None:
-        super().start2(**kwargs)
+    def start2(self, total: int, *, desc: Optional[str] = None, **kwargs) -> None:
+        super().start2(total=total, desc=desc, **kwargs)
 
-        self.tqdm.reset(kwargs.get("total"))
-        self.tqdm.set_description_str(kwargs.get("desc"))
+        self.tqdm.reset(total)
+        self.tqdm.set_description_str(desc)
 
     def finish(self):
         self.tqdm.refresh()
@@ -83,11 +83,34 @@ class TqdmProgressReporter2(_BaseTqdmProgressReporter):
         self.tqdm_args = tqdm_args or {}
         self.tqdm = None
 
-    def start2(self, **kwargs) -> None:
-        super().start2(**kwargs)
+    def start2(
+        self,
+        total: int,
+        *,
+        desc: Optional[str] = None,
+        unit: str = "it",
+        unit_scale: bool = False,
+        unit_divisor: int = 1000,
+        **kwargs,
+    ) -> None:
+        super().start2(
+            total=total,
+            desc=desc,
+            unit=unit,
+            unit_scale=unit_scale,
+            unit_divisor=unit_divisor,
+            **kwargs,
+        )
         assert not self.tqdm
 
-        self.tqdm = tqdm.tqdm(**self.tqdm_args, **kwargs)
+        self.tqdm = tqdm.tqdm(
+            **self.tqdm_args,
+            total=total,
+            desc=desc,
+            unit=unit,
+            unit_scale=unit_scale,
+            unit_divisor=unit_divisor,
+        )
 
     def finish(self):
         self.tqdm.close()

--- a/cvat-sdk/cvat_sdk/core/helpers.py
+++ b/cvat-sdk/cvat_sdk/core/helpers.py
@@ -62,7 +62,7 @@ class _BaseTqdmProgressReporter(BaseProgressReporter):
 class TqdmProgressReporter(_BaseTqdmProgressReporter):
     def __init__(self, instance: tqdm.tqdm) -> None:
         super().__init__()
-        warnings.warn(f"use {TqdmProgressReporter2.__name__} instead", DeprecationWarning)
+        warnings.warn(f"use {DeferredTqdmProgressReporter.__name__} instead", DeprecationWarning)
 
         self.tqdm = instance
 
@@ -77,7 +77,7 @@ class TqdmProgressReporter(_BaseTqdmProgressReporter):
         super().finish()
 
 
-class TqdmProgressReporter2(_BaseTqdmProgressReporter):
+class DeferredTqdmProgressReporter(_BaseTqdmProgressReporter):
     def __init__(self, tqdm_args: Optional[dict] = None) -> None:
         super().__init__()
         self.tqdm_args = tqdm_args or {}

--- a/cvat-sdk/cvat_sdk/core/helpers.py
+++ b/cvat-sdk/cvat_sdk/core/helpers.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import io
 import json
+import warnings
 from typing import Any, Dict, Iterable, List, Optional, Union
 
 import tqdm
@@ -13,7 +14,7 @@ import urllib3
 
 from cvat_sdk import exceptions
 from cvat_sdk.api_client.api_client import Endpoint
-from cvat_sdk.core.progress import ProgressReporter
+from cvat_sdk.core.progress import BaseProgressReporter, ProgressReporter
 
 
 def get_paginated_collection(
@@ -46,39 +47,60 @@ def get_paginated_collection(
     return results
 
 
-class TqdmProgressReporter(ProgressReporter):
-    def __init__(self, instance: tqdm.tqdm) -> None:
-        super().__init__()
-        self.tqdm = instance
-
-    @property
-    def period(self) -> float:
-        return 0
-
-    def start(self, total: int, *, desc: Optional[str] = None):
-        self.tqdm.reset(total)
-        self.tqdm.set_description_str(desc)
+class _BaseTqdmProgressReporter(BaseProgressReporter):
+    tqdm: Optional[tqdm.tqdm]
 
     def report_status(self, progress: int):
+        super().report_status(progress)
         self.tqdm.update(progress - self.tqdm.n)
 
     def advance(self, delta: int):
+        super().advance(delta)
         self.tqdm.update(delta)
+
+
+class TqdmProgressReporter(_BaseTqdmProgressReporter):
+    def __init__(self, instance: tqdm.tqdm) -> None:
+        super().__init__()
+        warnings.warn(f"use {TqdmProgressReporter2.__name__} instead", DeprecationWarning)
+
+        self.tqdm = instance
+
+    def start2(self, **kwargs) -> None:
+        super().start2(**kwargs)
+
+        self.tqdm.reset(kwargs.get("total"))
+        self.tqdm.set_description_str(kwargs.get("desc"))
 
     def finish(self):
         self.tqdm.refresh()
+        super().finish()
+
+
+class TqdmProgressReporter2(_BaseTqdmProgressReporter):
+    def __init__(self, tqdm_args: Optional[dict] = None) -> None:
+        super().__init__()
+        self.tqdm_args = tqdm_args or {}
+        self.tqdm = None
+
+    def start2(self, **kwargs) -> None:
+        super().start2(**kwargs)
+        assert not self.tqdm
+
+        self.tqdm = tqdm.tqdm(**self.tqdm_args, **kwargs)
+
+    def finish(self):
+        self.tqdm.close()
+        self.tqdm = None
+        super().finish()
 
 
 class StreamWithProgress:
-    def __init__(self, stream: io.RawIOBase, pbar: ProgressReporter, length: Optional[int] = None):
+    def __init__(self, stream: io.RawIOBase, pbar: ProgressReporter):
         self.stream = stream
         self.pbar = pbar
 
-        if hasattr(stream, "__len__"):
-            length = len(stream)
-
-        self.length = length
-        pbar.start(length)
+        assert self.stream.tell() == 0
 
     def read(self, size=-1):
         chunk = self.stream.read(size)
@@ -86,21 +108,14 @@ class StreamWithProgress:
             self.pbar.advance(len(chunk))
         return chunk
 
-    def __len__(self):
-        return self.length
+    def seek(self, pos: int, whence: int = io.SEEK_SET) -> None:
+        old_pos = self.stream.tell()
+        new_pos = self.stream.seek(pos, whence)
+        self.pbar.advance(new_pos - old_pos)
+        return new_pos
 
-    def seek(self, pos, start=0):
-        self.stream.seek(pos, start)
-        self.pbar.report_status(pos)
-
-    def tell(self):
+    def tell(self) -> int:
         return self.stream.tell()
-
-    def __enter__(self) -> StreamWithProgress:
-        return self
-
-    def __exit__(self, exc_type, exc_value, exc_traceback) -> None:
-        self.pbar.finish()
 
 
 def expect_status(codes: Union[int, Iterable[int]], response: urllib3.HTTPResponse) -> None:

--- a/cvat-sdk/cvat_sdk/core/progress.py
+++ b/cvat-sdk/cvat_sdk/core/progress.py
@@ -5,35 +5,56 @@
 
 from __future__ import annotations
 
-import math
-from typing import Iterable, Optional, Tuple, TypeVar
+import contextlib
+from typing import ContextManager, Iterable, Optional, TypeVar
 
 T = TypeVar("T")
 
 
 class ProgressReporter:
     """
-    Only one set of methods must be called:
-        - start - report_status / advance - finish
-        - iter
-        - split
+    Use as follows:
 
-    This class is supposed to manage the state of children progress bars
-    and release of their resources, if necessary.
+    with r.task(...):
+        r.report_status(...)
+        r.advance(...)
+
+        for x in r.iter(...):
+            ...
+
+    Implementations must override start2, finish, report_status and advance.
     """
 
-    @property
-    def period(self) -> float:
+    @contextlib.contextmanager
+    def task(self, **kwargs) -> ContextManager[None]:
         """
-        Returns reporting period.
+        Returns a context manager that represents a long-running task
+        for which progress can be reported.
 
-        For example, 0.1 would mean every 10%.
+        Entering it creates a progress bar, and exiting it destroys it.
+
+        kwargs will be passed to `start()`.
+        """
+        self.start2(**kwargs)
+
+        try:
+            yield None
+        finally:
+            self.finish()
+
+    def start(self, total: int, *, desc: Optional[str] = None) -> None:
+        """
+        This is a compatibility method. Override start2 instead.
         """
         raise NotImplementedError
 
-    def start(self, total: int, *, desc: Optional[str] = None):
-        """Initializes the progress bar"""
-        raise NotImplementedError
+    def start2(self, **kwargs) -> None:
+        """
+        Initializes the progress bar.
+
+        kwargs must contain tqdm-compatible arguments.
+        """
+        self.start(total=kwargs.get("total"), desc=kwargs.get("desc"))
 
     def report_status(self, progress: int):
         """Updates the progress bar"""
@@ -50,74 +71,43 @@ class ProgressReporter:
     def iter(
         self,
         iterable: Iterable[T],
-        *,
-        total: Optional[int] = None,
-        desc: Optional[str] = None,
     ) -> Iterable[T]:
         """
         Traverses the iterable and reports progress simultaneously.
 
-        Starts and finishes the progress bar automatically.
-
         Args:
             iterable: An iterable to be traversed
-            total: The expected number of iterations. If not provided, will
-              try to use iterable.__len__.
-            desc: The status message
 
         Returns:
             An iterable over elements of the input sequence
         """
 
-        if total is None and hasattr(iterable, "__len__"):
-            total = len(iterable)
-
-        self.start(total, desc=desc)
-
-        if total:
-            display_step = math.ceil(total * self.period)
-
-        for i, elem in enumerate(iterable):
-            if not total or i % display_step == 0:
-                self.report_status(i)
-
+        for elem in iterable:
             yield elem
-
-        self.finish()
-
-    def split(self, count: int) -> Tuple[ProgressReporter, ...]:
-        """
-        Splits the progress bar into few independent parts.
-        In case of 0 must return an empty tuple.
-
-        This class is supposed to manage the state of children progress bars
-        and release of their resources, if necessary.
-        """
-        raise NotImplementedError
+            self.advance(1)
 
 
-class NullProgressReporter(ProgressReporter):
-    @property
-    def period(self) -> float:
-        return 0
+class BaseProgressReporter(ProgressReporter):
+    def __init__(self) -> None:
+        self._in_progress = False
 
-    def start(self, total: int, *, desc: Optional[str] = None):
-        pass
+    def start2(self, **kwargs) -> None:
+        assert not self._in_progress
+        self._in_progress = True
 
     def report_status(self, progress: int):
-        pass
+        assert self._in_progress
 
     def advance(self, delta: int):
-        pass
+        assert self._in_progress
 
-    def iter(
-        self,
-        iterable: Iterable[T],
-        *,
-        total: Optional[int] = None,
-        desc: Optional[str] = None,
-    ) -> Iterable[T]:
-        yield from iterable
+    def finish(self) -> None:
+        assert self._in_progress
+        self._in_progress = False
 
-    def split(self, count: int) -> Tuple[ProgressReporter]:
-        return (self,) * count
+    def __del__(self):
+        assert not self._in_progress, "Unfinished task!"
+
+
+class NullProgressReporter(BaseProgressReporter):
+    pass

--- a/cvat-sdk/cvat_sdk/core/progress.py
+++ b/cvat-sdk/cvat_sdk/core/progress.py
@@ -48,13 +48,25 @@ class ProgressReporter:
         """
         raise NotImplementedError
 
-    def start2(self, **kwargs) -> None:
+    def start2(
+        self,
+        total: int,
+        *,
+        desc: Optional[str] = None,
+        unit: str = "it",
+        unit_scale: bool = False,
+        unit_divisor: int = 1000,
+        **kwargs,
+    ) -> None:
         """
         Initializes the progress bar.
 
-        kwargs must contain tqdm-compatible arguments.
+        total, desc, unit, unit_scale, unit_divisor have the same meaning as in tqdm.
+
+        kwargs is included for future extension; implementations of this method
+        must ignore it.
         """
-        self.start(total=kwargs.get("total"), desc=kwargs.get("desc"))
+        self.start(total=total, desc=desc)
 
     def report_status(self, progress: int):
         """Updates the progress bar"""
@@ -91,7 +103,16 @@ class BaseProgressReporter(ProgressReporter):
     def __init__(self) -> None:
         self._in_progress = False
 
-    def start2(self, **kwargs) -> None:
+    def start2(
+        self,
+        total: int,
+        *,
+        desc: Optional[str] = None,
+        unit: str = "it",
+        unit_scale: bool = False,
+        unit_divisor: int = 1000,
+        **kwargs,
+    ) -> None:
         assert not self._in_progress
         self._in_progress = True
 

--- a/tests/python/pytest.ini
+++ b/tests/python/pytest.ini
@@ -8,3 +8,6 @@ timeout = 15
 
 markers =
     with_external_services: The test requires services extrernal to the default CVAT deployment, e.g. a Git server etc.
+
+filterwarnings =
+    ignore::DeprecationWarning:cvat_sdk.core

--- a/tests/python/sdk/test_progress.py
+++ b/tests/python/sdk/test_progress.py
@@ -1,0 +1,82 @@
+# Copyright (C) 2023 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+import io
+import warnings
+from typing import Optional
+
+import tqdm
+from cvat_sdk.core.helpers import TqdmProgressReporter, TqdmProgressReporter2
+from cvat_sdk.core.progress import NullProgressReporter, ProgressReporter
+
+
+def _exercise_reporter(r: ProgressReporter) -> None:
+    with r.task(total=5, desc="Test task", unit="parrots"):
+        r.advance(1)
+        r.report_status(4)
+
+        for x in r.iter(["x"]):
+            assert x == "x"
+
+
+def test_null_reporter():
+    _exercise_reporter(NullProgressReporter())
+    # NPR doesn't do anything, so there's nothing to assert
+
+
+def test_tqdm_reporter():
+    f = io.StringIO()
+
+    instance = tqdm.tqdm(file=f)
+
+    with warnings.catch_warnings():
+        r = TqdmProgressReporter(instance)
+
+    _exercise_reporter(r)
+
+    output = f.getvalue()
+
+    assert "100%" in output
+    assert "Test task" in output
+    # TPR doesn't support parameters other than "total" and "desc",
+    # so there won't be any parrots in the output.
+
+
+def test_tqdm_reporter_2():
+    f = io.StringIO()
+
+    _exercise_reporter(TqdmProgressReporter2({"file": f}))
+
+    output = f.getvalue()
+
+    assert "100%" in output
+    assert "Test task" in output
+    assert "parrots" in output
+
+
+class _LegacyProgressReporter(ProgressReporter):
+    # overriding start instead of start2
+    def start(self, total: int, *, desc: Optional[str] = None) -> None:
+        self.total = total
+        self.desc = desc
+        self.progress = 0
+
+    def report_status(self, progress: int):
+        self.progress = progress
+
+    def advance(self, delta: int):
+        self.progress += delta
+
+    def finish(self):
+        self.finished = True
+
+
+def test_legacy_progress_reporter():
+    r = _LegacyProgressReporter()
+
+    _exercise_reporter(r)
+
+    assert r.total == 5
+    assert r.desc == "Test task"
+    assert r.progress == 5

--- a/tests/python/sdk/test_progress.py
+++ b/tests/python/sdk/test_progress.py
@@ -7,7 +7,7 @@ import warnings
 from typing import Optional
 
 import tqdm
-from cvat_sdk.core.helpers import TqdmProgressReporter, TqdmProgressReporter2
+from cvat_sdk.core.helpers import DeferredTqdmProgressReporter, TqdmProgressReporter
 from cvat_sdk.core.progress import NullProgressReporter, ProgressReporter
 
 
@@ -43,10 +43,10 @@ def test_tqdm_reporter():
     # so there won't be any parrots in the output.
 
 
-def test_tqdm_reporter_2():
+def test_deferred_tqdm_reporter():
     f = io.StringIO()
 
-    _exercise_reporter(TqdmProgressReporter2({"file": f}))
+    _exercise_reporter(DeferredTqdmProgressReporter({"file": f}))
 
     output = f.getvalue()
 

--- a/tests/python/sdk/util.py
+++ b/tests/python/sdk/util.py
@@ -9,11 +9,11 @@ from urllib.parse import urlparse
 
 import pytest
 from cvat_sdk.api_client.rest import RESTClientObject
-from cvat_sdk.core.helpers import TqdmProgressReporter2
+from cvat_sdk.core.helpers import DeferredTqdmProgressReporter
 
 
 def make_pbar(file, **kwargs):
-    return TqdmProgressReporter2({"file": file, "mininterval": 0, **kwargs})
+    return DeferredTqdmProgressReporter({"file": file, "mininterval": 0, **kwargs})
 
 
 def generate_coco_json(filename: Path, img_info: Tuple[Path, int, int]):

--- a/tests/python/sdk/util.py
+++ b/tests/python/sdk/util.py
@@ -9,12 +9,11 @@ from urllib.parse import urlparse
 
 import pytest
 from cvat_sdk.api_client.rest import RESTClientObject
-from cvat_sdk.core.helpers import TqdmProgressReporter
-from tqdm import tqdm
+from cvat_sdk.core.helpers import TqdmProgressReporter2
 
 
 def make_pbar(file, **kwargs):
-    return TqdmProgressReporter(tqdm(file=file, mininterval=0, **kwargs))
+    return TqdmProgressReporter2({"file": file, "mininterval": 0, **kwargs})
 
 
 def generate_coco_json(filename: Path, img_info: Tuple[Path, int, int]):


### PR DESCRIPTION

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There are several problems with how progress reporting is handled in the SDK, both on the interface and implementation level:

* The user is supposed to know, for a given function, which units it will report progress in. This is unnecessary coupling and prevents us from switching to different units, or to have several progress bars using different units.

* To create a TqdmProgressReporter, you have to create a tqdm instance, which immediately draws a progress bar. This works poorly if the function prints any log messages before the progress actually starts.

* There's no easy way to automatically call `finish` on a progress bar, so some functions don't (for example, `Downloader.download_file`). This can cause unexpected output, since tqdm will refresh the progress bar in a background thread (possibly after we've already printed something else).

* `iter` is basically broken, because it divides by `period`, which is 0 in all current implementations.

* Even ignoring that, it's hard to use correctly, because you need to manually call `finish` in case of an exception.

* `split` is not implemented and not used.

* `StreamWithProgress.seek` assumes that the progress bar is at 0 at the start, and so does `ProgressReporter.iter`. The former also works incorrectly if the second argument is not `SEEK_SET`.

Fix these problems by doing the following:

* Add a new `start2` method which accepts arbitrary tqdm parameters. The default implementation calls `start`, so that if a user has implemented the original interface, it'll keep working.

* Add a `TqdmProgressReporter2` that accepts tqdm parameters instead of a tqdm instance, and only creates an instance after `start2` is called. Use it where `TqdmProgressReporter` was used before. The old `TqdmProgressReporter` is kept for compatibility, but it doesn't support any `start2` arguments other than those supported by the original `start`.

* Add a `task` context manager, which automatically calls `start2` and `finish`. Use it everywhere instead of explicit `start`/`finish` calls. Remove `start`/`finish` calls from `StreamWithProgress` and `iter`.

* Implement basic assertions to ensure that `start2` and `finish` are used correctly.

* Remove `period` and `split`.

* Rewrite `StreamWithProgress.seek` and `ProgressReporter.iter` to use relative progress reports.

These changes should be backwards compatible for users who pass predefined or custom progress reporters into SDK functions. They are not backwards compatible for users who try to use progress reporters directly (e.g. calling `start`/`finish`). I don't consider that a significant issue, since the purpose of the `ProgressReporter` interface is for the user to get progress information from the SDK, not for them to use it in their own code.

Originally developed for #6483.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
