### PR TITLE
Simplify the dev environment setup instructions by reusing Compose files

### DIFF
--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -23,8 +23,3 @@ services:
       GITHUB_RUN_ID:
     volumes:
       - ${HOST_COVERAGE_DATA_DIR}:${CONTAINER_COVERAGE_DATA_DIR}
-
-  cvat_redis:
-    ports:
-      - 6379:6379
-

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -104,3 +104,7 @@ services:
   cvat_opa:
     ports:
       - '8181:8181'
+
+  cvat_redis:
+    ports:
+      - '6379:6379'

--- a/site/content/en/docs/contributing/development-environment.md
+++ b/site/content/en/docs/contributing/development-environment.md
@@ -152,25 +152,21 @@ description: 'Installing a development environment for different operating syste
   >
   > Perform this action before installing cvat requirements from the list mentioned above.
 
-- Install [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) and [Docker-Compose](https://docs.docker.com/compose/install/)
+- Install [Docker Engine](https://docs.docker.com/engine/install/ubuntu/) and [Docker Compose](https://docs.docker.com/compose/install/)
 
-- Pull and run Open Policy Agent docker image:
-
-  ```bash
-   docker run -d --rm --name cvat_opa_debug -p 8181:8181 --network=host openpolicyagent/opa:0.45.0-rootless \
-   run --server --set=decision_logs.console=true --set=services.cvat.url=http://localhost:7000 \
-   --set=bundles.cvat.service=cvat --set=bundles.cvat.resource=/api/auth/rules
-  ```
-
-- Pull and run PostgreSQL docker image:
+- Start service dependencies:
 
   ```bash
-  docker run --name cvat_db_debug -e POSTGRES_HOST_AUTH_METHOD=trust -e POSTGRES_USER=root \
-  -e POSTGRES_DB=cvat -p 5432:5432 -d postgres
+  docker compose -f docker-compose.yml -f docker-compose.dev.yml up -d --build \
+    cvat_opa cvat_db cvat_redis cvat_server
   ```
 
-  Note: use `docker start/stop cvat_db_debug` commands to start and stop the container.
-  If it is removed, data will be removed together with the container.
+  Note: this runs an extra copy of the CVAT server in order to supply rules to OPA.
+  If you update the OPA rules, rerun this command to recreate the server image and container.
+
+  Note: to stop these services, use
+  `docker compose -f docker-compose.yml -f docker-compose.dev.yml down`.
+  You can add `-v` to remove the data, as well.
 
 - Apply migrations and create a super user for CVAT:
 


### PR DESCRIPTION
The advantages of this are as follows:

* It's much easier for a developer to use one `docker compose up` command to bring everything up than to run a custom command for each service.

* We eliminate possible divergence of configuration (e.g. versions, command-line parameters) between what we actually use and what's listed in the documentation.

* It makes it easier to update the developer guide if new dependencies are introduced.

* And speaking of new dependencies, we have KeyDB now, which hasn't been added to the dev guide.

The disadvantage is that we have to run an extra copy of the CVAT server, because otherwise OPA can't fetch its rules. I don't think it's a significant issue, since it doesn't prevent you from debugging anything.

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Working on #7245, I realized that I don't want to add another custom command for running Redis in the development environment to the dev guide. So I wanted to remove the custom commands entirely.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
By manually following the updated instructions.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- [x] I have updated the documentation accordingly
- ~~[ ] I have added tests to cover my changes~~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
