### PR TITLE
Speed up resource updates when there are no matching webhooks

### DIFF
--- a/changelog.d/20240305_171241_roman_webhooks_lazy_rendering.md
+++ b/changelog.d/20240305_171241_roman_webhooks_lazy_rendering.md
@@ -1,0 +1,4 @@
+### Changed
+
+- Sped up resource updates when there are no matching webhooks
+  (<https://github.com/opencv/cvat/pull/7553>)

--- a/cvat/apps/webhooks/signals.py
+++ b/cvat/apps/webhooks/signals.py
@@ -136,25 +136,32 @@ def get_sender(instance):
 @receiver(pre_save, sender=Invitation, dispatch_uid=__name__ + ":invitation:pre_save")
 @receiver(pre_save, sender=Membership, dispatch_uid=__name__ + ":membership:pre_save")
 def pre_save_resource_event(sender, instance, **kwargs):
-    try:
-        old_instance = sender.objects.get(pk=instance.pk)
-    except ObjectDoesNotExist:
+    instance._webhooks_selected_webhooks = []
+
+    if instance.pk is None:
+        created = True
+    else:
+        try:
+            old_instance = sender.objects.get(pk=instance.pk)
+            created = False
+        except ObjectDoesNotExist:
+            created = True
+
+    resource_name = instance.__class__.__name__.lower()
+
+    event_type = event_name("create" if created else "update", resource_name)
+    if event_type not in map(lambda a: a[0], EventTypeChoice.choices()):
         return
 
-    old_serializer = get_serializer(instance=old_instance)
-    serializer = get_serializer(instance=instance)
-    diff = get_instance_diff(old_data=old_serializer.data, data=serializer.data)
-
-    if not diff:
+    instance._webhooks_selected_webhooks = select_webhooks(instance, event_type)
+    if not instance._webhooks_selected_webhooks:
         return
 
-    before_update = {
-        attr: value["old_value"]
-        for attr, value in diff.items()
-    }
-
-    instance._before_update = before_update
-
+    if created:
+        instance._webhooks_old_data = None
+    else:
+        old_serializer = get_serializer(instance=old_instance)
+        instance._webhooks_old_data = old_serializer.data
 
 @receiver(post_save, sender=Project, dispatch_uid=__name__ + ":project:post_save")
 @receiver(post_save, sender=Task, dispatch_uid=__name__ + ":task:post_save")
@@ -164,31 +171,38 @@ def pre_save_resource_event(sender, instance, **kwargs):
 @receiver(post_save, sender=Organization, dispatch_uid=__name__ + ":organization:post_save")
 @receiver(post_save, sender=Invitation, dispatch_uid=__name__ + ":invitation:post_save")
 @receiver(post_save, sender=Membership, dispatch_uid=__name__ + ":membership:post_save")
-def post_save_resource_event(sender, instance, created, **kwargs):
+def post_save_resource_event(sender, instance, **kwargs):
+    selected_webhooks = instance._webhooks_selected_webhooks
+    del instance._webhooks_selected_webhooks
+
+    if not selected_webhooks:
+        return
+
+    old_data = instance._webhooks_old_data
+    del instance._webhooks_old_data
+
+    created = old_data is None
+
     resource_name = instance.__class__.__name__.lower()
-
     event_type = event_name("create" if created else "update", resource_name)
-    if event_type not in map(lambda a: a[0], EventTypeChoice.choices()):
-        return
 
-    filtered_webhooks = select_webhooks(instance, event_type)
-    if not filtered_webhooks:
-        return
+    serializer = get_serializer(instance=instance)
 
     data = {
         "event": event_type,
-        resource_name: get_serializer(instance=instance).data,
+        resource_name: serializer.data,
         "sender": get_sender(instance),
     }
 
     if not created:
-        if before_update := getattr(instance, "_before_update", None):
-            data["before_update"] = before_update
-        else:
-            return
+        if diff := get_instance_diff(old_data=old_data, data=serializer.data):
+            data["before_update"] = {
+                attr: value["old_value"]
+                for attr, value in diff.items()
+            }
 
     transaction.on_commit(
-        lambda: batch_add_to_queue(filtered_webhooks, data),
+        lambda: batch_add_to_queue(selected_webhooks, data),
         robust=True,
     )
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The signal handling code in `cvat.apps.webhooks.signals` always fetches the old version of the resource from the database and serializes it. But if no webhook is defined for the current resource, this work is pointless.

Select the webhooks first, and only then (if necessary) serialize the old resource. Also, move the diffing of the old and new versions to the `post_save` signal handler, to avoid serializing the new version a second time. This leads to a considerable speedup for resources with complicated serializers, such as tasks and jobs, when no webhooks are attached. In my experiments, saving of annotations was sped up by 20-25% with this patch.

This patch also makes the signal handlers more hygienic with the use of temporary attributes. Both the attributes it uses are now prefixed with `_webhooks` to avoid collisions, and removed after they are used.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I think the existing tests are sufficient to cover this.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
