### PR TITLE
Added test for empty masks issues

### DIFF
--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -190,6 +190,20 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.get('.cvat-brush-tools-polygon-minus').should(condition);
         }
 
+        function checkMaskNotEmpty(selector) {
+            cy.get(selector).should('exist').and('be.visible');
+            cy.get(selector)
+                .should('have.attr', 'height')
+                .then((height) => {
+                    expect(+height).to.be.gt(1);
+                });
+            cy.get(selector)
+                .should('have.attr', 'width')
+                .then((width) => {
+                    expect(+width).to.be.gt(1);
+                });
+        }
+
         it('Erase tools are locked when nothing to erase', () => {
             const erasedMask = [{
                 method: 'brush',
@@ -270,6 +284,30 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             for (const id of [1, 4]) {
                 cy.get(`#cvat_canvas_shape_${id}`).should('exist').and('be.visible');
             }
+        });
+
+        it('Erasing a mask during editing is not allowed', () => {
+            const mask = [{
+                method: 'brush',
+                coordinates: [[450, 250], [600, 400], [450, 550], [300, 400]],
+            }];
+            const eraseAction = [{
+                method: 'polygon-minus',
+                coordinates: [[100, 100], [700, 100], [700, 700], [100, 700]],
+            }];
+
+            cy.startMaskDrawing();
+            cy.drawMask(mask);
+            cy.finishMaskDrawing();
+
+            cy.get('#cvat-objects-sidebar-state-item-1').within(() => {
+                cy.get('[aria-label="more"]').trigger('mouseover');
+            });
+            cy.get('.cvat-object-item-menu').last().should('be.visible').contains('button', 'Edit').click();
+            cy.drawMask(eraseAction);
+            cy.finishMaskDrawing();
+
+            checkMaskNotEmpty('#cvat_canvas_shape_1');
         });
     });
 });

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -74,7 +74,7 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
         });
     });
 
-    describe('Basic masks actions', () => {
+    describe('Tests to make sure that basic features work with masks', () => {
         beforeEach(() => {
             cy.removeAnnotations();
             cy.goCheckFrameNumber(0);
@@ -173,7 +173,7 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
         });
     });
 
-    describe('Empty masks actions', () => {
+    describe('Tests to make sure that empty masks cannot be created', () => {
         beforeEach(() => {
             cy.removeAnnotations();
         });
@@ -190,47 +190,40 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.get('.cvat-brush-tools-polygon-minus').should(condition);
         }
 
-        it(
-            'Drawing a mask, fully erase it. Erase tools are blocked with empty mask. Empty shape is not created.',
-            () => {
-                const erasedMask = [{
+        it('Erase tools are locked when nothing to erase', () => {
+            const erasedMask = [{
+                method: 'brush',
+                coordinates: [[450, 250], [600, 400], [450, 550], [300, 400]],
+            }, {
+                method: 'polygon-minus',
+                coordinates: [[100, 100], [700, 100], [700, 700], [100, 700]],
+            }];
+
+            cy.startMaskDrawing();
+            cy.drawMask(erasedMask);
+
+            cy.get('.cvat-brush-tools-brush').click();
+            checkEraseTools();
+
+            cy.finishMaskDrawing();
+            cy.get('#cvat_canvas_shape_1').should('not.exist');
+        });
+
+        it('Drawing a mask, finish with erasing tool. On new mask drawing tool is reset', () => {
+            const masks = [
+                [{
                     method: 'brush',
                     coordinates: [[450, 250], [600, 400], [450, 550], [300, 400]],
                 }, {
                     method: 'polygon-minus',
-                    coordinates: [[100, 100], [700, 100], [700, 700], [100, 700]],
-                }];
-
-                cy.startMaskDrawing();
-                cy.drawMask(erasedMask);
-
-                cy.get('.cvat-brush-tools-brush').click();
-                checkEraseTools();
-
-                cy.finishMaskDrawing();
-                cy.get('#cvat_canvas_shape_1').should('not.exist');
-            });
-
-        it('Drawing a mask, finish with erasing tool. On new mask drawing tool is reset', () => {
-            const masks = [
-                [
-                    {
-                        method: 'brush',
-                        coordinates: [[450, 250], [600, 400], [450, 550], [300, 400]],
-                    }, {
-                        method: 'polygon-minus',
-                        coordinates: [[100, 100], [400, 100], [400, 400], [100, 400]],
-                    },
-                ],
-                [
-                    {
-                        method: 'brush',
-                        coordinates: [[550, 350], [700, 500], [550, 650], [400, 500]],
-                    }, {
-                        method: 'eraser',
-                        coordinates: [[550, 350]],
-                    },
-                ],
+                    coordinates: [[100, 100], [400, 100], [400, 400], [100, 400]],
+                }], [{
+                    method: 'brush',
+                    coordinates: [[550, 350], [700, 500], [550, 650], [400, 500]],
+                }, {
+                    method: 'eraser',
+                    coordinates: [[550, 350]],
+                }],
             ];
             for (const [index, mask] of masks.entries()) {
                 cy.startMaskDrawing();

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -80,10 +80,6 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             cy.goCheckFrameNumber(0);
         });
 
-        after(() => {
-            cy.removeAnnotations();
-        });
-
         it('Drawing a couple of masks. Save job, reopen job, masks must exist', () => {
             cy.startMaskDrawing();
             cy.drawMask(drawingActions);
@@ -175,10 +171,6 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
 
     describe('Tests to make sure that empty masks cannot be created', () => {
         beforeEach(() => {
-            cy.removeAnnotations();
-        });
-
-        after(() => {
             cy.removeAnnotations();
         });
 

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -200,6 +200,7 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
             }];
 
             cy.startMaskDrawing();
+            checkEraseTools();
             cy.drawMask(erasedMask);
 
             cy.get('.cvat-brush-tools-brush').click();

--- a/tests/cypress/e2e/features/masks_basics.js
+++ b/tests/cypress/e2e/features/masks_basics.js
@@ -211,21 +211,20 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
         });
 
         it('Drawing a mask, finish with erasing tool. On new mask drawing tool is reset', () => {
-            const masks = [
-                [{
-                    method: 'brush',
-                    coordinates: [[450, 250], [600, 400], [450, 550], [300, 400]],
-                }, {
-                    method: 'polygon-minus',
-                    coordinates: [[100, 100], [400, 100], [400, 400], [100, 400]],
-                }], [{
-                    method: 'brush',
-                    coordinates: [[550, 350], [700, 500], [550, 650], [400, 500]],
-                }, {
-                    method: 'eraser',
-                    coordinates: [[550, 350]],
-                }],
-            ];
+            const masks = [[{
+                method: 'brush',
+                coordinates: [[450, 250], [600, 400], [450, 550], [300, 400]],
+            }, {
+                method: 'polygon-minus',
+                coordinates: [[100, 100], [400, 100], [400, 400], [100, 400]],
+            }], [{
+                method: 'brush',
+                coordinates: [[550, 350], [700, 500], [550, 650], [400, 500]],
+            }, {
+                method: 'eraser',
+                coordinates: [[550, 350]],
+            }]];
+
             for (const [index, mask] of masks.entries()) {
                 cy.startMaskDrawing();
                 cy.drawMask(mask);
@@ -240,33 +239,19 @@ context('Manipulations with masks', { scrollBehavior: false }, () => {
         });
 
         it('Empty masks are deleted using remove underlying pixels feature', () => {
-            const masks = [
-                [
-                    {
-                        method: 'brush',
-                        coordinates: [[150, 150], [170, 170]],
-                    },
-                ],
-                [
-                    {
-                        method: 'brush',
-                        coordinates: [[250, 250], [270, 270]],
-                    },
-                ],
-                [
-                    {
-                        method: 'brush',
-                        coordinates: [[350, 350], [370, 370]],
-                    },
-                ],
-                [
-
-                    {
-                        method: 'polygon-plus',
-                        coordinates: [[100, 100], [400, 100], [400, 400], [100, 400]],
-                    },
-                ],
-            ];
+            const masks = [[{
+                method: 'brush',
+                coordinates: [[150, 150], [170, 170]],
+            }], [{
+                method: 'brush',
+                coordinates: [[250, 250], [270, 270]],
+            }], [{
+                method: 'brush',
+                coordinates: [[350, 350], [370, 370]],
+            }], [{
+                method: 'polygon-plus',
+                coordinates: [[100, 100], [400, 100], [400, 400], [100, 400]],
+            }]];
 
             cy.startMaskDrawing();
             cy.get('.cvat-brush-tools-underlying-pixels').click();


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Added tests for #7295 with various UI improvements considering empty masks

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->~~
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
