### PR TITLE
Remove the DJANGO_CONFIGURATION environment variable

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,11 +73,11 @@ COPY utils/dataset_manifest/requirements.txt /tmp/utils/dataset_manifest/require
 # Exclude av from the requirements file
 RUN sed -i '/^av==/d' /tmp/utils/dataset_manifest/requirements.txt
 
-ARG DJANGO_CONFIGURATION="production"
+ARG CVAT_CONFIGURATION="production"
 
 RUN --mount=type=cache,target=/root/.cache/pip/http \
     DATUMARO_HEADLESS=1 python3 -m pip wheel --no-deps \
-    -r /tmp/cvat/requirements/${DJANGO_CONFIGURATION}.txt \
+    -r /tmp/cvat/requirements/${CVAT_CONFIGURATION}.txt \
     -w /tmp/wheelhouse
 
 FROM golang:1.20.5 AS build-smokescreen
@@ -103,8 +103,8 @@ ENV TERM=xterm \
     TZ=${TZ}
 
 ARG USER="django"
-ARG DJANGO_CONFIGURATION="production"
-ENV DJANGO_CONFIGURATION=${DJANGO_CONFIGURATION}
+ARG CVAT_CONFIGURATION="production"
+ENV DJANGO_SETTINGS_MODULE="cvat.settings.${CVAT_CONFIGURATION}"
 
 # Install necessary apt packages
 RUN apt-get update && \

--- a/Dockerfile.ci
+++ b/Dockerfile.ci
@@ -1,6 +1,6 @@
 FROM cvat/server:local
 
-ENV DJANGO_CONFIGURATION=testing
+ENV DJANGO_SETTINGS_MODULE=cvat.settings.testing
 USER root
 
 RUN apt-get update && \
@@ -25,7 +25,7 @@ RUN apt-get update && \
 COPY cvat/requirements/ /tmp/cvat/requirements/
 COPY utils/dataset_manifest/requirements.txt /tmp/utils/dataset_manifest/requirements.txt
 
-RUN DATUMARO_HEADLESS=1 python3 -m pip install --no-cache-dir -r /tmp/cvat/requirements/${DJANGO_CONFIGURATION}.txt
+RUN DATUMARO_HEADLESS=1 python3 -m pip install --no-cache-dir -r /tmp/cvat/requirements/testing.txt
 
 COPY cvat-core ${HOME}/cvat-core
 COPY cvat-data ${HOME}/cvat-data

--- a/cvat/asgi.py
+++ b/cvat/asgi.py
@@ -18,8 +18,7 @@ from django.core.handlers.asgi import ASGIHandler
 
 import cvat.utils.remote_debugger as debug
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cvat.settings.{}" \
-    .format(os.environ.get("DJANGO_CONFIGURATION", "development")))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cvat.settings.development")
 
 application = get_asgi_application()
 

--- a/manage.py
+++ b/manage.py
@@ -8,8 +8,7 @@ import os
 import sys
 
 if __name__ == "__main__":
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cvat.settings.{}" \
-        .format(os.environ.get("DJANGO_CONFIGURATION", "development")))
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "cvat.settings.development")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There are a few issues with it:

* It doesn't work for the Enterprise version, because its settings module is not located under `cvat.settings`.

* The name `DJANGO_CONFIGURATION` suggests that it's defined by Django, but it isn't. It's a CVAT-specific variable. There's also a 3rd-party module that uses this variable (django-configurations), but with different semantics, which could cause confusion.

* It's just redundant to have two variables that effectively do the same thing (`DJANGO_CONFIGURATION` and `DJANGO_SETTINGS_MODULE`).

Besides its runtime effect, `DJANGO_CONFIGURATION` is also used in the Dockerfile to select the packages to install. I could see that still being useful, so replace it with a build-only variable named `CVAT_CONFIGURATION`.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I built the Docker image with various values of `CVAT_CONFIGURATION`.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file~~
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
