### PR TITLE
Fixed Siammask tracker error on grayscale images

### DIFF
--- a/changelog.d/20231011_153251_andrey_fix_siammask.md
+++ b/changelog.d/20231011_153251_andrey_fix_siammask.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fixed Siammask tracker error on grayscale images
+  (<https://github.com/opencv/cvat/pull/6982>)

--- a/serverless/pytorch/foolwood/siammask/nuclio/main.py
+++ b/serverless/pytorch/foolwood/siammask/nuclio/main.py
@@ -20,6 +20,7 @@ def handler(context, event):
     shapes = data.get("shapes")
     states = data.get("states")
     image = Image.open(buf)
+    image = image.convert("RGB")  #  to make sure image comes in RGB
 
     results = {
         'shapes': [],


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->


### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
```python
"Exception caught in handler - \"not enough values to unpack (expected 3, got 2)\": Traceback (most recent call last):
 File \"/opt/nuclio/_nuclio_wrapper.py\", line 143, in serve_requests
 await self._handle_event(event)
 File \"/opt/nuclio/_nuclio_wrapper.py\", line 397, in _handle_event
 entrypoint_output = self._entrypoint(self._context, event)
 File \"/opt/nuclio/main.py\", line 29, in handler
 shape, state = context.user_data.model.infer(image, shape, states[i] if i < len(states) else None)
 File \"/opt/nuclio/model_handler.py\", line 56, in infer
 self.config['hp'], device=self.device)
 File \"/opt/nuclio/SiamMask/tools/test.py\", line 152, in siamese_init
 z_crop = get_subwindow_tracking(im, target_pos, p.exemplar_size, s_z, avg_chans)
 File \"/opt/nuclio/SiamMask/tools/test.py\", line 88, in get_subwindow_tracking
 r, c, k = im.shape
ValueError: not enough values to unpack (expected 3, got 2)
```

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manually

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
