### PR TITLE
Strip useless linebreak in the payload of send:exception events

### DIFF
--- a/changelog.d/20240129_190242_roman_HEAD.md
+++ b/changelog.d/20240129_190242_roman_HEAD.md
@@ -1,0 +1,5 @@
+### Changed
+
+- The "message" field of the payload of send:exception events
+  no longer includes a trailing linebreak
+  (<https://github.com/opencv/cvat/pull/7407>)

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -518,7 +518,7 @@ def handle_rq_exception(rq_job, exc_type, exc_value, tb):
     tb_strings = traceback.format_exception(exc_type, exc_value, tb)
 
     payload = {
-        "message": tb_strings[-1],
+        "message": tb_strings[-1].rstrip("\n"),
         "stack": ''.join(tb_strings),
     }
 
@@ -563,7 +563,7 @@ def handle_viewset_exception(exc, context):
             "content_type": request.content_type,
             "method": request.method,
         },
-        "message": tb_strings[-1],
+        "message": tb_strings[-1].rstrip("\n"),
         "stack": ''.join(tb_strings),
         "status_code": status_code,
     }


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
`traceback.format_exception` adds a `\n` to each element of the resulting list, so the message will always have a pointless `\n` at the end. Removing it makes CSV reports that include the message easier to parse visually, because there's no longer a linebreak in the middle of each line.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing by triggering an exception.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
