### PR TITLE
Fix filename for label in CamVid format

### DIFF
--- a/site/content/en/docs/manual/advanced/formats/format-camvid.md
+++ b/site/content/en/docs/manual/advanced/formats/format-camvid.md
@@ -13,7 +13,7 @@ Downloaded file: a zip archive of the following structure:
 
 ```bash
 taskname.zip/
-├── labelmap.txt # optional, required for non-CamVid labels
+├── label_colors.txt # optional, required for non-CamVid labels
 ├── <any_subset_name>/
 |   ├── image1.png
 |   └── image2.png
@@ -22,8 +22,9 @@ taskname.zip/
 |   └── image2.png
 └── <any_subset_name>.txt
 
-# labelmap.txt
+# label_colors.txt
 # color (RGB) label
+# if you do not enter a color (RGB) value, it will be set automatically.
 0 0 0 Void
 64 128 64 Animal
 192 0 128 Archway


### PR DESCRIPTION
In the previous description of the CamVid format, the filename for the label was 'labelmap.txt', but the correct filename is 'label_colors.txt'.

Therefore, in this proposal, I fixed 'labelmap.txt' to 'label_colors.txt'. Also, I added the comment about 'color (RGB) value is not necessary'.

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
#6599 After aligning the folder structure according to the CamVid format specified in the official documentation, I noticed that the import process was not working. Upon investigation, I found that the correct label filename should be 'label_colors.txt' instead of 'labelmap.txt' for successful import. To rectify the misinformation in the official documentation, I have created an issue and submitted a pull request to address this issue.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I tested that the import process was not successful when the label filename was set as 'labelmap.txt', but when I changed it to 'label_colors.txt' and attempted the import again, it was successful.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
