### PR TITLE
Remove project id in the comment of `tasks.rego`

### DIFF
--- a/cvat/apps/iam/rules/tasks.rego
+++ b/cvat/apps/iam/rules/tasks.rego
@@ -32,7 +32,6 @@ import data.organizations
 #         "assignee": { "id": <num> },
 #         "organization": { "id": <num> } or null,
 #         "project": {
-#             "id": <num>,
 #             "owner": { "id": <num> },
 #             "assignee": { "id": <num> },
 #             "organization": { "id": <num> } or null,


### PR DESCRIPTION
### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
In https://github.com/opencv/cvat/blob/b7cc5627daa04958ed045e4b3fe9fd68ec3c9e01/cvat/apps/iam/rules/tasks.rego#L29-L41, `resource` has a `project` `id` field according to the comment. But in
https://github.com/opencv/cvat/blob/b7cc5627daa04958ed045e4b3fe9fd68ec3c9e01/cvat/apps/iam/permissions.py#L1035-L1052, there is no corresponding `project` `id` field. According to @bsekachev's [suggestion](https://github.com/opencv/cvat/pull/7432#issuecomment-1933675588), this PR removes the `project` `id` in the comment of `tasks.rego`  (cvat/apps/iam/rules/tasks.rego).


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
