### PR TITLE
Defer most signal handling code until after the end of the current transaction

### DIFF
--- a/changelog.d/20240209_171518_roman_handle_after_transaction.md
+++ b/changelog.d/20240209_171518_roman_handle_after_transaction.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Side effects of data changes, such as the sending of webhooks,
+  are no longer triggered until after the changes have been committed
+  to the database
+  (<https://github.com/opencv/cvat/pull/7460>)

--- a/cvat/apps/engine/signals.py
+++ b/cvat/apps/engine/signals.py
@@ -2,9 +2,11 @@
 # Copyright (C) 2023 CVAT.ai Corporation
 #
 # SPDX-License-Identifier: MIT
+import functools
 import shutil
 
 from django.contrib.auth.models import User
+from django.db import transaction
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 
@@ -45,17 +47,21 @@ def __save_user_handler(instance, **kwargs):
 @receiver(post_delete, sender=Project,
     dispatch_uid=__name__ + ".delete_project_handler")
 def __delete_project_handler(instance, **kwargs):
-    shutil.rmtree(instance.get_dirname(), ignore_errors=True)
+    transaction.on_commit(
+        functools.partial(shutil.rmtree, instance.get_dirname(), ignore_errors=True))
 
 @receiver(post_delete, sender=Asset,
     dispatch_uid=__name__ + ".__delete_asset_handler")
 def __delete_asset_handler(instance, **kwargs):
-    shutil.rmtree(instance.get_asset_dir(), ignore_errors=True)
+    transaction.on_commit(
+        functools.partial(shutil.rmtree, instance.get_asset_dir(), ignore_errors=True))
 
 @receiver(post_delete, sender=Task,
     dispatch_uid=__name__ + ".delete_task_handler")
 def __delete_task_handler(instance, **kwargs):
-    shutil.rmtree(instance.get_dirname(), ignore_errors=True)
+    transaction.on_commit(
+        functools.partial(shutil.rmtree, instance.get_dirname(), ignore_errors=True))
+
     if instance.data and not instance.data.tasks.exists():
         instance.data.delete()
 
@@ -69,14 +75,17 @@ def __delete_task_handler(instance, **kwargs):
 @receiver(post_delete, sender=Job,
     dispatch_uid=__name__ + ".delete_job_handler")
 def __delete_job_handler(instance, **kwargs):
-    shutil.rmtree(instance.get_dirname(), ignore_errors=True)
+    transaction.on_commit(
+        functools.partial(shutil.rmtree, instance.get_dirname(), ignore_errors=True))
 
 @receiver(post_delete, sender=Data,
     dispatch_uid=__name__ + ".delete_data_handler")
 def __delete_data_handler(instance, **kwargs):
-    shutil.rmtree(instance.get_data_dirname(), ignore_errors=True)
+    transaction.on_commit(
+        functools.partial(shutil.rmtree, instance.get_data_dirname(), ignore_errors=True))
 
 @receiver(post_delete, sender=CloudStorage,
     dispatch_uid=__name__ + ".delete_cloudstorage_handler")
 def __delete_cloudstorage_handler(instance, **kwargs):
-    shutil.rmtree(instance.get_storage_dirname(), ignore_errors=True)
+    transaction.on_commit(
+        functools.partial(shutil.rmtree, instance.get_storage_dirname(), ignore_errors=True))

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -933,7 +933,8 @@ class ProjectDeleteAPITestCase(ApiTestBase):
                 task_dir = task.get_dirname()
                 self.assertTrue(os.path.exists(task_dir))
 
-        self._check_api_v2_projects_id(self.admin)
+        with self.captureOnCommitCallbacks(execute=True):
+            self._check_api_v2_projects_id(self.admin)
 
         for project in self.projects:
             project_dir = project.get_dirname()
@@ -2019,7 +2020,10 @@ class TaskDeleteAPITestCase(ApiTestBase):
         for task in self.tasks:
             task_dir = task.get_dirname()
             self.assertTrue(os.path.exists(task_dir))
-        self._check_api_v2_tasks_id(self.admin)
+
+        with self.captureOnCommitCallbacks(execute=True):
+            self._check_api_v2_tasks_id(self.admin)
+
         for task in self.tasks:
             task_dir = task.get_dirname()
             self.assertFalse(os.path.exists(task_dir))


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Non-database actions like deleting directories, sending webhooks, scheduling reports should only be done after the current transaction is committed. If we do it immediately, and the transaction is later aborted, then we will have (for example) sent a webhook about an event that didn't actually happen.

There's also a secondary benefit to moving this action outside of the transaction; the less time we spend inside a transaction, the better, since a transaction may lock out other clients from working on the affected DB rows.

In addition, prevent the affected actions from crashing the view handler with an exception (using the `robust=True` option). I don't think it's reasonable to (for example) return a 500 response to a `PATCH` request just because we failed to send the corresponding webhook.

There is one more type of action that should be modified in this way (sending events), but it would be easier to do that after a refactoring that I did in another patch, so I'll do it later.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
