### PR TITLE
Removed separate loggers for each task and project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Zooming canvas when scrooling comments list in an issue (<https://github.com/opencv/cvat/pull/6758>)
 - Issues can be created many times when initial submit (<https://github.com/opencv/cvat/pull/6758>)
 - Paddings on tasks/projects/models pages (<https://github.com/opencv/cvat/pull/6778>)
+- Memory leak in the logging system (<>)
 
 ### Security
 - TDB

--- a/cvat/apps/dataset_manager/views.py
+++ b/cvat/apps/dataset_manager/views.py
@@ -16,11 +16,13 @@ from django.conf import settings
 
 import cvat.apps.dataset_manager.task as task
 import cvat.apps.dataset_manager.project as project
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.models import Project, Task, Job
 
 from .formats.registry import EXPORT_FORMATS, IMPORT_FORMATS
 from .util import current_function_name
+
+slogger = ServerLogManager(__name__)
 
 _MODULE_NAME = __package__ + '.' + osp.splitext(osp.basename(__file__))[0]
 def log_exception(logger=None, exc_info=True):

--- a/cvat/apps/dataset_repo/dataset_repo.py
+++ b/cvat/apps/dataset_repo/dataset_repo.py
@@ -20,10 +20,11 @@ from django.conf import settings
 from cvat.apps.dataset_manager.formats.registry import format_for
 from cvat.apps.dataset_manager.task import export_task
 from cvat.apps.dataset_repo.models import GitData, GitStatusChoice
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.models import Job, Task, User
 from cvat.apps.engine.plugins import add_plugin
 
+slogger = ServerLogManager(__name__)
 
 def _have_no_access_exception(ex):
     if 'Permission denied' in ex.stderr or 'Could not read from remote repository' in ex.stderr:

--- a/cvat/apps/dataset_repo/views.py
+++ b/cvat/apps/dataset_repo/views.py
@@ -14,13 +14,15 @@ from rest_framework.decorators import api_view, permission_classes
 
 from drf_spectacular.utils import extend_schema
 
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine import models
 from cvat.apps.dataset_repo.models import GitData
 import contextlib
 
 import cvat.apps.dataset_repo.dataset_repo as CVATGit
 import django_rq
+
+slogger = ServerLogManager(__name__)
 
 def _legacy_api_view(allowed_method_names=None):
     # Currently, the views in this file use the legacy permission-checking

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -30,7 +30,7 @@ from distutils.util import strtobool
 
 import cvat.apps.dataset_manager as dm
 from cvat.apps.engine import models
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.serializers import (AttributeSerializer, DataSerializer,
     JobWriteSerializer, LabelSerializer, AnnotationGuideWriteSerializer, AssetWriteSerializer,
     LabeledDataSerializer, SegmentSerializer, SimpleJobSerializer, TaskReadSerializer,
@@ -48,6 +48,8 @@ from cvat.apps.engine.location import StorageType, get_location_configuration
 from cvat.apps.engine.view_utils import get_cloud_storage_for_import_or_export
 from cvat.apps.dataset_manager.views import TASK_CACHE_TTL, PROJECT_CACHE_TTL, get_export_cache_dir, clear_export_cache, log_exception
 from cvat.apps.dataset_manager.bindings import CvatImportError
+
+slogger = ServerLogManager(__name__)
 
 class Version(Enum):
     V1 = '1.0'

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -21,7 +21,7 @@ from rest_framework.exceptions import NotFound, ValidationError
 from cvat.apps.engine.cloud_provider import (Credentials,
                                              db_storage_to_storage_instance,
                                              get_cloud_storage_instance)
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.media_extractors import (ImageDatasetManifestReader,
                                                Mpeg4ChunkWriter,
                                                Mpeg4CompressedChunkWriter,
@@ -34,6 +34,7 @@ from cvat.apps.engine.models import (DataChoice, DimensionType, Job, Image,
 from cvat.apps.engine.utils import md5_hash
 from utils.dataset_manifest import ImageManifestManager
 
+slogger = ServerLogManager(__name__)
 
 class MediaCache:
     def __init__(self, dimension=DimensionType.DIM_2D):

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -27,9 +27,11 @@ from PIL import Image, ImageFile
 from rest_framework.exceptions import (NotFound, PermissionDenied,
                                        ValidationError)
 
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.models import CloudProviderChoice, CredentialsTypeChoice
 from cvat.apps.engine.utils import get_cpu_number
+
+slogger = ServerLogManager(__name__)
 
 ImageFile.LOAD_TRUNCATED_IMAGES = True
 

--- a/cvat/apps/engine/handlers.py
+++ b/cvat/apps/engine/handlers.py
@@ -5,8 +5,9 @@
 from pathlib import Path
 from time import time
 from django.conf import settings
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 
+slogger = ServerLogManager(__name__)
 
 def clear_import_cache(path: Path, creation_time: float) -> None:
     """

--- a/cvat/apps/engine/log.py
+++ b/cvat/apps/engine/log.py
@@ -5,40 +5,31 @@
 import logging
 import sys
 import os.path as osp
-from typing import Dict
 from contextlib import contextmanager
 
-from attr import define, field
 from django.conf import settings
 
-from cvat.settings.base import LOGGING
-from .models import Job, Task, Project, CloudStorage
+class _LoggerAdapter(logging.LoggerAdapter):
+    def process(self, msg: str, kwargs):
+        if msg_prefix := getattr(self.extra, "msg_prefix", None):
+            msg = msg_prefix + msg
+        return msg, kwargs
 
-def _get_project(pid):
-    try:
-        return Project.objects.get(pk=pid)
-    except Exception:
-        raise Exception('{} key must be a project identifier'.format(pid))
+class _LoggerAdapterMapping:
+    def __init__(self, logger: logging.Logger, object_type: str) -> None:
+        self._logger = logger
+        self._object_type = object_type
 
-def _get_task(tid):
-    try:
-        return Task.objects.get(pk=tid)
-    except Exception:
-        raise Exception('{} key must be a task identifier'.format(tid))
+    def __getitem__(self, id_: int) -> logging.LoggerAdapter:
+        return _LoggerAdapter(self._logger, {"msg_prefix": f"[{self._object_type}.id={id_}] "})
 
-def _get_job(jid):
-    try:
-        return Job.objects.select_related("segment__task").get(id=jid)
-    except Exception:
-        raise Exception('{} key must be a job identifier'.format(jid))
-
-def _get_storage(storage_id):
-    try:
-        return CloudStorage.objects.get(pk=storage_id)
-    except Exception:
-        raise Exception('{} key must be a cloud storage identifier'.format(storage_id))
-
-_opened_loggers: Dict[str, logging.Logger] = {}
+class ServerLogManager:
+    def __init__(self, logger_name: str) -> None:
+        self.glob = logging.getLogger(logger_name)
+        self.project = _LoggerAdapterMapping(self.glob, "Project")
+        self.task = _LoggerAdapterMapping(self.glob, "Task")
+        self.job = _LoggerAdapterMapping(self.glob, "Job")
+        self.cloud_storage = _LoggerAdapterMapping(self.glob, "CloudStorage")
 
 def get_logger(logger_name, log_file):
     logger = logging.getLogger(name=logger_name)
@@ -49,107 +40,9 @@ def get_logger(logger_name, log_file):
     logger.addHandler(file_handler)
     logger.addHandler(logging.StreamHandler(sys.stdout))
     logger.addHandler(logging.StreamHandler(sys.stderr))
-    _opened_loggers[logger_name] = logger
     return logger
 
-def _close_logger(logger: logging.Logger):
-    for handler in logger.handlers:
-        handler.close()
-
-class LogManager:
-    def close(self):
-        raise NotImplementedError
-
-class IndexedLogManager(LogManager):
-    def __init__(self):
-        self._storage: Dict[int, logging.Logger] = {}
-
-    def close(self):
-        for logger in self._storage.values():
-            _close_logger(logger)
-
-        self._storage = {}
-
-    def __getitem__(self, idx: int) -> logging.Logger:
-        """Get logger object"""
-        if idx not in self._storage:
-            self._storage[idx] = self._create_logger(idx)
-        return self._storage[idx]
-
-    def _create_logger(self, _: int) -> logging.Logger:
-        raise NotImplementedError
-
-
-class ProjectLoggerStorage(IndexedLogManager):
-    def _create_logger(self, pid):
-        project = _get_project(pid)
-
-        logger = logging.getLogger('cvat.server.project_{}'.format(pid))
-        server_file = logging.FileHandler(filename=project.get_log_path())
-        formatter = logging.Formatter(LOGGING['formatters']['standard']['format'])
-        server_file.setFormatter(formatter)
-        logger.addHandler(server_file)
-
-        return logger
-
-
-class TaskLoggerStorage(IndexedLogManager):
-    def _create_logger(self, tid):
-        task = _get_task(tid)
-
-        logger = logging.getLogger('cvat.server.task_{}'.format(tid))
-        server_file = logging.FileHandler(filename=task.get_log_path())
-        formatter = logging.Formatter(LOGGING['formatters']['standard']['format'])
-        server_file.setFormatter(formatter)
-        logger.addHandler(server_file)
-
-        return logger
-
-class JobLoggerStorage(IndexedLogManager):
-    def _create_logger(self, jid):
-        job = _get_job(jid)
-        return slogger.task[job.segment.task.id]
-
-class CloudSourceLoggerStorage(IndexedLogManager):
-    def _create_logger(self, sid):
-        cloud_storage = _get_storage(sid)
-
-        logger = logging.getLogger('cvat.server.cloud_storage_{}'.format(sid))
-        server_file = logging.FileHandler(filename=cloud_storage.get_log_path())
-        formatter = logging.Formatter(LOGGING['formatters']['standard']['format'])
-        server_file.setFormatter(formatter)
-        logger.addHandler(server_file)
-
-        return logger
-
-@define(slots=False)
-class _AggregateLogManager(LogManager):
-    def close(self):
-        for logger in vars(self).values(): # vars is incompatible with slots
-            if hasattr(logger, 'close'):
-                logger.close()
-
-@define(slots=False)
-class ServerLogManager(_AggregateLogManager):
-    project = field(factory=ProjectLoggerStorage)
-    task = field(factory=TaskLoggerStorage)
-    job = field(factory=JobLoggerStorage)
-    cloud_storage = field(factory=CloudSourceLoggerStorage)
-    glob = field(factory=lambda: logging.getLogger('cvat.server'))
-
-slogger = ServerLogManager()
-
 vlogger = logging.getLogger('vector')
-
-def close_all():
-    """Closes all opened loggers"""
-
-    slogger.close()
-
-    for logger in _opened_loggers.values():
-        _close_logger(logger)
-
-    _close_logger(vlogger)
 
 @contextmanager
 def get_migration_logger(migration_name):

--- a/cvat/apps/engine/mixins.py
+++ b/cvat/apps/engine/mixins.py
@@ -20,12 +20,13 @@ from rest_framework import mixins, status
 from rest_framework.response import Response
 
 from cvat.apps.engine.location import StorageType, get_location_configuration
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.models import Location
 from cvat.apps.engine.serializers import DataSerializer
 from cvat.apps.engine.handlers import clear_import_cache
 from cvat.apps.engine.utils import get_import_rq_id
 
+slogger = ServerLogManager(__name__)
 
 class TusFile:
     @dataclass

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -340,17 +340,8 @@ class Project(models.Model):
     def get_dirname(self):
         return os.path.join(settings.PROJECTS_ROOT, str(self.id))
 
-    def get_project_logs_dirname(self):
-        return os.path.join(self.get_dirname(), 'logs')
-
     def get_tmp_dirname(self):
         return os.path.join(self.get_dirname(), "tmp")
-
-    def get_client_log_path(self):
-        return os.path.join(self.get_project_logs_dirname(), "client.log")
-
-    def get_log_path(self):
-        return os.path.join(self.get_project_logs_dirname(), "project.log")
 
     def is_job_staff(self, user_id):
         if self.owner == user_id:
@@ -450,15 +441,6 @@ class Task(models.Model):
 
     def get_dirname(self):
         return os.path.join(settings.TASKS_ROOT, str(self.id))
-
-    def get_task_logs_dirname(self):
-        return os.path.join(self.get_dirname(), 'logs')
-
-    def get_client_log_path(self):
-        return os.path.join(self.get_task_logs_dirname(), "client.log")
-
-    def get_log_path(self):
-        return os.path.join(self.get_task_logs_dirname(), "task.log")
 
     def get_task_artifacts_dirname(self):
         return os.path.join(self.get_dirname(), 'artifacts')
@@ -1131,12 +1113,6 @@ class CloudStorage(models.Model):
 
     def get_storage_dirname(self):
         return os.path.join(settings.CLOUD_STORAGE_ROOT, str(self.id))
-
-    def get_storage_logs_dirname(self):
-        return os.path.join(self.get_storage_dirname(), 'logs')
-
-    def get_log_path(self):
-        return os.path.join(self.get_storage_logs_dirname(), "storage.log")
 
     def get_specific_attributes(self):
         return parse_specific_attributes(self.specific_attributes)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -20,11 +20,12 @@ from django.db import transaction
 from cvat.apps.dataset_manager.formats.utils import get_label_color
 from cvat.apps.engine import models
 from cvat.apps.engine.cloud_provider import get_cloud_storage_instance, Credentials, Status
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.utils import parse_specific_attributes, build_field_filter_params, get_list_view_name, reverse
 
 from drf_spectacular.utils import OpenApiExample, extend_schema_field, extend_schema_serializer
 
+slogger = ServerLogManager(__name__)
 
 class WriteOnceMixin:
     """

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1104,7 +1104,6 @@ class TaskWriteSerializer(WriteOnceMixin, serializers.ModelSerializer):
         if os.path.isdir(task_path):
             shutil.rmtree(task_path)
 
-        os.makedirs(db_task.get_task_logs_dirname())
         os.makedirs(db_task.get_task_artifacts_dirname())
 
         LabelSerializer.create_labels(labels, parent_instance=db_task)
@@ -1305,7 +1304,7 @@ class ProjectWriteSerializer(serializers.ModelSerializer):
         project_path = db_project.get_dirname()
         if os.path.isdir(project_path):
             shutil.rmtree(project_path)
-        os.makedirs(db_project.get_project_logs_dirname())
+        os.makedirs(project_path)
 
         LabelSerializer.create_labels(labels, parent_instance=db_project)
 
@@ -1807,8 +1806,8 @@ class CloudStorageWriteSerializer(serializers.ModelSerializer):
             cloud_storage_path = db_storage.get_storage_dirname()
             if os.path.isdir(cloud_storage_path):
                 shutil.rmtree(cloud_storage_path)
+            os.makedirs(cloud_storage_path)
 
-            os.makedirs(db_storage.get_storage_logs_dirname(), exist_ok=True)
             if temporary_file:
                 # so, gcs key file is valid and we need to set correct path to the file
                 real_path_to_key_file = db_storage.get_key_file_path()

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -24,7 +24,7 @@ from datetime import datetime
 from pathlib import Path
 
 from cvat.apps.engine import models
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.media_extractors import (MEDIA_TYPES, ImageListReader, Mpeg4ChunkWriter, Mpeg4CompressedChunkWriter,
     ValidateDimension, ZipChunkWriter, ZipCompressedChunkWriter, get_mime, sort)
 from cvat.apps.engine.utils import av_scan_paths, get_rq_job_meta
@@ -33,6 +33,8 @@ from utils.dataset_manifest import ImageManifestManager, VideoManifestManager, i
 from utils.dataset_manifest.core import VideoManifestValidator, is_dataset_manifest
 from utils.dataset_manifest.utils import detect_related_images
 from .cloud_provider import db_storage_to_storage_instance
+
+slogger = ServerLogManager(__name__)
 
 ############################# Low Level server API
 

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -89,7 +89,6 @@ def create_db_task(data):
     db_task = Task.objects.create(**data)
     shutil.rmtree(db_task.get_dirname(), ignore_errors=True)
     os.makedirs(db_task.get_dirname())
-    os.makedirs(db_task.get_task_logs_dirname())
     os.makedirs(db_task.get_task_artifacts_dirname())
     db_task.data = db_data
     db_task.save()
@@ -126,7 +125,6 @@ def create_db_project(data):
     db_project = Project.objects.create(**data)
     shutil.rmtree(db_project.get_dirname(), ignore_errors=True)
     os.makedirs(db_project.get_dirname())
-    os.makedirs(db_project.get_project_logs_dirname())
 
     if not labels is None:
         for label_data in labels:

--- a/cvat/apps/engine/views.py
+++ b/cvat/apps/engine/views.py
@@ -81,7 +81,7 @@ from cvat.apps.engine.mixins import PartialUpdateModelMixin, UploadMixin, Annota
 from cvat.apps.engine.location import get_location_configuration, StorageType
 
 from . import models, task
-from .log import slogger
+from .log import ServerLogManager
 from cvat.apps.iam.permissions import (CloudStoragePermission,
     CommentPermission, IssuePermission, JobPermission, LabelPermission, ProjectPermission,
     TaskPermission, UserPermission)
@@ -89,6 +89,7 @@ from cvat.apps.iam.filters import ORGANIZATION_OPEN_API_PARAMETERS
 from cvat.apps.engine.cache import MediaCache
 from cvat.apps.engine.view_utils import tus_chunk_action
 
+slogger = ServerLogManager(__name__)
 
 _UPLOAD_PARSER_CLASSES = api_settings.DEFAULT_PARSER_CLASSES + [MultiPartParser]
 

--- a/cvat/apps/events/export.py
+++ b/cvat/apps/events/export.py
@@ -17,8 +17,10 @@ from rest_framework import serializers, status
 from rest_framework.response import Response
 
 from cvat.apps.dataset_manager.views import clear_export_cache, log_exception
-from cvat.apps.engine.log import slogger
+from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.utils import sendfile
+
+slogger = ServerLogManager(__name__)
 
 DEFAULT_CACHE_TTL = timedelta(hours=1)
 


### PR DESCRIPTION
We have a memory leak in the logging system. The patch doesn't have the aim to redesign the logging system. Only to fix the memory leak and redirect all messages into cvat_server.log file. In the future it is better to think which error messages are really helpful and send them to ClickHouse instead of a local file. It will allow to avoid any problems with multi processing. Also we have huge amount of logs inside ClickHouse. I don't see any reason to have some of them on the file system.