### PR TITLE
Remove double `updated_date` bumping when saving annotations

### DIFF
--- a/changelog.d/20240305_193358_roman_less_bumpy.md
+++ b/changelog.d/20240305_193358_roman_less_bumpy.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- Job and task `updated_date` are no longer bumped twice when updating
+  annotations
+  (<https://github.com/opencv/cvat/pull/7556>)

--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -391,43 +391,51 @@ class JobAnnotation:
         self.db_job.segment.task.touch()
         self.db_job.touch()
 
-    def _save_to_db(self, data):
+    @staticmethod
+    def _data_is_empty(data):
+        return not (data["tags"] or data["shapes"] or data["tracks"])
+
+    def _create(self, data):
         self.reset()
         self._save_tags_to_db(data["tags"])
         self._save_shapes_to_db(data["shapes"])
         self._save_tracks_to_db(data["tracks"])
 
-        return self.ir_data.tags or self.ir_data.shapes or self.ir_data.tracks
-
-    def _create(self, data):
-        if self._save_to_db(data):
-            self._set_updated_date()
-
     def create(self, data):
         self._create(data)
         handle_annotations_change(self.db_job, self.data, "create")
 
+        if not self._data_is_empty(self.data):
+            self._set_updated_date()
+
     def put(self, data):
         deleted_data = self._delete()
         handle_annotations_change(self.db_job, deleted_data, "delete")
+
+        deleted_data_is_empty = self._data_is_empty(deleted_data)
+
         self._create(data)
         handle_annotations_change(self.db_job, self.data, "create")
 
+        if not deleted_data_is_empty or not self._data_is_empty(self.data):
+            self._set_updated_date()
 
     def update(self, data):
         self._delete(data)
         self._create(data)
         handle_annotations_change(self.db_job, self.data, "update")
 
+        if not self._data_is_empty(self.data):
+            self._set_updated_date()
+
     def _delete(self, data=None):
-        deleted_shapes = 0
         deleted_data = {}
         if data is None:
             self.init_from_db()
             deleted_data = self.data
-            deleted_shapes += self.db_job.labeledimage_set.all().delete()[0]
-            deleted_shapes += self.db_job.labeledshape_set.all().delete()[0]
-            deleted_shapes += self.db_job.labeledtrack_set.all().delete()[0]
+            self.db_job.labeledimage_set.all().delete()
+            self.db_job.labeledshape_set.all().delete()
+            self.db_job.labeledtrack_set.all().delete()
         else:
             labeledimage_ids = [image["id"] for image in data["tags"]]
             labeledshape_ids = [shape["id"] for shape in data["shapes"]]
@@ -446,9 +454,9 @@ class JobAnnotation:
             self.ir_data.shapes = data['shapes']
             self.ir_data.tracks = data['tracks']
 
-            deleted_shapes += labeledimage_set.delete()[0]
-            deleted_shapes += labeledshape_set.delete()[0]
-            deleted_shapes += labeledtrack_set.delete()[0]
+            labeledimage_set.delete()
+            labeledshape_set.delete()
+            labeledtrack_set.delete()
 
             deleted_data = {
                 "tags": data["tags"],
@@ -456,14 +464,14 @@ class JobAnnotation:
                 "tracks": data["tracks"],
             }
 
-        if deleted_shapes:
-            self._set_updated_date()
-
         return deleted_data
 
     def delete(self, data=None):
         deleted_data = self._delete(data)
         handle_annotations_change(self.db_job, deleted_data, "delete")
+
+        if not self._data_is_empty(deleted_data):
+            self._set_updated_date()
 
     @staticmethod
     def _extend_attributes(attributeval_set, default_attribute_values):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, `JobAnnotation.update` needlessly bumps the `updated_date` of the job and the task twice (both via `_delete` and `_create`). These updates are costly in terms of time due to the various side effects associated with them (such as webhook sending and event logging), so it's better to avoid doing them gratuitously.

Change the code so that the bumps only happen once.

I simplified the code a bit; previously, the code in `_delete` would only bump the date if something was actually deleted (i.e., the annotations passed in actually existed in the database). Now we just check if there were any annotations we _wanted_ to delete. This means that if a request only deletes non-existent annotations, the date will still get bumped. I don't think it's a significant issue, since this is a pathological case.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
