### PR TITLE
Add OPA in .vscode/tasks.json

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,6 +33,32 @@
                   "endsPattern": "Compiled"
                 }
             }
-        }
+      },
+      {
+        "type": "docker-run",
+        "label": "dokcer run cvat_opa",
+        "dockerRun": {
+          "network": "host",
+          "image": "openpolicyagent/opa:0.45.0-rootless",
+          "remove": true,
+          "ports": [
+            {
+              "containerPort": 8181,
+              "hostPort": 8181
+            }
+          ],
+          "containerName": "cvat_opa",
+          "portsPublishAll": false,
+          "command": [
+            "run",
+            "--server",
+            "--set=decision_logs.console=true",
+            "--set=services.cvat.url=http://localhost:7000",
+            "--set=bundles.cvat.service=cvat",
+            "--set=bundles.cvat.resource=/api/auth/rules"
+          ]
+        },
+        "problemMatcher": []
+      }
     ]
 }


### PR DESCRIPTION
### Motivation and context
I use it in my development environment to easily launch OPA. With this vscode task I just need to press 3 keyboard keys to start the OPA container.


### How has this been tested?


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
