### PR TITLE
Support running CVAT with an external database via Docker Compose

### DIFF
--- a/backend_entrypoint.sh
+++ b/backend_entrypoint.sh
@@ -8,7 +8,7 @@ fail() {
 }
 
 wait_for_db() {
-    ~/wait-for-it.sh "${CVAT_POSTGRES_HOST}:5432" -t 0
+    ~/wait-for-it.sh "${CVAT_POSTGRES_HOST}:${CVAT_POSTGRES_PORT:-5432}" -t 0
 }
 
 cmd_bash() {

--- a/changelog.d/20231024_190737_roman_docker_compose_external_db.md
+++ b/changelog.d/20231024_190737_roman_docker_compose_external_db.md
@@ -1,0 +1,4 @@
+### Added
+
+- Support for using an external database in a Docker Compose-based deployment
+  (<https://github.com/opencv/cvat/pull/7055>)

--- a/docker-compose.external_db.yml
+++ b/docker-compose.external_db.yml
@@ -1,0 +1,33 @@
+# Copyright (C) 2023 CVAT.ai Corporation
+#
+# SPDX-License-Identifier: MIT
+
+# This optional Docker Compose file may be used to deploy CVAT with an external database.
+
+x-backend-settings: &backend-settings
+  environment:
+    CVAT_POSTGRES_HOST:
+    CVAT_POSTGRES_PORT:
+    CVAT_POSTGRES_DBNAME:
+    CVAT_POSTGRES_USER:
+    CVAT_POSTGRES_PASSWORD_FILE: /run/secrets/postgres_password
+  secrets:
+    - postgres_password
+
+services:
+  cvat_db:
+    deploy:
+      replicas: 0
+
+  cvat_server: *backend-settings
+  cvat_utils: *backend-settings
+  cvat_worker_analytics_reports: *backend-settings
+  cvat_worker_annotation: *backend-settings
+  cvat_worker_export: *backend-settings
+  cvat_worker_import: *backend-settings
+  cvat_worker_quality_reports: *backend-settings
+  cvat_worker_webhooks: *backend-settings
+
+secrets:
+  postgres_password:
+    environment: CVAT_POSTGRES_PASSWORD

--- a/site/content/en/docs/administration/basics/installation.md
+++ b/site/content/en/docs/administration/basics/installation.md
@@ -521,6 +521,30 @@ docker compose -f docker-compose.yml -f docker-compose.https.yml up -d
 
 Then, the CVAT instance will be available at your domain on ports 443 (HTTPS) and 80 (HTTP, redirects to 443).
 
+### Deploy CVAT with an external database
+
+By default, `docker compose up` will start a PostgreSQL database server,
+which will be used to store CVAT's data.
+If you'd like to use your own PostgreSQL instance instead, you can do so as follows.
+Note that CVAT only supports the same major version of PostgreSQL
+as is used in `docker-compose.yml`.
+
+First, define environment variables with database connection settings:
+
+```shell
+export CVAT_POSTGRES_HOST=<PostgreSQL hostname> # mandatory
+export CVAT_POSTGRES_PORT=<PostgreSQL port> # defaults to 5432
+export CVAT_POSTGRES_DBNAME=<PostgreSQL database name> # defaults to "cvat"
+export CVAT_POSTGRES_USER=<PostgreSQL role name> # defaults to "root"
+export CVAT_POSTGRES_PASSWORD=<PostgreSQL role password> # mandatory
+```
+
+Then, add the `docker-compose.external_db.yml` file to your `docker compose up` command:
+
+```shell
+docker compose -f docker-compose.yml -f docker-compose.external_db.yml up -d
+```
+
 ### How to pull/build/update CVAT images
 
 - **For a CVAT version lower or equal to 2.1.0**, you need to pull images using docker because


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This would help users who don't want or need the complexity of Kubernetes, but would still like to use an external database.

With Docker Compose, you can initialize a secret from an environment variable, but you can't load a secret _into_ an environment variable. So in order to be able to read the DB password from a secret, I had to introduce a new `CVAT_POSTGRES_PASSWORD_FILE` variable.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
