### PR TITLE
[Helm] Allow pre-release k8s versions to fix AWS EKS deployments

### DIFF
--- a/changelog.d/20231129_112732_canyigitozen_helm_chart_kube_version.md
+++ b/changelog.d/20231129_112732_canyigitozen_helm_chart_kube_version.md
@@ -1,0 +1,3 @@
+### Changed
+
+- \[Helm\] Allow pre-release versions in kubernetes requirement to include AWS EKS versions (https://github.com/opencv/cvat/pull/7183)

--- a/changelog.d/20231129_112732_canyigitozen_helm_chart_kube_version.md
+++ b/changelog.d/20231129_112732_canyigitozen_helm_chart_kube_version.md
@@ -1,3 +1,3 @@
 ### Changed
 
-- \[Helm\] Allow pre-release versions in kubernetes requirement to include AWS EKS versions (https://github.com/opencv/cvat/pull/7183)
+- \[Helm\] Allow pre-release versions in kubernetes requirement to include AWS EKS versions (<https://github.com/opencv/cvat/pull/7183>)

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cvat
-kubeVersion: ">= 1.19.0"
+kubeVersion: ">= 1.19.0-0"
 description: A Helm chart for Kubernetes
 
 # A chart can be either an 'application' or a 'library' chart.


### PR DESCRIPTION
Fixes #7182 by including pre-release versions as explained in the [helm docs](https://helm.sh/docs/chart_template_guide/function_list/#working-with-prerelease-versions).