### PR TITLE
Add test for retrieving bucket content when bucket contains manually created dirs

### DIFF
--- a/changelog.d/20231018_103441_maria_add_test_for_retrieving_bucket_content_with_manually_created_dirs.md
+++ b/changelog.d/20231018_103441_maria_add_test_for_retrieving_bucket_content_with_manually_created_dirs.md
@@ -1,0 +1,4 @@
+### Added
+
+- Test for retrieving bucket content when bucket contains manually created dirs
+  (<https://github.com/opencv/cvat/pull/7018>)

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -622,10 +622,8 @@ class TestGetCloudStorageContent:
             cloud_storage_id,
         )["content"]
         assert len(initial_content) + 1 == len(content)
-        assert list(
-            filter(
-                lambda x: new_directory.strip() == x["name"] and "DIR" == x["mime_type"], content
-            )
+        assert any(
+            new_directory.strip("/") == x["name"] and "DIR" == str(x["type"]) for x in content
         )
 
         content = self._test_get_cloud_storage_content(


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
~~- [ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
~~- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
~~- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
