### PR TITLE
Fix GCS bucket name validation

### DIFF
--- a/changelog.d/20231205_204101_jootten_fix_validation.md
+++ b/changelog.d/20231205_204101_jootten_fix_validation.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Fix gcs bucket name validation
+- Attaching GCS and AWS S3 buckets with dots in name
   (<https://github.com/opencv/cvat/pull/7227>)

--- a/changelog.d/20231205_204101_jootten_fix_validation.md
+++ b/changelog.d/20231205_204101_jootten_fix_validation.md
@@ -1,4 +1,4 @@
 ### Fixed
 
 - Fix gcs bucket name validation
-  (<https://github.com/opencv/cvat/pull/XXXX>)
+  (<https://github.com/opencv/cvat/pull/7227>)

--- a/changelog.d/20231205_204101_jootten_fix_validation.md
+++ b/changelog.d/20231205_204101_jootten_fix_validation.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Fix gcs bucket name validation
+  (<https://github.com/opencv/cvat/pull/XXXX>)

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1796,14 +1796,14 @@ class CloudStorageWriteSerializer(serializers.ModelSerializer):
         # AWS S3: https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html?icmpid=docs_amazons3_console
         # Azure Container: https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#container-names
         # GCS: https://cloud.google.com/storage/docs/buckets#naming
-        COMMON_ALLOWED_RESOURCE_NAME_SYMBOLS = (
+        ALLOWED_RESOURCE_NAME_SYMBOLS = (
             string.ascii_lowercase + string.digits + "-"
         )
-        ALLOWED_RESOURCE_NAME_SYMBOLS = (
-            COMMON_ALLOWED_RESOURCE_NAME_SYMBOLS
-            if provider_type != models.CloudProviderChoice.GOOGLE_CLOUD_STORAGE
-            else COMMON_ALLOWED_RESOURCE_NAME_SYMBOLS + "_" + "."
-        )
+
+        if provider_type == models.CloudProviderChoice.GOOGLE_CLOUD_STORAGE:
+            ALLOWED_RESOURCE_NAME_SYMBOLS += "_" + "."
+        elif provider_type == models.CloudProviderChoice.AWS_S3:
+            ALLOWED_RESOURCE_NAME_SYMBOLS += "."
 
         # We need to check only basic naming rule
         if (resource := attrs.get("resource")) and (

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1801,7 +1801,7 @@ class CloudStorageWriteSerializer(serializers.ModelSerializer):
         )
 
         if provider_type == models.CloudProviderChoice.GOOGLE_CLOUD_STORAGE:
-            ALLOWED_RESOURCE_NAME_SYMBOLS += "_" + "."
+            ALLOWED_RESOURCE_NAME_SYMBOLS += "_."
         elif provider_type == models.CloudProviderChoice.AWS_S3:
             ALLOWED_RESOURCE_NAME_SYMBOLS += "."
 

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1802,7 +1802,7 @@ class CloudStorageWriteSerializer(serializers.ModelSerializer):
         ALLOWED_RESOURCE_NAME_SYMBOLS = (
             COMMON_ALLOWED_RESOURCE_NAME_SYMBOLS
             if provider_type != models.CloudProviderChoice.GOOGLE_CLOUD_STORAGE
-            else COMMON_ALLOWED_RESOURCE_NAME_SYMBOLS + "_"
+            else COMMON_ALLOWED_RESOURCE_NAME_SYMBOLS + "_" + "."
         )
 
         # We need to check only basic naming rule


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
It is not possible to attach a GCS cloud storage bucket which name contains a dot. As stated [here](https://cloud.google.com/storage/docs/buckets#naming), GCS bucket names allow dots. This is a major problem for us, and this PR fixes this issue.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
No tests required.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [x] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
