### PR TITLE
Removed separate loggers for each task and project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zooming canvas when scrooling comments list in an issue (<https://github.com/opencv/cvat/pull/6758>)
 - Issues can be created many times when initial submit (<https://github.com/opencv/cvat/pull/6758>)
 - Paddings on tasks/projects/models pages (<https://github.com/opencv/cvat/pull/6778>)
+- Memory leak in the logging system (<https://github.com/opencv/cvat/pull/6798>)
 
 ### Security
 - TDB

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -843,6 +843,7 @@ class ProjectImporter(_ImporterBase, _ProjectBackupBase):
         project_path = self._db_project.get_dirname()
         if os.path.isdir(project_path):
             shutil.rmtree(project_path)
+        os.makedirs(project_path)
 
         self._labels_mapping = self._create_labels(db_project=self._db_project, labels=labels)
 

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -663,7 +663,6 @@ class TaskImporter(_ImporterBase, _TaskBackupBase):
         if os.path.isdir(task_path):
             shutil.rmtree(task_path)
 
-        os.makedirs(self._db_task.get_task_logs_dirname())
         os.makedirs(self._db_task.get_task_artifacts_dirname())
 
         if not self._labels_mapping:
@@ -844,7 +843,6 @@ class ProjectImporter(_ImporterBase, _ProjectBackupBase):
         project_path = self._db_project.get_dirname()
         if os.path.isdir(project_path):
             shutil.rmtree(project_path)
-        os.makedirs(self._db_project.get_project_logs_dirname())
 
         self._labels_mapping = self._create_labels(db_project=self._db_project, labels=labels)
 

--- a/cvat/apps/engine/handlers.py
+++ b/cvat/apps/engine/handlers.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: MIT
 
+import logging
 from pathlib import Path
 from time import time
 from django.conf import settings
-from cvat.apps.engine.log import slogger
 
+slogger = logging.getLogger('cvat.server')
 
 def clear_import_cache(path: Path, creation_time: float) -> None:
     """
@@ -19,4 +20,4 @@ def clear_import_cache(path: Path, creation_time: float) -> None:
     """
     if path.is_file() and (time() - creation_time + 1) >= settings.IMPORT_CACHE_CLEAN_DELAY.total_seconds():
         path.unlink()
-        slogger.glob.warning(f"The file {str(path)} was removed from cleaning job.")
+        slogger.warning(f"The file {str(path)} was removed from cleaning job.")

--- a/cvat/apps/engine/log.py
+++ b/cvat/apps/engine/log.py
@@ -5,40 +5,10 @@
 import logging
 import sys
 import os.path as osp
-from typing import Dict
 from contextlib import contextmanager
-
-from attr import define, field
 from django.conf import settings
 
-from cvat.settings.base import LOGGING
-from .models import Job, Task, Project, CloudStorage
-
-def _get_project(pid):
-    try:
-        return Project.objects.get(pk=pid)
-    except Exception:
-        raise Exception('{} key must be a project identifier'.format(pid))
-
-def _get_task(tid):
-    try:
-        return Task.objects.get(pk=tid)
-    except Exception:
-        raise Exception('{} key must be a task identifier'.format(tid))
-
-def _get_job(jid):
-    try:
-        return Job.objects.select_related("segment__task").get(id=jid)
-    except Exception:
-        raise Exception('{} key must be a job identifier'.format(jid))
-
-def _get_storage(storage_id):
-    try:
-        return CloudStorage.objects.get(pk=storage_id)
-    except Exception:
-        raise Exception('{} key must be a cloud storage identifier'.format(storage_id))
-
-_opened_loggers: Dict[str, logging.Logger] = {}
+vlogger = logging.getLogger('vector')
 
 def get_logger(logger_name, log_file):
     logger = logging.getLogger(name=logger_name)
@@ -49,107 +19,7 @@ def get_logger(logger_name, log_file):
     logger.addHandler(file_handler)
     logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.addHandler(logging.StreamHandler(sys.stderr))
-    _opened_loggers[logger_name] = logger
     return logger
-
-def _close_logger(logger: logging.Logger):
-    for handler in logger.handlers:
-        handler.close()
-
-class LogManager:
-    def close(self):
-        raise NotImplementedError
-
-class IndexedLogManager(LogManager):
-    def __init__(self):
-        self._storage: Dict[int, logging.Logger] = {}
-
-    def close(self):
-        for logger in self._storage.values():
-            _close_logger(logger)
-
-        self._storage = {}
-
-    def __getitem__(self, idx: int) -> logging.Logger:
-        """Get logger object"""
-        if idx not in self._storage:
-            self._storage[idx] = self._create_logger(idx)
-        return self._storage[idx]
-
-    def _create_logger(self, _: int) -> logging.Logger:
-        raise NotImplementedError
-
-
-class ProjectLoggerStorage(IndexedLogManager):
-    def _create_logger(self, pid):
-        project = _get_project(pid)
-
-        logger = logging.getLogger('cvat.server.project_{}'.format(pid))
-        server_file = logging.FileHandler(filename=project.get_log_path())
-        formatter = logging.Formatter(LOGGING['formatters']['standard']['format'])
-        server_file.setFormatter(formatter)
-        logger.addHandler(server_file)
-
-        return logger
-
-
-class TaskLoggerStorage(IndexedLogManager):
-    def _create_logger(self, tid):
-        task = _get_task(tid)
-
-        logger = logging.getLogger('cvat.server.task_{}'.format(tid))
-        server_file = logging.FileHandler(filename=task.get_log_path())
-        formatter = logging.Formatter(LOGGING['formatters']['standard']['format'])
-        server_file.setFormatter(formatter)
-        logger.addHandler(server_file)
-
-        return logger
-
-class JobLoggerStorage(IndexedLogManager):
-    def _create_logger(self, jid):
-        job = _get_job(jid)
-        return slogger.task[job.segment.task.id]
-
-class CloudSourceLoggerStorage(IndexedLogManager):
-    def _create_logger(self, sid):
-        cloud_storage = _get_storage(sid)
-
-        logger = logging.getLogger('cvat.server.cloud_storage_{}'.format(sid))
-        server_file = logging.FileHandler(filename=cloud_storage.get_log_path())
-        formatter = logging.Formatter(LOGGING['formatters']['standard']['format'])
-        server_file.setFormatter(formatter)
-        logger.addHandler(server_file)
-
-        return logger
-
-@define(slots=False)
-class _AggregateLogManager(LogManager):
-    def close(self):
-        for logger in vars(self).values(): # vars is incompatible with slots
-            if hasattr(logger, 'close'):
-                logger.close()
-
-@define(slots=False)
-class ServerLogManager(_AggregateLogManager):
-    project = field(factory=ProjectLoggerStorage)
-    task = field(factory=TaskLoggerStorage)
-    job = field(factory=JobLoggerStorage)
-    cloud_storage = field(factory=CloudSourceLoggerStorage)
-    glob = field(factory=lambda: logging.getLogger('cvat.server'))
-
-slogger = ServerLogManager()
-
-vlogger = logging.getLogger('vector')
-
-def close_all():
-    """Closes all opened loggers"""
-
-    slogger.close()
-
-    for logger in _opened_loggers.values():
-        _close_logger(logger)
-
-    _close_logger(vlogger)
 
 @contextmanager
 def get_migration_logger(migration_name):

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -5,6 +5,7 @@
 
 import base64
 import json
+import logging
 import os
 import os.path
 import uuid
@@ -20,12 +21,12 @@ from rest_framework import mixins, status
 from rest_framework.response import Response
 
 from cvat.apps.engine.location import StorageType, get_location_configuration
-from cvat.apps.engine.log import slogger
 from cvat.apps.engine.models import Location
 from cvat.apps.engine.serializers import DataSerializer
 from cvat.apps.engine.handlers import clear_import_cache
 from cvat.apps.engine.utils import get_import_rq_id
 
+slogger = logging.getLogger('cvat.server')
 
 class TusFile:
     @dataclass
@@ -294,7 +295,7 @@ class UploadMixin:
                     path=path,
                     creation_time=Path(tus_file.file_path).stat().st_ctime
                 )
-                slogger.glob.info(
+                slogger.info(
                     f'The cleaning job {cleaning_job.id} is queued.'
                     f'The check that the file {path} is deleted will be carried out after '
                     f'{settings.IMPORT_CACHE_CLEAN_DELAY}.'

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -340,17 +340,8 @@ class Project(models.Model):
     def get_dirname(self):
         return os.path.join(settings.PROJECTS_ROOT, str(self.id))
 
-    def get_project_logs_dirname(self):
-        return os.path.join(self.get_dirname(), 'logs')
-
     def get_tmp_dirname(self):
         return os.path.join(self.get_dirname(), "tmp")
-
-    def get_client_log_path(self):
-        return os.path.join(self.get_project_logs_dirname(), "client.log")
-
-    def get_log_path(self):
-        return os.path.join(self.get_project_logs_dirname(), "project.log")
 
     def is_job_staff(self, user_id):
         if self.owner == user_id:
@@ -450,15 +441,6 @@ class Task(models.Model):
 
     def get_dirname(self):
         return os.path.join(settings.TASKS_ROOT, str(self.id))
-
-    def get_task_logs_dirname(self):
-        return os.path.join(self.get_dirname(), 'logs')
-
-    def get_client_log_path(self):
-        return os.path.join(self.get_task_logs_dirname(), "client.log")
-
-    def get_log_path(self):
-        return os.path.join(self.get_task_logs_dirname(), "task.log")
 
     def get_task_artifacts_dirname(self):
         return os.path.join(self.get_dirname(), 'artifacts')
@@ -1131,12 +1113,6 @@ class CloudStorage(models.Model):
 
     def get_storage_dirname(self):
         return os.path.join(settings.CLOUD_STORAGE_ROOT, str(self.id))
-
-    def get_storage_logs_dirname(self):
-        return os.path.join(self.get_storage_dirname(), 'logs')
-
-    def get_log_path(self):
-        return os.path.join(self.get_storage_logs_dirname(), "storage.log")
 
     def get_specific_attributes(self):
         return parse_specific_attributes(self.specific_attributes)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1109,7 +1109,6 @@ class TaskWriteSerializer(WriteOnceMixin, serializers.ModelSerializer):
         if os.path.isdir(task_path):
             shutil.rmtree(task_path)
 
-        os.makedirs(db_task.get_task_logs_dirname())
         os.makedirs(db_task.get_task_artifacts_dirname())
 
         LabelSerializer.create_labels(labels, parent_instance=db_task)
@@ -1310,7 +1309,6 @@ class ProjectWriteSerializer(serializers.ModelSerializer):
         project_path = db_project.get_dirname()
         if os.path.isdir(project_path):
             shutil.rmtree(project_path)
-        os.makedirs(db_project.get_project_logs_dirname())
 
         LabelSerializer.create_labels(labels, parent_instance=db_project)
 
@@ -1813,7 +1811,6 @@ class CloudStorageWriteSerializer(serializers.ModelSerializer):
             if os.path.isdir(cloud_storage_path):
                 shutil.rmtree(cloud_storage_path)
 
-            os.makedirs(db_storage.get_storage_logs_dirname(), exist_ok=True)
             if temporary_file:
                 # so, gcs key file is valid and we need to set correct path to the file
                 real_path_to_key_file = db_storage.get_key_file_path()

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1309,6 +1309,7 @@ class ProjectWriteSerializer(serializers.ModelSerializer):
         project_path = db_project.get_dirname()
         if os.path.isdir(project_path):
             shutil.rmtree(project_path)
+        os.makedirs(project_path)
 
         LabelSerializer.create_labels(labels, parent_instance=db_project)
 
@@ -1810,6 +1811,7 @@ class CloudStorageWriteSerializer(serializers.ModelSerializer):
             cloud_storage_path = db_storage.get_storage_dirname()
             if os.path.isdir(cloud_storage_path):
                 shutil.rmtree(cloud_storage_path)
+            os.makedirs(cloud_storage_path)
 
             if temporary_file:
                 # so, gcs key file is valid and we need to set correct path to the file

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -89,7 +89,6 @@ def create_db_task(data):
     db_task = Task.objects.create(**data)
     shutil.rmtree(db_task.get_dirname(), ignore_errors=True)
     os.makedirs(db_task.get_dirname())
-    os.makedirs(db_task.get_task_logs_dirname())
     os.makedirs(db_task.get_task_artifacts_dirname())
     db_task.data = db_data
     db_task.save()
@@ -126,7 +125,6 @@ def create_db_project(data):
     db_project = Project.objects.create(**data)
     shutil.rmtree(db_project.get_dirname(), ignore_errors=True)
     os.makedirs(db_project.get_dirname())
-    os.makedirs(db_project.get_project_logs_dirname())
 
     if not labels is None:
         for label_data in labels:

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -4,6 +4,7 @@
 # SPDX-License-Identifier: MIT
 
 import io
+import logging
 import os
 import os.path as osp
 from PIL import Image
@@ -81,7 +82,6 @@ from cvat.apps.engine.mixins import PartialUpdateModelMixin, UploadMixin, Annota
 from cvat.apps.engine.location import get_location_configuration, StorageType
 
 from . import models, task
-from .log import slogger
 from cvat.apps.iam.permissions import (CloudStoragePermission,
     CommentPermission, IssuePermission, JobPermission, LabelPermission, ProjectPermission,
     TaskPermission, UserPermission)
@@ -89,6 +89,7 @@ from cvat.apps.iam.filters import ORGANIZATION_OPEN_API_PARAMETERS
 from cvat.apps.engine.cache import MediaCache
 from cvat.apps.engine.view_utils import tus_chunk_action
 
+slogger = logging.getLogger('cvat.server')
 
 _UPLOAD_PARSER_CLASSES = api_settings.DEFAULT_PARSER_CLASSES + [MultiPartParser]
 
@@ -2490,15 +2491,15 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
         except CloudStorageModel.DoesNotExist:
             message = f"Storage {pk} does not exist"
-            slogger.glob.error(message)
+            slogger.error(message)
             return HttpResponseNotFound(message)
         except (ValidationError, PermissionDenied, NotFound) as ex:
             msg = str(ex) if not isinstance(ex, ValidationError) else \
                 '\n'.join([str(d) for d in ex.detail])
-            slogger.cloud_storage[pk].info(msg)
+            slogger.info(f'cloud_storage_id = {pk}' + msg)
             return Response(data=msg, status=ex.status_code)
         except Exception as ex:
-            slogger.glob.error(str(ex))
+            slogger.error(str(ex))
             return Response("An internal error has occurred",
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -2563,15 +2564,15 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
 
         except CloudStorageModel.DoesNotExist:
             message = f"Storage {pk} does not exist"
-            slogger.glob.error(message)
+            slogger.error(message)
             return HttpResponseNotFound(message)
         except (ValidationError, PermissionDenied, NotFound) as ex:
             msg = str(ex) if not isinstance(ex, ValidationError) else \
                 '\n'.join([str(d) for d in ex.detail])
-            slogger.cloud_storage[pk].info(msg)
+            slogger.info(f'cloud_storage_id = {pk}' + msg)
             return Response(data=msg, status=ex.status_code)
         except Exception as ex:
-            slogger.glob.error(str(ex))
+            slogger.error(str(ex))
             return Response("An internal error has occurred",
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -2599,15 +2600,15 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             return HttpResponse(preview, mime)
         except CloudStorageModel.DoesNotExist:
             message = f"Storage {pk} does not exist"
-            slogger.glob.error(message)
+            slogger.error(message)
             return HttpResponseNotFound(message)
         except (ValidationError, PermissionDenied, NotFound) as ex:
             msg = str(ex) if not isinstance(ex, ValidationError) else \
                 '\n'.join([str(d) for d in ex.detail])
-            slogger.cloud_storage[pk].info(msg)
+            slogger.info(f'cloud_storage_id = {pk}' + msg)
             return Response(data=msg, status=ex.status_code)
         except Exception as ex:
-            slogger.glob.error(str(ex))
+            slogger.error(str(ex))
             return Response("An internal error has occurred",
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR)
 
@@ -2624,7 +2625,7 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             return Response(storage_status)
         except CloudStorageModel.DoesNotExist:
             message = f"Storage {pk} does not exist"
-            slogger.glob.error(message)
+            slogger.error(message)
             return HttpResponseNotFound(message)
         except Exception as ex:
             msg = str(ex)
@@ -2646,7 +2647,7 @@ class CloudStorageViewSet(viewsets.GenericViewSet, mixins.ListModelMixin,
             return Response(actions, content_type="text/plain")
         except CloudStorageModel.DoesNotExist:
             message = f"Storage {pk} does not exist"
-            slogger.glob.error(message)
+            slogger.error(message)
             return HttpResponseNotFound(message)
         except Exception as ex:
             msg = str(ex)

--- a/cvat/apps/events/export.py
+++ b/cvat/apps/events/export.py
@@ -4,6 +4,7 @@
 
 import os
 import csv
+import logging
 from datetime import datetime, timedelta, timezone
 from dateutil import parser
 import uuid
@@ -17,8 +18,9 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from cvat.apps.dataset_manager.views import clear_export_cache, log_exception
-from cvat.apps.engine.log import slogger
 from cvat.apps.engine.utils import sendfile
+
+slogger = logging.getLogger('cvat.server')
 
 DEFAULT_CACHE_TTL = timedelta(hours=1)
 
@@ -74,14 +76,14 @@ def _create_csv(query_params, output_filename, cache_ttl):
             file_path=output_filename,
             file_ctime=archive_ctime,
         )
-        slogger.glob.info(
+        slogger.info(
             f"The {output_filename} is created "
             f"and available for downloading for the next {cache_ttl}. "
             f"Export cache cleaning job is enqueued, id '{cleaning_job.id}'"
         )
         return output_filename
     except Exception:
-        log_exception(slogger.glob)
+        log_exception(slogger)
         raise
 
 def export(request, filter_query, queue_name):


### PR DESCRIPTION
We have a memory leak in the logging system. The patch doesn't have the aim to redesign the logging system. Only to fix the memory leak and redirect all messages into cvat_server.log file. In the future it is better to think which error messages are really helpful and send them to ClickHouse instead of a local file. It will allow to avoid any problems with multi processing. Also we have huge amount of logs inside ClickHouse. I don't see any reason to have some of them on the file system.

