### PR TITLE
helm-chart: add a way to easily set parameters for all backend pods

### DIFF
--- a/changelog.d/20231116_140728_roman_backend_settings.md
+++ b/changelog.d/20231116_140728_roman_backend_settings.md
@@ -1,0 +1,4 @@
+### Added
+
+- \[Helm\] Values that apply to all backend deployments/jobs
+  (<https://github.com/opencv/cvat/pull/7148>)

--- a/helm-chart/templates/cvat_backend/initializer/job.yml
+++ b/helm-chart/templates/cvat_backend/initializer/job.yml
@@ -14,10 +14,10 @@ metadata:
     tier: backend
     component: initializer
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -29,10 +29,10 @@ spec:
         tier: backend
         component: initializer
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -41,30 +41,30 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["init"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
       restartPolicy: OnFailure
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.additionalVolumes }}
+      {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart/templates/cvat_backend/server/deployment.yml
+++ b/helm-chart/templates/cvat_backend/server/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: server
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: server
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,7 +49,7 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -62,7 +62,7 @@ spec:
           - name: IAM_OPA_BUNDLE
             value: "1"
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:
@@ -84,7 +84,7 @@ spec:
           - mountPath: /home/django/models
             name: cvat-backend-data
             subPath: models
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -92,7 +92,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -115,15 +115,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -137,7 +137,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with $localValues.additionalVolumes }}
+        {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/utils/deployment.yml
+++ b/helm-chart/templates/cvat_backend/utils/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: utils
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: utils
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,14 +49,14 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "utils"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           ports:
@@ -78,7 +78,7 @@ spec:
           - mountPath: /home/django/models
             name: cvat-backend-data
             subPath: models
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -86,7 +86,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -109,15 +109,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -131,7 +131,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with $localValues.additionalVolumes }}
+        {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_analyticsreports/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_analyticsreports/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: worker-analyticsreports
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: worker-analyticsreports
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,29 +49,29 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.analytics_reports"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.additionalVolumes }}
+      {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_annotation/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: worker-annotation
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: worker-annotation
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,14 +49,14 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.annotation"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           volumeMounts:
@@ -79,7 +79,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -87,7 +87,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -110,15 +110,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -132,7 +132,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with $localValues.additionalVolumes }}
+        {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_export/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_export/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: worker-export
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: worker-export
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,14 +49,14 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.export"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           volumeMounts:
@@ -79,7 +79,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -87,7 +87,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -110,15 +110,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -132,7 +132,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with $localValues.additionalVolumes }}
+        {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_import/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_import/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: worker-import
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: worker-import
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,14 +49,14 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.import"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
           volumeMounts:
@@ -79,7 +79,7 @@ spec:
           - mountPath: /home/django/tmp_storage
             name: cvat-backend-data
             subPath: tmp_storage
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
       initContainers:
@@ -87,7 +87,7 @@ spec:
         - name: user-data-permission-fix
           image: busybox
           command: ["/bin/chmod", "-R", "777", "/home/django"]
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
@@ -110,15 +110,15 @@ spec:
             name: cvat-backend-data
             subPath: models
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
         {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -132,7 +132,7 @@ spec:
           emptyDir: {}
         {{- end }}
         {{- end }}
-        {{- with $localValues.additionalVolumes }}
+        {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.imagePullSecrets }}

--- a/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_qualityreports/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: worker-qualityreports
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: worker-qualityreports
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,29 +49,29 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.quality_reports"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.additionalVolumes }}
+      {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
+++ b/helm-chart/templates/cvat_backend/worker_webhooks/deployment.yml
@@ -10,10 +10,10 @@ metadata:
     tier: backend
     component: worker-webhooks
     {{- include "cvat.labels" . | nindent 4 }}
-    {{- with $localValues.labels }}
+    {{- with merge $localValues.labels .Values.cvat.backend.labels }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
-  {{- with $localValues.annotations }}
+  {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
   annotations:
   {{- toYaml . | nindent 4 }}
   {{- end }}
@@ -24,7 +24,7 @@ spec:
   selector:
     matchLabels:
       {{- include "cvat.labels" . | nindent 6 }}
-      {{- with $localValues.labels }}
+      {{- with merge $localValues.labels .Values.cvat.backend.labels }}
       {{- toYaml . | nindent 6 }}
       {{- end }}
       app: cvat-app
@@ -37,10 +37,10 @@ spec:
         tier: backend
         component: worker-webhooks
         {{- include "cvat.labels" . | nindent 8 }}
-        {{- with $localValues.labels }}
+        {{- with merge $localValues.labels .Values.cvat.backend.labels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      {{- with $localValues.annotations }}
+      {{- with merge $localValues.annotations .Values.cvat.backend.annotations }}
       annotations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
@@ -49,29 +49,29 @@ spec:
         - name: cvat-backend
           image: {{ .Values.cvat.backend.image }}:{{ .Values.cvat.backend.tag }}
           imagePullPolicy: {{ .Values.cvat.backend.imagePullPolicy }}
-          {{- with $localValues.resources }}
+          {{- with merge $localValues.resources .Values.cvat.backend.resources }}
           resources:
           {{- toYaml . | nindent 12 }}
           {{- end }}
           args: ["run", "worker.webhooks"]
           env:
           {{ include "cvat.sharedBackendEnv" . | indent 10 }}
-          {{- with $localValues.additionalEnv }}
+          {{- with concat .Values.cvat.backend.additionalEnv $localValues.additionalEnv }}
           {{- toYaml . | nindent 10 }}
           {{- end }}
-          {{- with $localValues.additionalVolumeMounts }}
+          {{- with concat .Values.cvat.backend.additionalVolumeMounts $localValues.additionalVolumeMounts }}
           volumeMounts:
           {{- toYaml . | nindent 10 }}
           {{- end }}
-      {{- with $localValues.affinity }}
+      {{- with merge $localValues.affinity .Values.cvat.backend.affinity }}
       affinity:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.tolerations }}
+      {{- with concat .Values.cvat.backend.tolerations $localValues.tolerations }}
       tolerations:
       {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $localValues.additionalVolumes }}
+      {{- with concat .Values.cvat.backend.additionalVolumes $localValues.additionalVolumes }}
       volumes:
       {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -9,6 +9,15 @@ fullnameOverride: ""
 
 cvat:
   backend:
+    labels: {}
+    annotations: {}
+    resources: {}
+    affinity: {}
+    tolerations: []
+    additionalEnv: []
+    additionalVolumes: []
+    additionalVolumeMounts: []
+
     initializer:
       labels: {}
       annotations: {}


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Since backend pods are all fairly similar, it stands to reason that users would want to apply similar configuration to them. Add some `cvat.backend.*` parameters that are applied to all backend deployments/jobs.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
