### PR TITLE
Fixed: a mask becomes visible even if hidden after changing opacity level 

### DIFF
--- a/changelog.d/20231025_101044_boris_keypoints.md
+++ b/changelog.d/20231025_101044_boris_keypoints.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- A mask becomes visible even if hidden after changing opacity level
+  (<https://github.com/opencv/cvat/pull/7060>)

--- a/cvat-canvas/package.json
+++ b/cvat-canvas/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-canvas",
-  "version": "2.18.0",
+  "version": "2.18.1",
   "description": "Part of Computer Vision Annotation Tool which presents its canvas library",
   "main": "src/canvas.ts",
   "scripts": {

--- a/cvat-canvas/src/typescript/canvasView.ts
+++ b/cvat-canvas/src/typescript/canvasView.ts
@@ -2921,6 +2921,18 @@ export class CanvasViewImpl implements CanvasView, Listener {
             }),
         );
 
+        if (state.occluded) {
+            image.addClass('cvat_canvas_shape_occluded');
+        }
+
+        if (state.hidden || state.outside || this.isInnerHidden(state.clientID)) {
+            image.addClass('cvat_canvas_hidden');
+        }
+
+        if (state.isGroundTruth) {
+            image.addClass('cvat_canvas_ground_truth');
+        }
+
         return image;
     }
 

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -151,7 +151,7 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.get('.cvat-appearance-opacity-slider').click('right');
             cy.get('.cvat-appearance-opacity-slider').click('center');
             cy.get('#cvat_canvas_shape_1')
-                .should('exist').and('be.visible').and('have.class', 'cvat_canvas_hidden');
+                .should('exist').and('have.class', 'cvat_canvas_hidden').and('not.be.visible');
         });
 
         it('Editing a drawn mask', () => {

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -133,6 +133,27 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.get('#cvat_canvas_shape_2').should('exist').and('be.visible');
         });
 
+        it('Check hidden mask still invisible after changing frame/opacity', () => {
+            cy.startMaskDrawing();
+            cy.drawMask(drawingActions);
+            cy.finishMaskDrawing();
+
+            cy.get('#cvat-objects-sidebar-state-item-1').within(() => {
+                cy.get('.cvat-object-item-button-hidden')
+                    .should('exist').and('be.visible').click();
+                cy.get('.cvat-object-item-button-hidden')
+                    .should('have.class', 'cvat-object-item-button-hidden-enabled');
+            });
+
+            cy.goCheckFrameNumber(serverFiles.length - 1);
+            cy.goCheckFrameNumber(0);
+
+            cy.get('.cvat-appearance-opacity-slider').click('right');
+            cy.get('.cvat-appearance-opacity-slider').click('center');
+            cy.get('#cvat_canvas_shape_1')
+                .should('exist').and('be.visible').and('have.class', 'cvat_canvas_hidden');
+        });
+
         it('Editing a drawn mask', () => {
             cy.startMaskDrawing();
             cy.drawMask(drawingActions);


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
