### PR TITLE
YOLOv7: use the correct version of ONNX Runtime for GPU

### DIFF
--- a/changelog.d/20231009_140340_roman_HEAD.md
+++ b/changelog.d/20231009_140340_roman_HEAD.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- The GPU version of the YOLOv7 serverless function not actually using the GPU
+  (<https://github.com/opencv/cvat/pull/6940>)

--- a/serverless/onnx/WongKinYiu/yolov7/nuclio/function-gpu.yaml
+++ b/serverless/onnx/WongKinYiu/yolov7/nuclio/function-gpu.yaml
@@ -96,7 +96,7 @@ spec:
   eventTimeout: 30s
   build:
     image: cvat.onnx.wongkinyiu.yolov7
-    baseImage: nvidia/cuda:12.2.0-runtime-ubuntu22.04
+    baseImage: nvidia/cuda:11.8.0-cudnn8-runtime-ubuntu22.04
 
     directives:
       preCopy:
@@ -107,7 +107,7 @@ spec:
         - kind: WORKDIR
           value: /opt/nuclio
         - kind: RUN
-          value: pip install onnxruntime opencv-python-headless pillow pyyaml
+          value: pip install onnxruntime-gpu=='1.16.*' opencv-python-headless pillow pyyaml
         - kind: WORKDIR
           value: /opt/nuclio
         - kind: RUN


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, we install plain `onnxruntime`, which means that when the function is deployed with `deploy_gpu.sh`, it ends up using the CPU anyway.

Fixes #6793.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
