### PR TITLE
Add basic checks for changelog fragments to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Verify version consistency
         run: ./dev/update_version.py --verify-current
 
+      - name: Check changelog fragments
+        run: ./dev/check_changelog_fragments.py
+
       - name: CVAT server. Getting cache from the default branch
         uses: actions/cache@v3
         with:

--- a/dev/check_changelog_fragments.py
+++ b/dev/check_changelog_fragments.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+
+import configparser
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+def main():
+    scriv_config = configparser.ConfigParser()
+    scriv_config.read(REPO_ROOT / 'changelog.d/scriv.ini')
+
+    scriv_section = scriv_config['scriv']
+    assert scriv_section['format'] == 'md'
+
+    md_header_level = int(scriv_section['md_header_level'])
+    md_header_prefix = '#' * md_header_level + '# '
+
+    categories = {s.strip() for s in scriv_section['categories'].split(',')}
+
+    success = True
+
+    def complain(message):
+        nonlocal success
+        success = False
+        print(f"{fragment_path.relative_to(REPO_ROOT)}:{line_index+1}: {message}", file=sys.stderr)
+
+    for fragment_path in REPO_ROOT.glob('changelog.d/*.md'):
+        with open(fragment_path) as fragment_file:
+            for line_index, line in enumerate(fragment_file):
+                if not line.startswith(md_header_prefix):
+                    # The first line should be a header, and all headers should be of appropriate level.
+                    if line_index == 0 or line.startswith('#'):
+                        complain(f"line should start with {md_header_prefix!r}")
+                    continue
+
+                category = line.removeprefix(md_header_prefix).strip()
+                if category not in categories:
+                    complain(f"unknown category: {category}")
+
+    sys.exit(0 if success else 1)
+
+main()


### PR DESCRIPTION

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This'll help prevent simple mistakes that would cause scriv to assemble the changelog incorrectly.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
