### PR TITLE
Prevent zombie processes from accumulating in the Kvrocks container

### DIFF
--- a/changelog.d/20240130_184639_roman.md
+++ b/changelog.d/20240130_184639_roman.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Prevented zombie processes from accumulating in the Kvrocks container
+  (<https://github.com/opencv/cvat/pull/7412>)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,6 +57,12 @@ services:
     command: [
       "--dir", "/var/lib/kvrocks/data"
     ]
+    # The kvrocks image a) has a healthcheck command, and b) has a root process
+    # that doesn't reap children, so it's susceptible to the problem described here:
+    # <https://stackoverflow.com/a/77109064>. Kvrocks also uses a tiny timeout for
+    # its healthcheck command (1s), which makes the problem more likely to manifest.
+    # Use a separate init process as a workaround.
+    init: true
     volumes:
       - cvat_cache_db:/var/lib/kvrocks/data
     networks:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
I saw several hundreds of zombie processes accumulate in the Kvrocks container in production. This should fix that. See the comment in `docker-compose.yml` for more explanation.

Note that as far as I'm aware, Kubernetes does not use healthcheck commands configured in Docker images, so this issue should be irrelevant for Kubernetes deployments.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
