### PR TITLE
helm-chart: make backend templates more uniform

### DIFF
--- a/changelog.d/20231113_174833_roman_refactor_values.md
+++ b/changelog.d/20231113_174833_roman_refactor_values.md
@@ -1,0 +1,5 @@
+### Changed
+
+- \[Helm\] All backend-related deployments now use `cvat-app` as the value
+  for the `app` label
+  (<https://github.com/opencv/cvat/pull/7127>)

--- a/helm-chart/templates/cvat_backend/initializer/job.yml
+++ b/helm-chart/templates/cvat_backend/initializer/job.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.initializer -}}
+
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -12,10 +14,10 @@ metadata:
     tier: backend
     component: initializer
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.initializer.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.initializer.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -27,42 +29,42 @@ spec:
         tier: backend
         component: initializer
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.initializer.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.initializer.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-initializer-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.initializer.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["init"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.initializer.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.cvat.backend.initializer.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
       restartPolicy: OnFailure
-      {{- with .Values.cvat.backend.initializer.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.initializer.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.initializer.additionalVolumes }}
+      {{- with $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart/templates/cvat_backend/server/deployment.yml
+++ b/helm-chart/templates/cvat_backend/server/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.server -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,21 +10,21 @@ metadata:
     tier: backend
     component: server
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.server.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.server.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.server.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.server.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -35,32 +37,32 @@ spec:
         tier: backend
         component: server
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.server.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.server.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-server-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.server.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "server"]
           env:
           - name: ALLOWED_HOSTS
-            value: {{ .Values.cvat.backend.server.envs.ALLOWED_HOSTS | squote}}
+            value: {{ $localValues.envs.ALLOWED_HOSTS | squote}}
           - name: DJANGO_MODWSGI_EXTRA_ARGS
-            value: {{ .Values.cvat.backend.server.envs.DJANGO_MODWSGI_EXTRA_ARGS}}
+            value: {{ $localValues.envs.DJANGO_MODWSGI_EXTRA_ARGS}}
           - name: IAM_OPA_BUNDLE
             value: "1"
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.server.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:
@@ -68,7 +70,7 @@ spec:
           volumeMounts:
           {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-server-backend-cache
+            name: cvat-backend-per-service-cache
           {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
@@ -82,7 +84,7 @@ spec:
           - mountPath: /home/django/models
             name: cvat-backend-data
             subPath: models
-          {{- with .Values.cvat.backend.server.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -90,7 +92,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with .Values.cvat.backend.server.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -98,7 +100,7 @@ spec:
           {{- if .Values.cvat.backend.defaultStorage.enabled }}
           {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-server-backend-cache
+            name: cvat-backend-per-service-cache
           {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
@@ -113,15 +115,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with .Values.cvat.backend.server.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with .Values.cvat.backend.server.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.server.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -131,11 +133,11 @@ spec:
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-backend-data"
         {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
-        - name: cvat-server-backend-cache
+        - name: cvat-backend-per-service-cache
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with .Values.cvat.backend.server.additionalVolumes }}
+        {{- with $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/utils/deployment.yml
+++ b/helm-chart/templates/cvat_backend/utils/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.utils -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,62 +10,62 @@ metadata:
     tier: backend
     component: utils
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.utils.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.utils.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.utils.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.utils.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      app: cvat-app-utils
+      app: cvat-app
       tier: backend
       component: utils
   template:
     metadata:
       labels:
-        app: cvat-app-utils
+        app: cvat-app
         tier: backend
         component: utils
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.utils.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.utils.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-utils-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.utils.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "utils"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.utils.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:
           - containerPort: 8080
           volumeMounts:
-        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+          {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-utils-backend-cache
-        {{- end }}
+            name: cvat-backend-per-service-cache
+          {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
             subPath: data
@@ -76,7 +78,7 @@ spec:
           - mountPath: /home/django/models
             name: cvat-backend-data
             subPath: models
-          {{- with .Values.cvat.backend.utils.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -84,7 +86,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with .Values.cvat.backend.utils.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -92,8 +94,8 @@ spec:
           {{- if .Values.cvat.backend.defaultStorage.enabled }}
           {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-utils-backend-cache
-            {{- end }}
+            name: cvat-backend-per-service-cache
+          {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
             subPath: data
@@ -107,15 +109,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with .Values.cvat.backend.utils.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with .Values.cvat.backend.utils.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.utils.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -124,13 +126,12 @@ spec:
         - name: cvat-backend-data
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-backend-data"
-
         {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
-        - name: cvat-utils-backend-cache
+        - name: cvat-backend-per-service-cache
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with .Values.cvat.backend.utils.additionalVolumes }}
+        {{- with $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_analyticsreports/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_analyticsreports/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.worker.analyticsreports -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,68 +10,68 @@ metadata:
     tier: backend
     component: worker-analyticsreports
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.analyticsreports.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.analyticsreports.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.analyticsreports.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.analyticsreports.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      app: cvat-app-worker-analyticsreports
+      app: cvat-app
       tier: backend
       component: worker-analyticsreports
   template:
     metadata:
       labels:
-        app: cvat-app-worker-analyticsreports
+        app: cvat-app
         tier: backend
         component: worker-analyticsreports
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.analyticsreports.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.analyticsreports.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-analyticsreports-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.analyticsreports.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.analytics_reports"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.worker.analyticsreports.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.cvat.backend.worker.analyticsreports.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      {{- with .Values.cvat.backend.worker.analyticsreports.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.analyticsreports.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.analyticsreports.additionalVolumes }}
+      {{- with $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.worker.annotation -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,21 +10,21 @@ metadata:
     tier: backend
     component: worker-annotation
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.annotation.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.annotation.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.annotation.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.annotation.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -35,33 +37,33 @@ spec:
         tier: backend
         component: worker-annotation
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.annotation.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.annotation.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-annotation-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.annotation.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.annotation"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.worker.annotation.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           volumeMounts:
-        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+          {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-worker-annotation-backend-cache
-        {{- end }}
+            name: cvat-backend-per-service-cache
+          {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
             subPath: data
@@ -77,7 +79,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with .Values.cvat.backend.worker.annotation.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -85,16 +87,16 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with .Values.cvat.backend.worker.annotation.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
           {{- if .Values.cvat.backend.defaultStorage.enabled }}
-        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+          {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-worker-annotation-backend-cache
-        {{- end }}
+            name: cvat-backend-per-service-cache
+          {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
             subPath: data
@@ -108,15 +110,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with .Values.cvat.backend.worker.annotation.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.annotation.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.annotation.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -125,10 +127,12 @@ spec:
         - name: cvat-backend-data
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-backend-data"
-        - name: cvat-worker-annotation-backend-cache
+        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+        - name: cvat-backend-per-service-cache
           emptyDir: {}
         {{- end }}
-        {{- with .Values.cvat.backend.worker.annotation.additionalVolumes }}
+        {{- end }}
+        {{- with $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_export/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_export/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.worker.export -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,21 +10,21 @@ metadata:
     tier: backend
     component: worker-export
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.export.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.export.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.export.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.export.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -35,33 +37,33 @@ spec:
         tier: backend
         component: worker-export
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.export.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.export.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-export-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.export.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.export"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.worker.export.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           volumeMounts:
-        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+          {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-worker-export-backend-cache
-        {{- end }}
+            name: cvat-backend-per-service-cache
+          {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
             subPath: data
@@ -77,7 +79,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with .Values.cvat.backend.worker.export.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -85,16 +87,16 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with .Values.cvat.backend.worker.export.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           volumeMounts:
           {{- if .Values.cvat.backend.defaultStorage.enabled }}
-        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+          {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-worker-export-backend-cache
-        {{- end }}
+            name: cvat-backend-per-service-cache
+          {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
             subPath: data
@@ -108,15 +110,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with .Values.cvat.backend.worker.export.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.export.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.export.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -125,13 +127,12 @@ spec:
         - name: cvat-backend-data
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-backend-data"
-
         {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
-        - name: cvat-worker-export-backend-cache
+        - name: cvat-backend-per-service-cache
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with .Values.cvat.backend.worker.export.additionalVolumes }}
+        {{- with $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_import/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_import/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.worker.import -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,21 +10,21 @@ metadata:
     tier: backend
     component: worker-import
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.import.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.import.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.import.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.import.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -35,33 +37,33 @@ spec:
         tier: backend
         component: worker-import
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.import.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.import.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-import-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.import.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.import"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.worker.import.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           volumeMounts:
-        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+          {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-worker-import-backend-cache
-        {{- end }}
+            name: cvat-backend-per-service-cache
+          {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
             subPath: data
@@ -77,7 +79,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with .Values.cvat.backend.worker.import.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -85,7 +87,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with .Values.cvat.backend.worker.import.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -93,7 +95,7 @@ spec:
           {{- if .Values.cvat.backend.defaultStorage.enabled }}
           {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
           - mountPath: /home/django/data/cache
-            name: cvat-worker-import-backend-cache
+            name: cvat-backend-per-service-cache
           {{- end }}
           - mountPath: /home/django/data
             name: cvat-backend-data
@@ -108,15 +110,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with .Values.cvat.backend.worker.import.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.import.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.import.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -125,10 +127,12 @@ spec:
         - name: cvat-backend-data
           persistentVolumeClaim:
             claimName: "{{ .Release.Name }}-backend-data"
-        - name: cvat-worker-import-backend-cache
+        {{- if not .Values.cvat.backend.disableDistinctCachePerService }}
+        - name: cvat-backend-per-service-cache
           emptyDir: {}
         {{- end }}
-        {{- with .Values.cvat.backend.worker.import.additionalVolumes }}
+        {{- end }}
+        {{- with $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.worker.qualityreports -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,21 +10,21 @@ metadata:
     tier: backend
     component: worker-qualityreports
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.qualityreports.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.qualityreports.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.qualityreports.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.qualityreports.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -35,41 +37,41 @@ spec:
         tier: backend
         component: worker-qualityreports
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.qualityreports.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.qualityreports.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-qualityreports-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.qualityreports.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.quality_reports"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.worker.qualityreports.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.cvat.backend.worker.qualityreports.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      {{- with .Values.cvat.backend.worker.qualityreports.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.qualityreports.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.qualityreports.additionalVolumes }}
+      {{- with $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
@@ -1,3 +1,5 @@
+{{- $localValues := .Values.cvat.backend.worker.webhooks -}}
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -8,68 +10,68 @@ metadata:
     tier: backend
     component: worker-webhooks
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with .Values.cvat.backend.worker.webhooks.labels }}
+    {{- with $localValues.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with .Values.cvat.backend.worker.webhooks.annotations }}
+  {{- with $localValues.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  replicas: {{ .Values.cvat.backend.worker.webhooks.replicas }}
+  replicas: {{ $localValues.replicas }}
   strategy:
     type: Recreate
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with .Values.cvat.backend.worker.webhooks.labels }}
+      {{- with $localValues.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
-      app: cvat-app-worker-webhooks
+      app: cvat-app
       tier: backend
       component: worker-webhooks
   template:
     metadata:
       labels:
-        app: cvat-app-worker-webhooks
+        app: cvat-app
         tier: backend
         component: worker-webhooks
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with .Values.cvat.backend.worker.webhooks.labels }}
+        {{- with $localValues.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with .Values.cvat.backend.worker.webhooks.annotations }}
+      {{- with $localValues.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
     spec:
       containers:
-        - name: cvat-app-backend-worker-webhooks-container
+        - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with .Values.cvat.backend.worker.webhooks.resources }}
+          {{- with $localValues.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.webhooks"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with .Values.cvat.backend.worker.webhooks.additionalEnv }}
+          {{- with $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with .Values.cvat.backend.worker.webhooks.additionalVolumeMounts }}
+          {{- with $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      {{- with .Values.cvat.backend.worker.webhooks.affinity }}
+      {{- with $localValues.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.webhooks.tolerations }}
+      {{- with $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.cvat.backend.worker.webhooks.additionalVolumes }}
+      {{- with $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The templates for the various backend service deployments differ in many ways, but a lot of those differences can be eliminated. That way, it becomes easier to compare different templates, to create new services, and to make changes across all templates.

Specific differences which are eliminated are as follows:

* Different sets of values are used for customization. This can be mitigated by putting the specific set of values in a local variable once. That way, only the variable assignment needs to differ.

* Containers and volumes are named differently. There's no need for this, since these names are local to a pod. Just name all analogous containers/volumes the same thing.

* Some deployments use different values for the `app` label. This just seems incorrect, since they all belong to the same app. Standardize on `cvat-app` as the value.

* Some deployments forget to check disableDistinctCachePerService. That seems like a bug.

* There are minor formatting differences.

Ideally I'd like to reduce these templates to just calling one big shared template with service-specific parameters, but there are still enough differences between the templates that I don't feel like doing that just yet.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
`helm template`

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
