### PR TITLE
Drop Python 3.7 support in the SDK and CLI

### DIFF
--- a/cvat-cli/setup.py
+++ b/cvat-cli/setup.py
@@ -56,7 +56,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     install_requires=BASE_REQUIREMENTS,
     entry_points={
         "console_scripts": [

--- a/cvat-sdk/cvat_sdk/auto_annotation/interface.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/interface.py
@@ -3,11 +3,10 @@
 # SPDX-License-Identifier: MIT
 
 import abc
-from typing import List, Sequence
+from typing import List, Protocol, Sequence
 
 import attrs
 import PIL.Image
-from typing_extensions import Protocol
 
 import cvat_sdk.models as models
 

--- a/cvat-sdk/cvat_sdk/core/proxies/model_proxy.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/model_proxy.py
@@ -13,6 +13,7 @@ from typing import (
     Dict,
     Generic,
     List,
+    Literal,
     Optional,
     Tuple,
     Type,
@@ -21,7 +22,7 @@ from typing import (
     overload,
 )
 
-from typing_extensions import Literal, Self
+from typing_extensions import Self
 
 from cvat_sdk.api_client.model_utils import IModelData, ModelNormal, to_json
 from cvat_sdk.core.helpers import get_paginated_collection

--- a/cvat-sdk/cvat_sdk/core/utils.py
+++ b/cvat-sdk/cvat_sdk/core/utils.py
@@ -14,13 +14,12 @@ from typing import (
     ContextManager,
     Dict,
     Iterator,
+    Literal,
     Sequence,
     TextIO,
     Union,
     overload,
 )
-
-from typing_extensions import Literal
 
 
 def filter_dict(

--- a/cvat-sdk/cvat_sdk/pytorch/transforms.py
+++ b/cvat-sdk/cvat_sdk/pytorch/transforms.py
@@ -2,13 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import FrozenSet
+from typing import FrozenSet, TypedDict
 
 import attrs
 import attrs.validators
 import torch
 import torch.utils.data
-from typing_extensions import TypedDict
 
 from cvat_sdk.datasets.common import UnsupportedDatasetError
 from cvat_sdk.pytorch.common import Target

--- a/cvat-sdk/gen/generator-config.yml
+++ b/cvat-sdk/gen/generator-config.yml
@@ -4,7 +4,7 @@ additionalProperties:
   packageName: "cvat_sdk.api_client"
   initRequiredVars: true
   generateSourceCodeOnly: false
-  generatorLanguageVersion: '>=3.7'
+  generatorLanguageVersion: '>=3.8'
 globalProperties:
   generateAliasAsModel: true
   apiTests: false

--- a/site/content/en/docs/api_sdk/cli/_index.md
+++ b/site/content/en/docs/api_sdk/cli/_index.md
@@ -30,7 +30,7 @@ To install an [official release of CVAT CLI](https://pypi.org/project/cvat-cli/)
 pip install cvat-cli
 ```
 
-We support Python versions 3.7 - 3.9.
+We support Python versions 3.8 and higher.
 
 ## Usage
 

--- a/site/content/en/docs/api_sdk/sdk/_index.md
+++ b/site/content/en/docs/api_sdk/sdk/_index.md
@@ -44,7 +44,7 @@ To use the PyTorch adapter, request the `pytorch` extra:
 pip install "cvat-sdk[pytorch]"
 ```
 
-We support Python versions 3.7 - 3.9.
+We support Python versions 3.8 and higher.
 
 ## Usage
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Upstream support for Python 3.7 ended on 2023-06-27.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [x] I have updated the documentation accordingly
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
