### PR TITLE
Fixed missed exif rotation

### DIFF
--- a/changelog.d/20231122_111559_sekachev.bs_fixed_exif.md
+++ b/changelog.d/20231122_111559_sekachev.bs_fixed_exif.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Compressed chunks do not use exif rotation tag
+  (<https://github.com/opencv/cvat/pull/7162>)

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -596,7 +596,7 @@ class IChunkWriter(ABC):
             with Image.open(source_image) as _img:
                 image = ImageOps.exif_transpose(_img)
         elif isinstance(source_image, Image.Image):
-            image = source_image
+            image = ImageOps.exif_transpose(source_image)
 
         assert image is not None
 

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -814,11 +814,14 @@ class TestPostTaskData:
                 _, response = api_client.tasks_api.retrieve_data(
                     task_id, number=0, type="chunk", quality=chunk_quality
                 )
+                data_meta, _ = api_client.tasks_api.retrieve_data_meta(task_id)
+
                 with zipfile.ZipFile(io.BytesIO(response.data)) as zip_file:
-                    for name in zip_file.namelist():
+                    for name, frame_meta in zip(zip_file.namelist(), data_meta.frames):
                         with zip_file.open(name) as zipped_img:
                             im = Image.open(zipped_img)
                             # original is 480x640 with 90/-90 degrees rotation
+                            assert frame_meta.height == 640 and frame_meta.width == 480
                             assert im.height == 640 and im.width == 480
 
     def test_can_create_task_with_big_images(self):

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -809,16 +809,17 @@ class TestPostTaskData:
         task_id, _ = create_task(self._USERNAME, task_spec, task_data)
 
         # check that the frames have correct width and height
-        with make_api_client(self._USERNAME) as api_client:
-            _, response = api_client.tasks_api.retrieve_data(
-                task_id, number=0, type="chunk", quality="original"
-            )
-            with zipfile.ZipFile(io.BytesIO(response.data)) as zip_file:
-                for name in zip_file.namelist():
-                    with zip_file.open(name) as zipped_img:
-                        im = Image.open(zipped_img)
-                        # original is 480x640 with 90/-90 degrees rotation
-                        assert im.height == 640 and im.width == 480
+        for chunk_quality in ["original", "compressed"]:
+            with make_api_client(self._USERNAME) as api_client:
+                _, response = api_client.tasks_api.retrieve_data(
+                    task_id, number=0, type="chunk", quality=chunk_quality
+                )
+                with zipfile.ZipFile(io.BytesIO(response.data)) as zip_file:
+                    for name in zip_file.namelist():
+                        with zip_file.open(name) as zipped_img:
+                            im = Image.open(zipped_img)
+                            # original is 480x640 with 90/-90 degrees rotation
+                            assert im.height == 640 and im.width == 480
 
     def test_can_create_task_with_big_images(self):
         # Checks for regressions about the issue


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Resolved #7155
Resolved #7141

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
