### PR TITLE
Stabilized cypress test: issue_2900_creating_more_one_tasks_from_project_per_time.js

### DIFF
--- a/cvat-ui/src/components/tasks-page/task-item.tsx
+++ b/cvat-ui/src/components/tasks-page/task-item.tsx
@@ -72,18 +72,19 @@ class TaskItemComponent extends React.PureComponent<TaskItemProps & RouteCompone
             }).then((createdTask: Task) => {
                 if (!this.#isUnmounted) {
                     this.setState({ importingState: null });
-                }
 
-                setTimeout(() => {
-                    if (!this.#isUnmounted) {
-                        const { taskInstance: currentTaskInstance } = this.props;
-                        if (currentTaskInstance.size !== createdTask.size) {
-                            // update state only if it was not updated anywhere else
-                            // for example in createTaskAsync
-                            updateTaskInState(createdTask);
+                    setTimeout(() => {
+                        if (!this.#isUnmounted) {
+                            // check again, because the component may be unmounted to this moment
+                            const { taskInstance: currentTaskInstance } = this.props;
+                            if (currentTaskInstance.size !== createdTask.size) {
+                                // update state only if it was not updated anywhere else
+                                // for example in createTaskAsync
+                                updateTaskInState(createdTask);
+                            }
                         }
-                    }
-                }, 1000);
+                    }, 1000);
+                }
             });
         }
     }

--- a/cvat-ui/src/components/tasks-page/task-item.tsx
+++ b/cvat-ui/src/components/tasks-page/task-item.tsx
@@ -72,15 +72,18 @@ class TaskItemComponent extends React.PureComponent<TaskItemProps & RouteCompone
             }).then((createdTask: Task) => {
                 if (!this.#isUnmounted) {
                     this.setState({ importingState: null });
-                    setTimeout(() => {
+                }
+
+                setTimeout(() => {
+                    if (!this.#isUnmounted) {
                         const { taskInstance: currentTaskInstance } = this.props;
                         if (currentTaskInstance.size !== createdTask.size) {
                             // update state only if it was not updated anywhere else
                             // for example in createTaskAsync
                             updateTaskInState(createdTask);
                         }
-                    }, 1000);
-                }
+                    }
+                }, 1000);
             });
         }
     }

--- a/tests/cypress/e2e/actions_projects_models/issue_2900_creating_more_one_tasks_from_project_per_time.js
+++ b/tests/cypress/e2e/actions_projects_models/issue_2900_creating_more_one_tasks_from_project_per_time.js
@@ -34,7 +34,9 @@ context('Create more than one task per time when create from project.', () => {
         cy.get('.cvat-constructor-viewer-new-item').should('not.exist');
         cy.get('input[type="file"]').attachFile(archiveName, { subjectType: 'drag-n-drop' });
         cy.contains('button', 'Submit & Continue').click();
-        cy.get('.cvat-notification-create-task-success').should('exist');
+        cy.get('.cvat-notification-create-task-success').should('exist').within(() => {
+            cy.get('.anticon-close').click();
+        });
         cy.get('.cvat-notification-create-task-fail').should('not.exist');
     }
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Test creates two tasks in a row
After first task created notification appears: "Task was created"
Immediately after that code creates one more task and checks the notification
But if previous notification is still visible, Cypress sees it and considers as a message for the newest task

Then it goes to project page, but can't find the newest task there because it was not created yet.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
