### PR TITLE
Switch to using scriv for maintaining the changelog

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ t
 line. If you don't do that, GitHub will show incorrect progress for the pull request.
 If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
 - [ ] I submit my changes into the `develop` branch
-- [ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file
+- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
 - [ ] I have updated the documentation accordingly
 - [ ] I have added tests to cover my changes
 - [ ] I have linked related issues (see [GitHub docs](

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,31 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## \[Unreleased\]
+<!--
+  Developers: this project uses scriv (<https://scriv.readthedocs.io/en/stable/index.html>)
+  to maintain the changelog. To add an entry, create a fragment:
 
-### Added
+    $ scriv create --edit
 
-- The latest comment displayed in issues sidebar (<https://github.com/opencv/cvat/pull/6937>)
+  Fragments will be merged into this file whenever a release is made.
+-->
 
-### Changed
-
-- TDB
-
-### Deprecated
-
-- TDB
-
-### Removed
-
-- TDB
-
-### Fixed
-
-- It was not possible to copy issue comment from issue dialog (<https://github.com/opencv/cvat/pull/6937>)
-
-### Security
-
-- Update Grafana from 9.3.6 to 10.1.2
+<!-- scriv-insert-here -->
 
 ## \[2.7.3\] - 2023-10-02
 
@@ -1766,26 +1751,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Initial version
-
-## Template
-
-```
-## \[Unreleased]
-### Added
-- TDB
-
-### Changed
-- TDB
-
-### Deprecated
-- TDB
-
-### Removed
-- TDB
-
-### Fixed
-- TDB
-
-### Security
-- TDB
-```

--- a/changelog.d/fragment.j2
+++ b/changelog.d/fragment.j2
@@ -1,0 +1,4 @@
+### {{ config.categories | join('|') }} <!-- pick one -->
+
+- Describe your change here...
+  (<https://github.com/opencv/cvat/pull/XXXX>)

--- a/changelog.d/legacy.md
+++ b/changelog.d/legacy.md
@@ -1,0 +1,11 @@
+### Added
+
+- The latest comment displayed in issues sidebar (<https://github.com/opencv/cvat/pull/6937>)
+
+### Fixed
+
+- It was not possible to copy issue comment from issue dialog (<https://github.com/opencv/cvat/pull/6937>)
+
+### Security
+
+- Update Grafana from 9.3.6 to 10.1.2

--- a/changelog.d/scriv.ini
+++ b/changelog.d/scriv.ini
@@ -1,0 +1,6 @@
+[scriv]
+categories = Added, Changed, Deprecated, Removed, Fixed, Security
+entry_title_template = \[{{ version }}\] - {{ date.strftime('%%Y-%%m-%%d') }}
+format = md
+md_header_level = 2
+new_fragment_template = file: fragment.j2


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is beneficial in multiple ways:

* No more `CHANGELOG.md` merge conflicts and mis-merges.

* At release time all you need to do to update the changelog is run `scriv collect --version X.Y.Z`.

Scriv can also create GitHub releases, although I haven't evaluated this feature yet.

Configure scriv so that its output format is the same as what we currently use for our changelog. There are only a few minor differences:

* scriv prepends an HTML anchor to every version heading.

* scriv puts blank lines between list items (in CommonMark terms, the lists are loose rather than tight).

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have added a description of my changes into the [CHANGELOG](https://github.com/opencv/cvat/blob/develop/CHANGELOG.md) file~~
- [x] I have updated the documentation accordingly
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
