### PR TITLE
Fix cosmetic issues in the cloud storage creation form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Zooming canvas when scrooling comments list in an issue (<https://github.com/opencv/cvat/pull/6758>)
 - Issues can be created many times when initial submit (<https://github.com/opencv/cvat/pull/6758>)
+- Cosmetic issues with the AWS credential fields in the cloud storage creation form
+  (<https://github.com/opencv/cvat/pull/6783>)
 
 ### Security
 - TDB

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Zooming canvas when scrooling comments list in an issue (<https://github.com/opencv/cvat/pull/6758>)
 - Issues can be created many times when initial submit (<https://github.com/opencv/cvat/pull/6758>)
-- Cosmetic issues with the AWS credential fields in the cloud storage creation form
-  (<https://github.com/opencv/cvat/pull/6783>)
 
 ### Security
 - TDB

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.55.5",
+  "version": "1.55.6",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/create-cloud-storage-page/cloud-storage-form.tsx
+++ b/cvat-ui/src/components/create-cloud-storage-page/cloud-storage-form.tsx
@@ -332,9 +332,9 @@ export default function CreateCloudStorageForm(props: Props): JSX.Element {
             return (
                 <>
                     <Form.Item
-                        label='ACCESS KEY ID'
+                        label='Access key ID'
                         name='key'
-                        rules={[{ required: true, message: 'Please, specify your access_key_id' }]}
+                        rules={[{ required: true, message: 'Please, specify your access key ID' }]}
                         {...internalCommonProps}
                     >
                         <Input.Password
@@ -346,9 +346,9 @@ export default function CreateCloudStorageForm(props: Props): JSX.Element {
                         />
                     </Form.Item>
                     <Form.Item
-                        label='SECRET ACCESS KEY ID'
+                        label='Secret access key'
                         name='secret_key'
-                        rules={[{ required: true, message: 'Please, specify your secret_access_key_id' }]}
+                        rules={[{ required: true, message: 'Please, specify your secret access key' }]}
                         {...internalCommonProps}
                     >
                         <Input.Password


### PR DESCRIPTION
Specifically, with the AWS credential fields:

* Replace SHOUTY CAPS with normal sentence case.

* Remove the word "ID" from the label of the second field; it's a key, not an ID.

* Remove gratuitous snake_case from the validation messages.

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The shouty caps were mildly irritating, and once I started fixing them, I decided I might as well fix some other issues too.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
