### PR TITLE
[Helm] Don't try to install Traefik Middleware when Traefik is disabled

### DIFF
--- a/changelog.d/20231129_112017_canyigitozen_helm_traefik_middleware.md
+++ b/changelog.d/20231129_112017_canyigitozen_helm_traefik_middleware.md
@@ -1,3 +1,3 @@
 ### Fixed
 
-- [Helm] Fixed installing Traefik Middleware even if Traefik is disabled in the values (<https://github.com/opencv/cvat/pull/7184>)
+- \[Helm\] Fixed installing Traefik Middleware even if Traefik is disabled in the values (<https://github.com/opencv/cvat/pull/7184>)

--- a/changelog.d/20231129_112017_canyigitozen_helm_traefik_middleware.md
+++ b/changelog.d/20231129_112017_canyigitozen_helm_traefik_middleware.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- [Helm] Fixed installing Traefik Middleware even if Traefik is disabled in the values (<https://github.com/opencv/cvat/pull/7184>)

--- a/helm-chart/templates/analytics/middlewares/forwardauth.yaml
+++ b/helm-chart/templates/analytics/middlewares/forwardauth.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.analytics.enabled }}
+{{- if and .Values.traefik.enabled .Values.analytics.enabled }}
 
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware

--- a/helm-chart/templates/analytics/middlewares/stripprefix.yaml
+++ b/helm-chart/templates/analytics/middlewares/stripprefix.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.ingress.enabled .Values.analytics.enabled }}
+{{- if and .Values.traefik.enabled .Values.analytics.enabled }}
 
 apiVersion: traefik.containo.us/v1alpha1
 kind: Middleware


### PR DESCRIPTION
This PR is complementary to #7132. 

#7132 updated ingress templates to work with `traefik.enabled=false` and `ingress.enabled=true` values.

However the templates in `templates/analytics/middlewares` path lead to creation of resources of kind `Middleware`, which is a Traefik CRD. Helm install fails if Traefik is not installed on the cluster.

Changing the top-level conditional from `ingress.enabled` to `traefik.enabled` solves the issue.