### PR TITLE
Fixed the docs link in ISSUE_TEMPLATE

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -8,7 +8,7 @@ body:
     options:
     - label: I searched the existing issues and did not find anything similar.
       required: true
-    - label: I read/searched [the docs](https://github.com/cvat-ai/cvat/tree/master#documentation)
+    - label: I read/searched [the docs](https://opencv.github.io/cvat/docs/)
       required: true
 
 - type: textarea

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -8,7 +8,7 @@ body:
     options:
     - label: I searched the existing issues and did not find anything similar.
       required: true
-    - label: I read/searched [the docs](https://github.com/cvat-ai/cvat/tree/master#documentation)
+    - label: I read/searched [the docs](https://opencv.github.io/cvat/docs/)
       required: true
 - type: textarea
   attributes:


### PR DESCRIPTION
Fixes #7531 

I have replaced the previous link with the correct link to the documentation.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
~- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->~
~- [ ] I have updated the documentation accordingly~
~- [ ] I have added tests to cover my changes~
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
~- [ ] I have increased versions of npm packages if it is necessary~
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
