### PR TITLE
Handle task creation with unsupported data types from cloud storage with cache enabled

### DIFF
--- a/changelog.d/20231107_145655_maria_handle_task_creation_withvideo_from_cs_and_cache.md
+++ b/changelog.d/20231107_145655_maria_handle_task_creation_withvideo_from_cs_and_cache.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Ignore the "use cache" option on the server when creating a task with cloud storage data (except images)
+  (<https://github.com/opencv/cvat/pull/7087>)

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -648,7 +648,7 @@ def _create_thread(
 
     if is_data_in_cloud:
         # first we need to filter files and keep only supported ones
-        if set(media.keys()) - set(['image']) and db_data.storage_method == models.StorageMethodChoice.CACHE:
+        if any([v for k, v in media.items() if k != 'image']) and db_data.storage_method == models.StorageMethodChoice.CACHE:
             # FUTURE-FIXME: This is a temporary workaround for creating tasks
             # with unsupported cloud storage data (video, archive, pdf) when use_cache is enabled
             db_data.storage_method = models.StorageMethodChoice.FILE_SYSTEM

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -658,6 +658,13 @@ def _create_thread(
                 upload_dir, data.get('server_files_path'), data.get('server_files_exclude'))
             manifest_root = upload_dir
         elif is_data_in_cloud:
+            for m_type in set(media.keys()) - set(['image']):
+                if media[m_type]:
+                    raise ValidationError(
+                        f'Creating tasks from cloud storage {m_type} files with an enabled use cache option '
+                        'is not currently supported. Disable this option to create a task.'
+                    )
+
             if job_file_mapping is not None:
                 sorted_media = list(itertools.chain.from_iterable(job_file_mapping))
             else:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This PR ignores the `use cache` option on the server when creating tasks with cloud storage data (except images)
### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
~~- [ ] I have updated the documentation accordingly~~
~~- [ ] I have added tests to cover my changes~~
~~- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
~~- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
