### PR TITLE
Record DB-related events only after changes are committed

### DIFF
--- a/changelog.d/20240209_171518_roman_handle_after_transaction.md
+++ b/changelog.d/20240209_171518_roman_handle_after_transaction.md
@@ -3,4 +3,5 @@
 - Side effects of data changes, such as the sending of webhooks,
   are no longer triggered until after the changes have been committed
   to the database
-  (<https://github.com/opencv/cvat/pull/7460>)
+  (<https://github.com/opencv/cvat/pull/7460>,
+  <https://github.com/opencv/cvat/pull/7477>)

--- a/cvat/apps/events/event.py
+++ b/cvat/apps/events/event.py
@@ -6,6 +6,8 @@ from rest_framework.renderers import JSONRenderer
 from datetime import datetime, timezone
 from typing import Optional
 
+from django.db import transaction
+
 from cvat.apps.engine.log import vlogger
 
 def event_scope(action, resource):
@@ -39,6 +41,7 @@ def record_server_event(
     scope: str,
     request_id: Optional[str],
     payload: Optional[dict] = None,
+    on_commit: bool = False,
     **kwargs,
 ) -> None:
     payload = payload or {}
@@ -59,7 +62,12 @@ def record_server_event(
         **kwargs,
     }
 
-    vlogger.info(JSONRenderer().render(data).decode('UTF-8'))
+    rendered_data = JSONRenderer().render(data).decode('UTF-8')
+
+    if on_commit:
+        transaction.on_commit(lambda: vlogger.info(rendered_data), robust=True)
+    else:
+        vlogger.info(rendered_data)
 
 
 class EventScopeChoice:

--- a/cvat/apps/events/handlers.py
+++ b/cvat/apps/events/handlers.py
@@ -281,6 +281,7 @@ def handle_create(scope, instance, **kwargs):
     record_server_event(
         scope=scope,
         request_id=request_id(),
+        on_commit=True,
         obj_id=getattr(instance, 'id', None),
         obj_name=_get_object_name(instance),
         org_id=oid,
@@ -313,6 +314,7 @@ def handle_update(scope, instance, old_instance, **kwargs):
         record_server_event(
             scope=scope,
             request_id=request_id(),
+            on_commit=True,
             obj_name=prop,
             obj_id=getattr(instance, f'{prop}_id', None),
             obj_val=str(change["new_value"]),
@@ -364,6 +366,7 @@ def handle_delete(scope, instance, store_in_deletion_cache=False, **kwargs):
     record_server_event(
         scope=scope,
         request_id=request_id(),
+        on_commit=True,
         obj_id=getattr(instance, 'id', None),
         obj_name=_get_object_name(instance),
         org_id=oid,
@@ -405,6 +408,7 @@ def handle_annotations_change(instance, annotations, action, **kwargs):
         record_server_event(
             scope=event_scope(action, "tags"),
             request_id=request_id(),
+            on_commit=True,
             count=len(tags),
             org_id=oid,
             org_slug=oslug,
@@ -427,6 +431,7 @@ def handle_annotations_change(instance, annotations, action, **kwargs):
             record_server_event(
                 scope=scope,
                 request_id=request_id(),
+                on_commit=True,
                 obj_name=shape_type,
                 count=len(shapes),
                 org_id=oid,
@@ -455,6 +460,7 @@ def handle_annotations_change(instance, annotations, action, **kwargs):
             record_server_event(
                 scope=scope,
                 request_id=request_id(),
+                on_commit=True,
                 obj_name=track_type,
                 count=len(tracks),
                 org_id=oid,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a small addendum to #7460, which I couldn't include in that PR, because it was blocked by #7430.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
