### PR TITLE
[Refactoring] Removed custom exif rotation method

### DIFF
--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -10,13 +10,12 @@ import os
 
 import cv2
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageOps
 
 from cvat.apps.engine.cache import MediaCache
 from cvat.apps.engine.media_extractors import VideoReader, ZipReader
 from cvat.apps.engine.mime_types import mimetypes
 from cvat.apps.engine.models import DataChoice, StorageMethodChoice, DimensionType
-from cvat.apps.engine.media_extractors import rotate_within_exif
 from rest_framework.exceptions import ValidationError
 
 class RandomAccessIterator:
@@ -175,7 +174,7 @@ class FrameProvider:
         else:
             preview, _ = self.get_frame(frame_number, self.Quality.COMPRESSED, self.Type.PIL)
 
-        preview = rotate_within_exif(preview)
+        preview = ImageOps.exif_transpose(preview)
         preview.thumbnail(PREVIEW_SIZE)
 
         output_buf = BytesIO()

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -619,6 +619,7 @@ class IChunkWriter(ABC):
             image = ImageOps.equalize(image)         # The Images need equalization. High resolution with 16-bit but only small range that actually contains information
 
         converted_image = image.convert('RGB')
+        image.close()
         try:
             buf = io.BytesIO()
             converted_image.save(buf, format='JPEG', quality=quality, optimize=True)

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -83,22 +83,6 @@ def image_size_within_orientation(img: Image):
 def has_exif_rotation(img: Image):
     return img.getexif().get(ORIENTATION_EXIF_TAG, ORIENTATION.NORMAL_HORIZONTAL) != ORIENTATION.NORMAL_HORIZONTAL
 
-def rotate_within_exif(img: Image):
-    orientation = img.getexif().get(ORIENTATION_EXIF_TAG,  ORIENTATION.NORMAL_HORIZONTAL)
-    if orientation in [ORIENTATION.NORMAL_180_ROTATED, ORIENTATION.MIRROR_VERTICAL]:
-        img = img.rotate(180, expand=True)
-    elif orientation in [ORIENTATION.NORMAL_270_ROTATED, ORIENTATION.MIRROR_HORIZONTAL_90_ROTATED]:
-        img = img.rotate(90, expand=True)
-    elif orientation in [ORIENTATION.NORMAL_90_ROTATED, ORIENTATION.MIRROR_HORIZONTAL_270_ROTATED]:
-        img = img.rotate(270, expand=True)
-    if orientation in [
-        ORIENTATION.MIRROR_HORIZONTAL, ORIENTATION.MIRROR_VERTICAL,
-        ORIENTATION.MIRROR_HORIZONTAL_270_ROTATED ,ORIENTATION.MIRROR_HORIZONTAL_90_ROTATED,
-    ]:
-        img = img.transpose(Image.FLIP_LEFT_RIGHT)
-
-    return img
-
 class IMediaReader(ABC):
     def __init__(self, source_path, step, start, stop, dimension):
         self._source_path = source_path
@@ -127,7 +111,7 @@ class IMediaReader(ABC):
             preview = Image.open(obj)
         else:
             preview = obj
-        preview = rotate_within_exif(preview)
+        preview = ImageOps.exif_transpose(preview)
         # TODO - Check if the other formats work. I'm only interested in I;16 for now. Sorry @:-|
         # Summary:
         # Images in the Format I;16 definitely don't work. Most likely I;16B/L/N won't work as well.
@@ -227,8 +211,8 @@ class ImageListReader(IMediaReader):
             with open(self.get_path(i), 'rb') as f:
                 properties = ValidateDimension.get_pcd_properties(f)
                 return int(properties["WIDTH"]),  int(properties["HEIGHT"])
-        img = Image.open(self._source_path[i])
-        return image_size_within_orientation(img)
+        with Image.open(self._source_path[i]) as img:
+            return image_size_within_orientation(img)
 
     def reconcile(self, source_files, step=1, start=0, stop=None, dimension=DimensionType.DIM_2D, sorting_method=None):
         # FIXME
@@ -369,8 +353,8 @@ class ZipReader(ImageListReader):
             with open(self.get_path(i), 'rb') as f:
                 properties = ValidateDimension.get_pcd_properties(f)
                 return int(properties["WIDTH"]),  int(properties["HEIGHT"])
-        img = Image.open(io.BytesIO(self._zip_source.read(self._source_path[i])))
-        return image_size_within_orientation(img)
+        with Image.open(io.BytesIO(self._zip_source.read(self._source_path[i]))) as img:
+            return image_size_within_orientation(img)
 
     def get_image(self, i):
         if self._dimension == DimensionType.DIM_3D:
@@ -604,8 +588,12 @@ class IChunkWriter(ABC):
 
     @staticmethod
     def _compress_image(image_path, quality):
-        image = image_path.to_image() if isinstance(image_path, av.VideoFrame) else Image.open(image_path)
-        image = rotate_within_exif(image)
+        if isinstance(image_path, av.VideoFrame):
+            image = image_path.to_image()
+        else:
+            with Image.open(image_path) as source_image:
+                image = ImageOps.exif_transpose(source_image)
+
         # Ensure image data fits into 8bit per pixel before RGB conversion as PIL clips values on conversion
         if image.mode == "I":
             # Image mode is 32bit integer pixels.
@@ -631,13 +619,14 @@ class IChunkWriter(ABC):
             image = ImageOps.equalize(image)         # The Images need equalization. High resolution with 16-bit but only small range that actually contains information
 
         converted_image = image.convert('RGB')
-        image.close()
-        buf = io.BytesIO()
-        converted_image.save(buf, format='JPEG', quality=quality, optimize=True)
-        buf.seek(0)
-        width, height = converted_image.size
-        converted_image.close()
-        return width, height, buf
+        try:
+            buf = io.BytesIO()
+            converted_image.save(buf, format='JPEG', quality=quality, optimize=True)
+            buf.seek(0)
+            width, height = converted_image.size
+            return width, height, buf
+        finally:
+            converted_image.close()
 
     @abstractmethod
     def save_as_chunk(self, images, chunk_path):
@@ -664,17 +653,25 @@ class ZipChunkWriter(IChunkWriter):
                 ext = os.path.splitext(path)[1].replace('.', '')
                 output = io.BytesIO()
                 if self._dimension == DimensionType.DIM_2D:
-                    pil_image = Image.open(image)
-                    if has_exif_rotation(pil_image):
-                        rot_image = rotate_within_exif(pil_image)
-                        if rot_image.format == 'TIFF':
-                            # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
-                            # use loseless lzw compression for tiff images
-                            rot_image.save(output, format='TIFF', compression='tiff_lzw')
+                    with Image.open(image) as pil_image:
+                        if has_exif_rotation(pil_image):
+                            rot_image = ImageOps.exif_transpose(pil_image)
+                            try:
+                                if rot_image.format == 'TIFF':
+                                # https://pillow.readthedocs.io/en/stable/handbook/image-file-formats.html
+                                # use loseless lzw compression for tiff images
+                                    rot_image.save(output, format='TIFF', compression='tiff_lzw')
+                                else:
+                                    rot_image.save(
+                                        output,
+                                        format=rot_image.format if rot_image.format else self.IMAGE_EXT,
+                                        quality=100,
+                                        subsampling=0
+                                    )
+                            finally:
+                                rot_image.close()
                         else:
-                            rot_image.save(output, format=rot_image.format if rot_image.format else self.IMAGE_EXT, quality=100, subsampling=0)
-                    else:
-                        output = image
+                            output = image
                 else:
                     output, ext = self._write_pcd_file(image)[0:2]
                 arcname = '{:06d}.{}'.format(idx, ext)
@@ -700,8 +697,8 @@ class ZipCompressedChunkWriter(ZipChunkWriter):
                     else:
                         assert isinstance(image, io.IOBase)
                         image_buf = io.BytesIO(image.read())
-                        w, h = Image.open(image_buf).size
-
+                        with Image.open(image_buf) as img:
+                            w, h = img.size
                     extension = self.IMAGE_EXT
                 else:
                     image_buf, extension, w, h = self._write_pcd_file(image)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
* We do not need custom exif rotation method, since PIL already has one.
* Added some closings for PIL Images

> The lifecycle of a single-frame image is relatively simple. The file must remain open until the load() or close() function is called or the context manager exits.

https://pillow.readthedocs.io/en/stable/reference/open_files.html#image-lifecycle

Means, that if we opened file and load() was not called internally, the file will stay opened. So, I added context manager and called close() in somewhere just in case

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
