### PR TITLE
Setup nuclio timeout

### DIFF
--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -62,14 +62,15 @@ class LambdaGateway:
             host or settings.NUCLIO['HOST'],
             port or settings.NUCLIO['PORT'])
         NUCLIO_FUNCTION_NAMESPACE = function_namespace or settings.NUCLIO['FUNCTION_NAMESPACE']
+        NUCLIO_TIMEOUT = settings.NUCLIO['DEFAULT_TIMEOUT']
         extra_headers = {
             'x-nuclio-project-name': 'cvat',
             'x-nuclio-function-namespace': NUCLIO_FUNCTION_NAMESPACE,
             'x-nuclio-invoke-via': 'domain-name',
+            'X-Nuclio-Invoke-Timeout': f"{NUCLIO_TIMEOUT}s",
         }
         if headers:
             extra_headers.update(headers)
-        NUCLIO_TIMEOUT = settings.NUCLIO['DEFAULT_TIMEOUT']
 
         if url:
             url = "{}{}".format(NUCLIO_GATEWAY, url)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
See these several issues. They are connected to each other in some way. 
The thing is that nuclio has a default timeout of 1 minute. With this change we can force nuclio dashboard not to terminate the connection.
https://github.com/nuclio/nuclio/issues/3016
https://github.com/opencv/cvat/issues/3301
https://github.com/opencv/cvat/issues/6041

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
