### PR TITLE
Improve waiting for CVAT in the Helm workflow

### DIFF
--- a/.github/workflows/helm.yml
+++ b/.github/workflows/helm.yml
@@ -50,6 +50,17 @@ jobs:
         cd ..
         helm upgrade -n default release-${{ github.run_id }}-${{ github.run_attempt }} -i --create-namespace helm-chart -f helm-chart/values.yaml -f helm-chart/cvat.values.yaml -f helm-chart/test.values.yaml
 
+    - name: Generate SDK
+      run: |
+        pip3 install --user -r cvat-sdk/gen/requirements.txt
+        ./cvat-sdk/gen/generate.sh
+
+    - name: Install test requirements
+      run: |
+        pip3 install --user cvat-sdk/
+        pip3 install --user cvat-cli/
+        pip3 install --user -r tests/python/requirements.txt
+
     - name: Update test config
       run: |
         sed -i -e 's$http://localhost:8080$http://cvat.local:80$g' tests/python/shared/utils/config.py
@@ -65,17 +76,10 @@ jobs:
         kubectl get pods
         kubectl logs $(kubectl get pods -l component=server -o jsonpath='{.items[0].metadata.name}')
 
-
-    - name: Generate SDK
-      run: |
-        pip3 install --user -r cvat-sdk/gen/requirements.txt
-        ./cvat-sdk/gen/generate.sh
-
-    - name: Install test requirements
-      run: |
-        pip3 install --user cvat-sdk/
-        pip3 install --user cvat-cli/
-        pip3 install --user -r tests/python/requirements.txt
+        if [[ max_tries -le 0 ]]; then
+          echo "CVAT failed to become ready in the expected time period"
+          exit 1
+        fi
 
     - name: REST API and SDK tests
       # We don't have external services in Helm tests, so we ignore corresponding cases


### PR DESCRIPTION
* Do useful stuff (installing the SDK) while CVAT is starting up.

* Fail if CVAT never comes up instead of relying on tests to fail.

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This should slightly speed up the Helm workflow, and avoid running tests in a situation where they wouldn't succeed anyway.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
