### PR TITLE
Optimize `update:*` event logging when only `updated_date` is changed

### DIFF
--- a/cvat/apps/events/signals.py
+++ b/cvat/apps/events/signals.py
@@ -7,6 +7,7 @@ from django.db.models.signals import pre_save, post_save, post_delete
 from django.core.exceptions import ObjectDoesNotExist
 
 from cvat.apps.engine.models import (
+    TimestampedModel,
     Project,
     Task,
     Job,
@@ -30,7 +31,19 @@ from .event import EventScopeChoice, event_scope
 @receiver(pre_save, sender=Issue, dispatch_uid="issue:update_receiver")
 @receiver(pre_save, sender=Comment, dispatch_uid="comment:update_receiver")
 @receiver(pre_save, sender=Label, dispatch_uid="label:update_receiver")
-def resource_update(sender, instance, **kwargs):
+def resource_update(sender, *, instance, update_fields, **kwargs):
+    if (
+        isinstance(instance, TimestampedModel)
+            and update_fields and list(update_fields) == ["updated_date"]
+    ):
+        # This is an optimization for the common case where only the date is bumped
+        # (see `TimestampedModel.touch`). Since the actual update of the field will
+        # be performed _after_ this signal is sent (in `DateTimeField.pre_save`),
+        # and no other fields are updated, there is guaranteed to be no difference
+        # between the old and current states of the instance. Therefore, no events
+        # will need be logged, so we can just exit immediately.
+        return
+
     resource_name = instance.__class__.__name__.lower()
 
     try:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Diffing the old and new state of the object is fairly costly, so it helps to avoid doing that when it isn't necessary.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
