### PR TITLE
Fixed unstable test (fit_images_different_resolutions)

### DIFF
--- a/tests/cypress/e2e/actions_tasks2/fit_image_different_res.js
+++ b/tests/cypress/e2e/actions_tasks2/fit_image_different_res.js
@@ -48,7 +48,9 @@ context('Correct behaviour of fit when navigating between frames with different 
     });
 
     beforeEach(() => {
+        cy.intercept('GET', `/tasks/${taskID}/jobs/${jobID}`).as('visitAnnotationView');
         cy.visit(`/tasks/${taskID}/jobs/${jobID}`);
+        cy.wait('@visitAnnotationView');
         cy.get('.cvat-canvas-container').should('exist').and('be.visible');
     });
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
It may not to work sometimes because check: ``cy.get('.cvat-canvas-container').should('exist').and('be.visible');`` passes even before the command ``cy.visit(`/tasks/${taskID}/jobs/${jobID}`);`` takes effect.

![image](https://github.com/opencv/cvat/assets/40690378/10f96160-9749-4744-97cd-83508ed8e2c7)


### How has this been tested?
Added interceptor

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
