### PR TITLE
Add a GitHub workflow for finalizing a release

### DIFF
--- a/.github/workflows/finalize-release.yml
+++ b/.github/workflows/finalize-release.yml
@@ -1,0 +1,109 @@
+name: Finalize release
+on:
+  workflow_dispatch:
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Discover pending release
+        id: discover
+        env:
+          GH_TOKEN: "${{ github.token }}"
+        run: |
+          gh --repo="${{ github.repository }}" \
+            pr list --base master --state open --json number,headRefName \
+            --jq 'map(select(.headRefName | startswith("release-")))' \
+            > /tmp/release-prs.json
+
+          if jq -e 'length < 1' /tmp/release-prs.json > /dev/null; then
+            echo "No open release pull requests found."
+            exit 1
+          elif jq -e 'length > 1' /tmp/release-prs.json > /dev/null; then
+            echo "Multiple open release pull requests found:"
+            jq -r '.[] | "https://github.com/${{ github.repository }}/pull/\(.number)"' /tmp/release-prs.json
+            exit 1
+          fi
+
+          jq -r '.[] | "prNumber=\(.number)", "version=\(.headRefName | ltrimstr("release-"))"' \
+            /tmp/release-prs.json >> "$GITHUB_OUTPUT"
+
+      # When you use the default github.token to make changes in the repository,
+      # it does not trigger further GitHub pipelines. We want to trigger CI for
+      # the pull request and artifact building for the release, so we have to use
+      # an app token.
+      - name: Generate authentication token
+        id: gen-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: "${{ secrets.CVAT_BOT_APP_ID }}"
+          private-key: "${{ secrets.CVAT_BOT_PRIVATE_KEY }}"
+
+      - name: Install dependencies
+        run:
+          sudo apt-get install -y pandoc
+
+      - uses: actions/checkout@v4
+        with:
+          ref: "release-${{ steps.discover.outputs.version }}"
+
+      - name: Verify that the release is new
+        env:
+          NEW_VERSION: "${{ steps.discover.outputs.version }}"
+        run: |
+          if git ls-remote --exit-code origin "refs/tags/v$NEW_VERSION" > /dev/null; then
+            echo "Release v$NEW_VERSION already exists"
+            exit 1
+          fi
+
+      # Do post-release tasks before publishing the release. If anything goes wrong,
+      # the dev-release-* branch can be deleted, and the whole process restarted again;
+      # whereas we can't unmerge the release PR.
+
+      - name: Create post-release branch
+        run:
+          git checkout -b "dev-release-${{ steps.discover.outputs.version }}"
+
+      - name: Bump version
+        run:
+          ./dev/update_version.py --minor
+
+      - name: Commit post-release changes
+        run: |
+          git -c user.name='cvat-bot[bot]' -c user.email='147643061+cvat-bot[bot]@users.noreply.github.com' \
+            commit -a -m "Update ${{ github.ref_name }} after v${{ steps.discover.outputs.version }}"
+
+      - name: Push post-release branch
+        run:
+          git push -u origin "dev-release-${{ steps.discover.outputs.version }}"
+
+      - name: Create post-release pull request
+        env:
+          GH_TOKEN: "${{ steps.gen-token.outputs.token }}"
+        run: |
+          gh pr create \
+            --base="${{ github.ref_name }}" \
+            --title="Update ${{ github.ref_name }} after v${{ steps.discover.outputs.version }}" \
+            --body=""
+
+      # Now publish the release.
+
+      - name: Merge release pull request
+        env:
+          GH_TOKEN: "${{ steps.gen-token.outputs.token }}"
+        run:
+          gh pr merge --merge "${{ steps.discover.outputs.prNumber }}" --delete-branch
+
+      - name: Create release
+        env:
+          GH_TOKEN: "${{ steps.gen-token.outputs.token }}"
+          NEW_VERSION: "${{ steps.discover.outputs.version }}"
+        run: |
+          # We could grab the release notes from the PR description, but it could
+          # be outdated if any changes were made on the release branch. So instead,
+          # just re-extract them from the changelog again.
+
+          ./dev/gh_release_notes.sh \
+            | gh release create "v$NEW_VERSION" \
+              --target=master \
+              --title="v$NEW_VERSION" \
+              --notes-file=-

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -19,6 +19,20 @@ jobs:
             exit 1
           fi
 
+      # When you use the default github.token to make changes in the repository,
+      # it does not trigger further GitHub pipelines. We want to trigger CI for
+      # the pull request, so we have to use an app token.
+      - name: Generate authentication token
+        id: gen-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: "${{ secrets.CVAT_BOT_APP_ID }}"
+          private-key: "${{ secrets.CVAT_BOT_PRIVATE_KEY }}"
+
+      - name: Install dependencies
+        run:
+          sudo apt-get install -y pandoc
+
       - uses: actions/checkout@v4
 
       - name: Verify that the release is new
@@ -42,7 +56,7 @@ jobs:
 
       - name: Commit release preparation changes
         run: |
-          git -c user.name='github-actions[bot]' -c user.email='github-actions[bot]@users.noreply.github.com' \
+          git -c user.name='cvat-bot[bot]' -c user.email='147643061+cvat-bot[bot]@users.noreply.github.com' \
             commit -a -m "Prepare release v${{ inputs.newVersion }}"
 
       - name: Push release branch
@@ -51,9 +65,10 @@ jobs:
 
       - name: Create release pull request
         env:
-          GH_TOKEN: "${{ github.token }}"
+          GH_TOKEN: "${{ steps.gen-token.outputs.token }}"
         run: |
-          gh pr create \
-            --base=master \
-            --title="Release v${{ inputs.newVersion }}" \
-            --body="$(awk '/^## / { hn += 1; next } hn == 1 && !/^</' CHANGELOG.md)"
+          ./dev/gh_release_notes.sh \
+            | gh pr create \
+              --base=master \
+              --title="Release v${{ inputs.newVersion }}" \
+              --body-file=-

--- a/dev/gh_release_notes.sh
+++ b/dev/gh_release_notes.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+# This script takes the release notes for the most recent release
+# and reformats them for use in GitHub.
+
+# In GitHub PR and release descriptions, a single line break is
+# equivalent to <br>, so we pipe the text through pandoc to unwrap all lines.
+
+set -eu
+
+repo_root="$(dirname "$0")/.."
+
+awk '/^## / { hn += 1; next } hn == 1 && !/^</' "$repo_root/CHANGELOG.md" \
+  | pandoc -f gfm -t gfm --wrap=none


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This automates the second half of the release process (the first being automated by `prepare-release.yml`). After this workflow completes, the only action that should remain for the releaser to do is to merge the `dev-release-*` pull request. We can't do that as part of this workflow, because CI has to finish first, and it seems pointless to create another workflow just to merge 1 PR.

Apply some of the aspects of this pipeline to `prepare-release.yml` as well:

* Make the release notes extraction process more sophisticated to work around GitHub's frustrating handling of line breaks in PR and release descriptions.

* Use GitHub app credentials in order to be able to trigger other pipelines.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I tried the pipelines on my CVAT fork.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
