### PR TITLE
Correct updating server ID after patching annotations

### DIFF
--- a/cvat-core/src/annotations-saver.ts
+++ b/cvat-core/src/annotations-saver.ts
@@ -363,7 +363,7 @@ export default class AnnotationsSaver {
             const { created, updated, deleted } = this._split(exported);
 
             onUpdate('Updated objects are being saved on the server');
-            this._extractClientIDs(updated);
+            const updatedIndexes = this._extractClientIDs(updated);
             let requestBody = { ...updated, version: this.version };
             let updatedData = null;
             try {
@@ -373,6 +373,7 @@ export default class AnnotationsSaver {
             }
 
             this.version = updatedData.version;
+            this._updateCreatedObjects(updatedData, updatedIndexes);
             for (const type of Object.keys(this.initialObjects)) {
                 for (const object of updatedData[type]) {
                     this.initialObjects[type][object.id] = object;
@@ -397,7 +398,7 @@ export default class AnnotationsSaver {
             }
 
             onUpdate('Created objects are being saved on the server');
-            const indexes = this._extractClientIDs(created);
+            const createdIndexes = this._extractClientIDs(created);
             requestBody = { ...created, version: this.version };
             let createdData = null;
             try {
@@ -407,7 +408,7 @@ export default class AnnotationsSaver {
             }
 
             this.version = createdData.version;
-            this._updateCreatedObjects(createdData, indexes);
+            this._updateCreatedObjects(createdData, createdIndexes);
             for (const type of Object.keys(this.initialObjects)) {
                 for (const object of createdData[type]) {
                     this.initialObjects[type][object.id] = object;


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
In some cases IDs assigned by the server are not updated after saving (e.g. in tracks and skeleton elements)
That does not affect UX, but it makes the server to remove and recreate objects instead of updating them

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
