### PR TITLE
REST API tests for default bucket prefix

### DIFF
--- a/changelog.d/20231030_124607_maria_test_for_default_prefix.md
+++ b/changelog.d/20231030_124607_maria_test_for_default_prefix.md
@@ -1,0 +1,4 @@
+### Added
+
+- REST API tests for default bucket prefix
+  (<https://github.com/opencv/cvat/pull/7079>)

--- a/changelog.d/20231030_124607_maria_test_for_default_prefix.md
+++ b/changelog.d/20231030_124607_maria_test_for_default_prefix.md
@@ -1,4 +1,0 @@
-### Added
-
-- REST API tests for default bucket prefix
-  (<https://github.com/opencv/cvat/pull/7079>)

--- a/cvat/apps/engine/cloud_provider.py
+++ b/cvat/apps/engine/cloud_provider.py
@@ -256,7 +256,7 @@ class _CloudStorage(ABC):
 
         search_prefix = prefix
         if self.prefix and (len(prefix) < len(self.prefix)):
-            if '/' in self.prefix[len(prefix):]:
+            if prefix and '/' in self.prefix[len(prefix):]:
                 next_layer_and_tail = self.prefix[prefix.find('/') + 1:].split(
                     "/", maxsplit=1
                 )

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -444,6 +444,7 @@ class TestGetCloudStoragePreview:
         else:
             self._test_cannot_see(username, storage_id)
 
+
 @pytest.mark.usefixtures("restore_db_per_function")
 class TestGetCloudStorageContent:
     USER = "admin1"

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -603,6 +603,16 @@ class TestGetCloudStorageContent:
                 [],
             ),
             (
+                SUPPORTED_VERSIONS.V2,  # [v2] list bucket content based on manifest when default bucket prefix contains dirs and prefix starts with it
+                "sub/manifest.jsonl",
+                "s",
+                "sub/",
+                None,
+                [
+                    FileInfo(mime_type="DIR", name="sub", type="DIR"),
+                ],
+            ),
+            (
                 SUPPORTED_VERSIONS.V2,  # [v2] list real bucket content when default bucket prefix is set to directory
                 None,
                 None,
@@ -656,6 +666,16 @@ class TestGetCloudStorageContent:
                 "sub/image_case_65_2",
                 None,
                 [],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list real bucket content when default bucket prefix contains dirs and prefix starts with it
+                None,
+                "s",
+                "sub/",
+                None,
+                [
+                    FileInfo(mime_type="DIR", name="sub", type="DIR"),
+                ],
             ),
         ],
     )

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -444,7 +444,7 @@ class TestGetCloudStoragePreview:
         else:
             self._test_cannot_see(username, storage_id)
 
-
+@pytest.mark.usefixtures("restore_db_per_function")
 class TestGetCloudStorageContent:
     USER = "admin1"
 
@@ -477,11 +477,12 @@ class TestGetCloudStorageContent:
 
     @pytest.mark.parametrize("cloud_storage_id", [2])
     @pytest.mark.parametrize(
-        "version, manifest, prefix, page_size, expected_content",
+        "version, manifest, prefix, default_bucket_prefix, page_size, expected_content",
         [
             (
                 SUPPORTED_VERSIONS.V1,  # [v1] list all bucket content
                 "sub/manifest.jsonl",
+                None,
                 None,
                 None,
                 ["sub/image_case_65_1.png", "sub/image_case_65_2.png"],
@@ -491,12 +492,14 @@ class TestGetCloudStorageContent:
                 "sub/manifest.jsonl",
                 None,
                 None,
+                None,
                 [FileInfo(mime_type="DIR", name="sub", type="DIR")],
             ),
             (
                 SUPPORTED_VERSIONS.V2,  # [v2] search by some prefix in bucket content based on manifest
                 "sub/manifest.jsonl",
                 "sub/image_case_65_1",
+                None,
                 None,
                 [
                     FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
@@ -506,6 +509,7 @@ class TestGetCloudStorageContent:
                 SUPPORTED_VERSIONS.V2,  # [v2] list the second layer (directory "sub") of bucket content based on manifest
                 "sub/manifest.jsonl",
                 "sub/",
+                None,
                 None,
                 [
                     FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
@@ -517,12 +521,14 @@ class TestGetCloudStorageContent:
                 None,
                 None,
                 None,
+                None,
                 [FileInfo(mime_type="DIR", name="sub", type="DIR")],
             ),
             (
                 SUPPORTED_VERSIONS.V2,  # [v2] list the second layer (directory "sub") of real bucket content
                 None,
                 "sub/",
+                None,
                 2,
                 [
                     FileInfo(mime_type="unknown", name="demo_manifest.jsonl", type="REG"),
@@ -534,6 +540,7 @@ class TestGetCloudStorageContent:
                 None,
                 "/sub/",  # cover case: API is identical to share point API
                 None,
+                None,
                 [
                     FileInfo(mime_type="unknown", name="demo_manifest.jsonl", type="REG"),
                     FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
@@ -543,6 +550,112 @@ class TestGetCloudStorageContent:
                     FileInfo(mime_type="unknown", name="manifest_2.jsonl", type="REG"),
                 ],
             ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list bucket content based on manifest when default bucket prefix is set to directory
+                "sub/manifest.jsonl",
+                None,
+                "sub/",
+                None,
+                [
+                    FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
+                    FileInfo(mime_type="image", name="image_case_65_2.png", type="REG"),
+                ],
+            ),
+            (
+                # [v2] list bucket content based on manifest when default bucket prefix
+                # is set to template from which the files should start
+                SUPPORTED_VERSIONS.V2,
+                "sub/manifest.jsonl",
+                None,
+                "sub/image_case_65_1",
+                None,
+                [
+                    FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
+                ],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list bucket content based on manifest when specified prefix is stricter than default bucket prefix
+                "sub/manifest.jsonl",
+                "sub/image_case_65_1",
+                "sub/image_case",
+                None,
+                [
+                    FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
+                ],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list bucket content based on manifest when default bucket prefix is stricter than specified prefix
+                "sub/manifest.jsonl",
+                "sub/image_case",
+                "sub/image_case_65_1",
+                None,
+                [
+                    FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
+                ],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list bucket content based on manifest when default bucket prefix and specified prefix have no intersection
+                "sub/manifest.jsonl",
+                "sub/image_case_65_1",
+                "sub/image_case_65_2",
+                None,
+                [],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list real bucket content when default bucket prefix is set to directory
+                None,
+                None,
+                "sub/",
+                None,
+                [
+                    FileInfo(mime_type="unknown", name="demo_manifest.jsonl", type="REG"),
+                    FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
+                    FileInfo(mime_type="image", name="image_case_65_2.png", type="REG"),
+                    FileInfo(mime_type="unknown", name="manifest.jsonl", type="REG"),
+                    FileInfo(mime_type="unknown", name="manifest_1.jsonl", type="REG"),
+                    FileInfo(mime_type="unknown", name="manifest_2.jsonl", type="REG"),
+                ],
+            ),
+            (
+                # [v2] list real bucket content when default bucket prefix
+                # is set to template from which the files should start
+                SUPPORTED_VERSIONS.V2,
+                None,
+                None,
+                "sub/demo",
+                None,
+                [
+                    FileInfo(mime_type="unknown", name="demo_manifest.jsonl", type="REG"),
+                ],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list real bucket content when specified prefix is stricter than default bucket prefix
+                None,
+                "sub/image_case_65_1",
+                "sub/image_case",
+                None,
+                [
+                    FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
+                ],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list real bucket content when default bucket prefix is stricter than specified prefix
+                None,
+                "sub/image_case",
+                "sub/image_case_65_1",
+                None,
+                [
+                    FileInfo(mime_type="image", name="image_case_65_1.png", type="REG"),
+                ],
+            ),
+            (
+                SUPPORTED_VERSIONS.V2,  # [v2] list real bucket content when default bucket prefix and specified prefix have no intersection
+                None,
+                "sub/image_case_65_1",
+                "sub/image_case_65_2",
+                None,
+                [],
+            ),
         ],
     )
     def test_get_cloud_storage_content(
@@ -551,9 +664,23 @@ class TestGetCloudStorageContent:
         version: SUPPORTED_VERSIONS,
         manifest: Optional[str],
         prefix: Optional[str],
+        default_bucket_prefix: Optional[str],
         page_size: Optional[int],
         expected_content: Optional[Any],
+        cloud_storages,
     ):
+        if default_bucket_prefix:
+            cloud_storage = cloud_storages[cloud_storage_id]
+
+            with make_api_client(self.USER) as api_client:
+                (_, response) = api_client.cloudstorages_api.partial_update(
+                    cloud_storage_id,
+                    patched_cloud_storage_write_request={
+                        "specific_attributes": f'{cloud_storage["specific_attributes"]}&prefix={default_bucket_prefix}'
+                    },
+                )
+                assert response.status == HTTPStatus.OK
+
         result = self._test_get_cloud_storage_content(
             cloud_storage_id, version, manifest, prefix=prefix, page_size=page_size
         )

--- a/utils/dataset_manifest/core.py
+++ b/utils/dataset_manifest/core.py
@@ -622,7 +622,7 @@ class ImageManifestManager(_ManifestManager):
 
         search_prefix = prefix
         if default_prefix and (len(prefix) < len(default_prefix)):
-            if '/' in self.prefix[len(prefix):]:
+            if prefix and '/' in default_prefix[len(prefix):]:
                 next_layer_and_tail = default_prefix[prefix.find('/') + 1:].split(
                     "/", maxsplit=1
                 )


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This PR contains REST API tests for https://github.com/opencv/cvat/pull/6943
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
~~- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->~~
~~- [ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
~~- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
~~- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
