### PR TITLE
Fix log message duplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Memory leak in the logging system (<https://github.com/opencv/cvat/pull/6804>)
 - A race condition during initial `secret_key.py` creation
   (<https://github.com/opencv/cvat/pull/6775>)
+- Duplicate log entries from the CVAT server
+  (<https://github.com/opencv/cvat/pull/6766>)
 
 ### Security
 - TDB

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -535,17 +535,18 @@ LOGGING = {
             'database_path': EVENTS_LOCAL_DB_FILE,
         }
     },
+    'root': {
+        'handlers': ['console', 'server_file'],
+    },
     'loggers': {
         'cvat': {
-            'handlers': ['console', 'server_file'],
             'level': os.getenv('DJANGO_LOG_LEVEL', 'DEBUG'),
         },
 
         'django': {
-            'handlers': ['console', 'server_file'],
             'level': 'INFO',
-            'propagate': True
         },
+
         'vector': {
             'handlers': [],
             'level': 'INFO',

--- a/supervisord/server.conf
+++ b/supervisord/server.conf
@@ -42,8 +42,6 @@ autorestart=true
 environment=SSH_AUTH_SOCK="/tmp/ssh-agent.sock",CVAT_EVENTS_LOCAL_DB_FILENAME="events_%(process_num)03d.db"
 numprocs=%(ENV_NUMPROCS)s
 process_name=%(program_name)s-%(process_num)s
-stdout_logfile=/dev/stdout
-stdout_logfile_maxbytes=0
 
 [program:smokescreen]
 command=smokescreen --listen-ip=127.0.0.1 %(ENV_SMOKESCREEN_OPTS)s


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There are two independent problems that cause some log messages to be printed twice:

* In the CVAT logging configuration, we attach a console handler to the `cvat` and `django` loggers. However, when any library[1] used by CVAT uses one of the top-level `logging` functions (e.g. `logging.info`), then it will cause the root logger to get autoconfigured with another console handler. Since `cvat` and `django` are configured to propagate events to the ancestor logger's handlers, those events are passed to _two_ console handlers, so they are printed twice.

  Fix it by moving our handlers to the root logger. If the root logger has handlers, it will no longer get autoconfigured when top-level `logging` functions are invoked; so there will only be one console handler in the logger chain.

  An alternative would be to configure the root logger with a `NullHandler` (which will also disable autoconfiguration), but this will suppress all logs that are coming from places other than Django and CVAT, which seems undesirable.

* The supervisord config file for the server redirects the server's stdout to supervisord's stdout. However, supervisord already displays the stdout of all child processes due to the `loglevel=debug` setting. So all stdout messages of the server are displayed twice.

  Fix it by removing the redirection.

[1] Specifically, Datumaro does this. It could probably be fixed, but that wouldn't fix the root problem, which is the duplicate console handler.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
