### PR TITLE
Add new community links to the `Links` README section

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,8 @@ questions and get our support.
 - [Intel AI blog: New Computer Vision Tool Accelerates Annotation of Digital Images and Video](https://www.intel.ai/introducing-cvat)
 - [Intel Software: Computer Vision Annotation Tool: A Universal Approach to Data Annotation](https://software.intel.com/en-us/articles/computer-vision-annotation-tool-a-universal-approach-to-data-annotation)
 - [VentureBeat: Intel open-sources CVAT, a toolkit for data labeling](https://venturebeat.com/2019/03/05/intel-open-sources-cvat-a-toolkit-for-data-labeling/)
+- [How to Use CVAT (Roboflow guide)](https://blog.roboflow.com/cvat/)
+- [How to auto-label data in CVAT with one of 50,000+ models on Roboflow Universe](https://blog.roboflow.com/how-to-use-roboflow-models-in-cvat/)
 
   <!-- prettier-ignore-start -->
   <!-- Badges -->


### PR DESCRIPTION
This PR adds two links to the CVAT README `Links` section. The first link is a tutorial written by the Roboflow team on how to use CVAT and the second link shows the Roboflow guide to using models for automatic labeling in CVAT. I would love for the Roboflow + CVAT integration to be more accessible to new users; the faster someone can label, the quicker they can get a model into production.