### PR TITLE
Don't fetch existing annotations in `cvat_sdk.auto_annotation.annotate_task`

### DIFF
--- a/changelog.d/20231017_194639_roman_auto_annotate_no_load.md
+++ b/changelog.d/20231017_194639_roman_auto_annotate_no_load.md
@@ -1,0 +1,9 @@
+### Added
+
+- \[SDK\] A parameter to `TaskDataset` that allows you to disable annotation loading
+  (<https://github.com/opencv/cvat/pull/7019>)
+
+### Fixed
+- \[SDK\] `cvat_sdk.auto_annotation.annotate_task` no longer performs
+  unnecessary fetches of existing annotations
+  (<https://github.com/opencv/cvat/pull/7019>)

--- a/cvat-sdk/cvat_sdk/auto_annotation/driver.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/driver.py
@@ -268,7 +268,7 @@ def annotate_task(
     if pbar is None:
         pbar = NullProgressReporter()
 
-    dataset = TaskDataset(client, task_id)
+    dataset = TaskDataset(client, task_id, load_annotations=False)
 
     assert isinstance(function.spec, DetectionFunctionSpec)
 

--- a/cvat-sdk/cvat_sdk/datasets/common.py
+++ b/cvat-sdk/cvat_sdk/datasets/common.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: MIT
 
 import abc
-from typing import List
+from typing import List, Optional
 
 import attrs
 import attrs.validators
@@ -53,8 +53,12 @@ class Sample:
     frame_name: str
     """File name of the frame in its task."""
 
-    annotations: FrameAnnotations
-    """Annotations belonging to the frame."""
+    annotations: Optional[FrameAnnotations]
+    """
+    Annotations belonging to the frame.
+
+    Will be None if the dataset was created without loading annotations.
+    """
 
     media: MediaElement
     """Media data of the frame."""

--- a/cvat-sdk/cvat_sdk/datasets/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/datasets/task_dataset.py
@@ -6,14 +6,14 @@ from __future__ import annotations
 
 import zipfile
 from concurrent.futures import ThreadPoolExecutor
-from typing import Sequence
+from typing import Iterable, Sequence
 
 import PIL.Image
 
 import cvat_sdk.core
 import cvat_sdk.core.exceptions
 import cvat_sdk.models as models
-from cvat_sdk.datasets.caching import UpdatePolicy, make_cache_manager
+from cvat_sdk.datasets.caching import CacheManager, UpdatePolicy, make_cache_manager
 from cvat_sdk.datasets.common import FrameAnnotations, MediaElement, Sample, UnsupportedDatasetError
 
 _NUM_DOWNLOAD_THREADS = 4
@@ -49,12 +49,17 @@ class TaskDataset:
         task_id: int,
         *,
         update_policy: UpdatePolicy = UpdatePolicy.IF_MISSING_OR_STALE,
+        load_annotations: bool = True,
     ) -> None:
         """
         Creates a dataset corresponding to the task with ID `task_id` on the
         server that `client` is connected to.
 
         `update_policy` determines when and if the local cache will be updated.
+
+        `load_annotations` determines whether annotations will be loaded from
+        the server. If set to False, the `annotations` field in the samples will
+        be set to None.
         """
 
         self._logger = client.logger
@@ -102,26 +107,12 @@ class TaskDataset:
 
         self._logger.info("All chunks downloaded")
 
-        annotations = cache_manager.ensure_task_model(
-            self._task.id,
-            "annotations.json",
-            models.LabeledData,
-            self._task.get_annotations,
-            "annotations",
-        )
-
-        self._frame_annotations = {
-            frame_index: FrameAnnotations() for frame_index in sorted(active_frame_indexes)
-        }
-
-        for tag in annotations.tags:
-            # Some annotations may belong to deleted frames; skip those.
-            if tag.frame in self._frame_annotations:
-                self._frame_annotations[tag.frame].tags.append(tag)
-
-        for shape in annotations.shapes:
-            if shape.frame in self._frame_annotations:
-                self._frame_annotations[shape.frame].shapes.append(shape)
+        if load_annotations:
+            self._load_annotations(cache_manager, sorted(active_frame_indexes))
+        else:
+            self._frame_annotations = {
+                frame_index: None for frame_index in sorted(active_frame_indexes)
+            }
 
         # TODO: tracks?
 
@@ -134,6 +125,26 @@ class TaskDataset:
             )
             for k, v in self._frame_annotations.items()
         ]
+
+    def _load_annotations(self, cache_manager: CacheManager, frame_indexes: Iterable[int]) -> None:
+        annotations = cache_manager.ensure_task_model(
+            self._task.id,
+            "annotations.json",
+            models.LabeledData,
+            self._task.get_annotations,
+            "annotations",
+        )
+
+        self._frame_annotations = {frame_index: FrameAnnotations() for frame_index in frame_indexes}
+
+        for tag in annotations.tags:
+            # Some annotations may belong to deleted frames; skip those.
+            if tag.frame in self._frame_annotations:
+                self._frame_annotations[tag.frame].tags.append(tag)
+
+        for shape in annotations.shapes:
+            if shape.frame in self._frame_annotations:
+                self._frame_annotations[shape.frame].shapes.append(shape)
 
     @property
     def labels(self) -> Sequence[models.ILabel]:

--- a/tests/python/sdk/test_datasets.py
+++ b/tests/python/sdk/test_datasets.py
@@ -206,3 +206,17 @@ class TestTaskDataset:
         )
 
         assert dataset.samples[6].annotations.shapes[0].label_id == self.expected_labels[0].id
+
+    def test_no_annotations(self):
+        dataset = cvatds.TaskDataset(self.client, self.task.id, load_annotations=False)
+
+        for index, sample in enumerate(dataset.samples):
+            assert sample.frame_index == index
+            assert sample.frame_name == self.images[index].name
+
+            actual_image = sample.media.load_image()
+            expected_image = PIL.Image.open(self.images[index])
+
+            assert actual_image == expected_image
+
+            assert sample.annotations is None


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
We don't need existing annotations in order to re-annotate a task, but they were being fetched anyway, because that's how the underlying `TaskDataset` class works.

Add an option to `TaskDataset` to disable annotation loading, and use it in `auto_annotate` to prevent those unnecessary fetches.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
