### PR TITLE
[GSoC2024] fix warped image loading

### DIFF
--- a/changelog.d/20240326_195957_tahamukhtar20.md
+++ b/changelog.d/20240326_195957_tahamukhtar20.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- 90 deg-rotated video was added with "Prefer Zip Chunks" disabled was warped, fixed using the static cropImage function.
+  (<https://github.com/opencv/cvat/pull/7583>)

--- a/changelog.d/20240326_195957_tahamukhtar20.md
+++ b/changelog.d/20240326_195957_tahamukhtar20.md
@@ -1,4 +1,5 @@
 ### Fixed
 
-- 90 deg-rotated video was added with "Prefer Zip Chunks" disabled was warped, fixed using the static cropImage function.
+- 90 deg-rotated video was added with "Prefer Zip Chunks" disabled 
+was warped, fixed using the static cropImage function.
   (<https://github.com/opencv/cvat/pull/7583>)

--- a/cvat-data/src/ts/cvat-data.ts
+++ b/cvat-data/src/ts/cvat-data.ts
@@ -213,14 +213,13 @@ export class FrameDecoder {
         const source = new Uint32Array(imageBuffer);
 
         const bufferSize = width * height * 4;
-        const buffer = new ArrayBuffer(bufferSize);
-        const rgbaInt32 = new Uint32Array(buffer);
-        const rgbaInt8Clamped = new Uint8ClampedArray(buffer);
-
         if (imageWidth === width) {
             return new ImageData(new Uint8ClampedArray(imageBuffer, 0, bufferSize), width, height);
         }
 
+        const buffer = new ArrayBuffer(bufferSize);
+        const rgbaInt32 = new Uint32Array(buffer);
+        const rgbaInt8Clamped = new Uint8ClampedArray(buffer);
         let writeIdx = 0;
         for (let row = 0; row < height; row++) {
             const start = row * imageWidth;

--- a/cvat-data/src/ts/cvat-data.ts
+++ b/cvat-data/src/ts/cvat-data.ts
@@ -204,12 +204,10 @@ export class FrameDecoder {
         imageBuffer: ArrayBuffer,
         imageWidth: number,
         imageHeight: number,
-        xOffset: number,
-        yOffset: number,
         width: number,
         height: number,
     ): ImageData {
-        if (xOffset === 0 && width === imageWidth && yOffset === 0 && height === imageHeight) {
+        if (width === imageWidth && height === imageHeight) {
             return new ImageData(new Uint8ClampedArray(imageBuffer), width, height);
         }
         const source = new Uint32Array(imageBuffer);
@@ -220,12 +218,12 @@ export class FrameDecoder {
         const rgbaInt8Clamped = new Uint8ClampedArray(buffer);
 
         if (imageWidth === width) {
-            return new ImageData(new Uint8ClampedArray(imageBuffer, yOffset * 4, bufferSize), width, height);
+            return new ImageData(new Uint8ClampedArray(imageBuffer, 0, bufferSize), width, height);
         }
 
         let writeIdx = 0;
-        for (let row = yOffset; row < height; row++) {
-            const start = row * imageWidth + xOffset;
+        for (let row = 0; row < height; row++) {
+            const start = row * imageWidth;
             rgbaInt32.set(source.subarray(start, start + width), writeIdx);
             writeIdx += width;
         }
@@ -276,8 +274,6 @@ export class FrameDecoder {
                         e.data.buf,
                         e.data.width,
                         e.data.height,
-                        0,
-                        0,
                         width,
                         height,
                     )).then((bitmap) => {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

Fixes: #7394 

This PR fixes the issue stated in the above-mentioned issue, the issue was caused when a 90 deg-rotated video was added with "Prefer Zip Chunks" disabled, and the image loaded was warped, which is now fixed using the static cropImage function found in this [commit](https://github.com/opencv/cvat/commit/844a72b82c241c2f612debc113de54b2f3612e7e#diff-2ca4b22442f076f5f5c3086ee757649fbaa903a75baca70991e419e2bd1d822fR281) as this was the commit where this issue initially started

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Added various images to test the bug fix, this did not require any new test cases.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
