### PR TITLE
[GSoC2024] fix and refactor import-dataset-modal code (#7428)

### DIFF
--- a/changelog.d/20240313_014112_umangapatel123_refactor_into_usereducer.md
+++ b/changelog.d/20240313_014112_umangapatel123_refactor_into_usereducer.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- set `file` and `fileName` to null after import is done and change `useState` to `useReducer`
+  (<https://github.com/opencv/cvat/pull/7599>)

--- a/changelog.d/20240313_014112_umangapatel123_refactor_into_usereducer.md
+++ b/changelog.d/20240313_014112_umangapatel123_refactor_into_usereducer.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- Incorrect file name usage in importing annotation via cloud storage
+- Incorrect file name usage when importing annotations from a cloud storage
   (<https://github.com/opencv/cvat/pull/7599>)

--- a/changelog.d/20240313_014112_umangapatel123_refactor_into_usereducer.md
+++ b/changelog.d/20240313_014112_umangapatel123_refactor_into_usereducer.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- set `file` and `fileName` to null after import is done and change `useState` to `useReducer`
+- Incorrect file name usage in importing annotation via cloud storage
   (<https://github.com/opencv/cvat/pull/7599>)

--- a/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
+++ b/cvat-ui/src/components/import-dataset/import-dataset-modal.tsx
@@ -4,7 +4,7 @@
 // SPDX-License-Identifier: MIT
 
 import './styles.scss';
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useReducer } from 'react';
 import { connect, useDispatch } from 'react-redux';
 import Modal from 'antd/lib/modal';
 import Form, { RuleObject } from 'antd/lib/form';
@@ -24,6 +24,7 @@ import Space from 'antd/lib/space';
 import Switch from 'antd/lib/switch';
 import { getCore, Storage, StorageData } from 'cvat-core-wrapper';
 import StorageField from 'components/storage/storage-field';
+import { createAction, ActionUnion } from 'utils/redux';
 import ImportDatasetStatusModal from './import-dataset-status-modal';
 
 const { confirm } = Modal;
@@ -57,6 +58,216 @@ interface UploadParams {
     fileName: string | null;
 }
 
+interface State {
+    instanceType: string;
+    file: File | null;
+    selectedLoader: any;
+    useDefaultSettings: boolean;
+    defaultStorageLocation: string;
+    defaultStorageCloudId: number | undefined;
+    helpMessage: string;
+    selectedSourceStorageLocation: StorageLocation;
+    uploadParams: UploadParams;
+    resource: string;
+}
+
+enum ReducerActionType {
+    SET_INSTANCE_TYPE = 'SET_INSTANCE_TYPE',
+    SET_FILE = 'SET_FILE',
+    SET_SELECTED_LOADER = 'SET_SELECTED_LOADER',
+    SET_USE_DEFAULT_SETTINGS = 'SET_USE_DEFAULT_SETTINGS',
+    SET_DEFAULT_STORAGE_LOCATION = 'SET_DEFAULT_STORAGE_LOCATION',
+    SET_DEFAULT_STORAGE_CLOUD_ID = 'SET_DEFAULT_STORAGE_CLOUD_ID',
+    SET_HELP_MESSAGE = 'SET_HELP_MESSAGE',
+    SET_SELECTED_SOURCE_STORAGE_LOCATION = 'SET_SELECTED_SOURCE_STORAGE_LOCATION',
+    SET_FILE_NAME = 'SET_FILE_NAME',
+    SET_SELECTED_FORMAT = 'SET_SELECTED_FORMAT',
+    SET_CONV_MASK_TO_POLY = 'SET_CONV_MASK_TO_POLY',
+    SET_SOURCE_STORAGE = 'SET_SOURCE_STORAGE',
+    SET_RESOURCE = 'SET_RESOURCE',
+}
+
+export const reducerActions = {
+    setInstanceType: (instanceType: string) => (
+        createAction(ReducerActionType.SET_INSTANCE_TYPE, { instanceType })
+    ),
+    setFile: (file: File | null) => (
+        createAction(ReducerActionType.SET_FILE, { file })
+    ),
+    setSelectedLoader: (selectedLoader: any) => (
+        createAction(ReducerActionType.SET_SELECTED_LOADER, { selectedLoader })
+    ),
+    setUseDefaultSettings: (useDefaultSettings: boolean) => (
+        createAction(ReducerActionType.SET_USE_DEFAULT_SETTINGS, { useDefaultSettings })
+    ),
+    setDefaultStorageLocation: (defaultStorageLocation: string) => (
+        createAction(ReducerActionType.SET_DEFAULT_STORAGE_LOCATION, { defaultStorageLocation })
+    ),
+    setDefaultStorageCloudId: (defaultStorageCloudId: number | undefined) => (
+        createAction(ReducerActionType.SET_DEFAULT_STORAGE_CLOUD_ID, { defaultStorageCloudId })
+    ),
+    setHelpMessage: (helpMessage: string) => (
+        createAction(ReducerActionType.SET_HELP_MESSAGE, { helpMessage })
+    ),
+    setSelectedSourceStorageLocation: (selectedSourceStorageLocation: StorageLocation) => (
+        createAction(ReducerActionType.SET_SELECTED_SOURCE_STORAGE_LOCATION, { selectedSourceStorageLocation })
+    ),
+    setFileName: (fileName: string) => (
+        createAction(ReducerActionType.SET_FILE_NAME, { fileName })
+    ),
+    setSelectedFormat: (selectedFormat: string) => (
+        createAction(ReducerActionType.SET_SELECTED_FORMAT, { selectedFormat })
+    ),
+    setConvMaskToPoly: (convMaskToPoly: boolean) => (
+        createAction(ReducerActionType.SET_CONV_MASK_TO_POLY, { convMaskToPoly })
+    ),
+    setSourceStorage: (sourceStorage: Storage) => (
+        createAction(ReducerActionType.SET_SOURCE_STORAGE, { sourceStorage })
+    ),
+    setResource: (resource: string) => (
+        createAction(ReducerActionType.SET_RESOURCE, { resource })
+    ),
+};
+
+const reducer = (state: State, action: ActionUnion<typeof reducerActions>): State => {
+    if (action.type === ReducerActionType.SET_INSTANCE_TYPE) {
+        return {
+            ...state,
+            instanceType: action.payload.instanceType,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_FILE) {
+        return {
+            ...state,
+            file: action.payload.file,
+            uploadParams: {
+                ...state.uploadParams,
+                file: action.payload.file,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_SELECTED_LOADER) {
+        return {
+            ...state,
+            selectedLoader: action.payload.selectedLoader,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_USE_DEFAULT_SETTINGS) {
+        const isDefaultSettings = action.payload.useDefaultSettings;
+        return {
+            ...state,
+            useDefaultSettings: action.payload.useDefaultSettings,
+            uploadParams: {
+                ...state.uploadParams,
+                useDefaultSettings: action.payload.useDefaultSettings,
+                sourceStorage: isDefaultSettings ? {
+                    location: state.defaultStorageLocation,
+                    cloudStorageId: state.defaultStorageCloudId,
+                } as Storage : state.uploadParams.sourceStorage,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_DEFAULT_STORAGE_LOCATION) {
+        return {
+            ...state,
+            defaultStorageLocation: action.payload.defaultStorageLocation,
+            uploadParams: {
+                ...state.uploadParams,
+                sourceStorage: {
+                    location: action.payload.defaultStorageLocation,
+                    cloudStorageId: state.defaultStorageCloudId,
+                } as Storage,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_DEFAULT_STORAGE_CLOUD_ID) {
+        return {
+            ...state,
+            defaultStorageCloudId: action.payload.defaultStorageCloudId,
+            uploadParams: {
+                ...state.uploadParams,
+                sourceStorage: {
+                    location: state.defaultStorageLocation,
+                    cloudStorageId: action.payload.defaultStorageCloudId,
+                } as Storage,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_HELP_MESSAGE) {
+        return {
+            ...state,
+            helpMessage: action.payload.helpMessage,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_SELECTED_SOURCE_STORAGE_LOCATION) {
+        return {
+            ...state,
+            selectedSourceStorageLocation: action.payload.selectedSourceStorageLocation,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_FILE_NAME) {
+        return {
+            ...state,
+            uploadParams: {
+                ...state.uploadParams,
+                fileName: action.payload.fileName,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_SELECTED_FORMAT) {
+        return {
+            ...state,
+            uploadParams: {
+                ...state.uploadParams,
+                selectedFormat: action.payload.selectedFormat,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_CONV_MASK_TO_POLY) {
+        return {
+            ...state,
+            uploadParams: {
+                ...state.uploadParams,
+                convMaskToPoly: action.payload.convMaskToPoly,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_SOURCE_STORAGE) {
+        return {
+            ...state,
+            uploadParams: {
+                ...state.uploadParams,
+                sourceStorage: action.payload.sourceStorage,
+            } as UploadParams,
+        };
+    }
+
+    if (action.type === ReducerActionType.SET_RESOURCE) {
+        const [resource] = action.payload.resource;
+        return {
+            ...state,
+            resource: action.payload.resource,
+            uploadParams: {
+                ...state.uploadParams,
+                resource: resource === 'dataset' ? 'dataset' : 'annotation',
+            } as UploadParams,
+        };
+    }
+
+    return state;
+};
+
 function ImportDatasetModal(props: StateToProps): JSX.Element {
     const {
         importers,
@@ -66,50 +277,54 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
     } = props;
     const [form] = Form.useForm();
     const dispatch = useDispatch();
-    // TODO useState -> useReducer
-    const [instanceType, setInstanceType] = useState('');
-    const [file, setFile] = useState<File | null>(null);
-    const [selectedLoader, setSelectedLoader] = useState<any>(null);
-    const [useDefaultSettings, setUseDefaultSettings] = useState(true);
-    const [defaultStorageLocation, setDefaultStorageLocation] = useState(StorageLocation.LOCAL);
-    const [defaultStorageCloudId, setDefaultStorageCloudId] = useState<number | undefined>(undefined);
-    const [helpMessage, setHelpMessage] = useState('');
-    const [selectedSourceStorageLocation, setSelectedSourceStorageLocation] = useState(StorageLocation.LOCAL);
-    const [uploadParams, setUploadParams] = useState<UploadParams>({
-        convMaskToPoly: true,
+
+    const [state, dispatchReducer] = useReducer(reducer, {
+        instanceType: '',
+        file: null,
+        selectedLoader: null,
         useDefaultSettings: true,
-    } as UploadParams);
-    const [resource, setResource] = useState('');
+        defaultStorageLocation: StorageLocation.LOCAL,
+        defaultStorageCloudId: undefined,
+        helpMessage: '',
+        selectedSourceStorageLocation: StorageLocation.LOCAL,
+        uploadParams: {
+            convMaskToPoly: true,
+            useDefaultSettings: true,
+        } as UploadParams,
+        resource: '',
+    });
+
+    const {
+        instanceType,
+        file,
+        selectedLoader,
+        useDefaultSettings,
+        defaultStorageLocation,
+        defaultStorageCloudId,
+        helpMessage,
+        selectedSourceStorageLocation,
+        uploadParams,
+        resource,
+    } = state;
 
     useEffect(() => {
         if (instanceT === 'project') {
-            setResource('dataset');
+            dispatchReducer(reducerActions.setResource('dataset'));
         } else if (instanceT === 'task' || instanceT === 'job') {
-            setResource('annotation');
+            dispatchReducer(reducerActions.setResource('annotation'));
         }
     }, [instanceT]);
 
     const isDataset = useCallback((): boolean => resource === 'dataset', [resource]);
     const isAnnotation = useCallback((): boolean => resource === 'annotation', [resource]);
 
-    useEffect(() => {
-        setUploadParams({
-            ...uploadParams,
-            resource,
-            sourceStorage: {
-                location: defaultStorageLocation,
-                cloudStorageId: defaultStorageCloudId,
-            } as Storage,
-        } as UploadParams);
-    }, [resource, defaultStorageLocation, defaultStorageCloudId]);
-
     const isProject = useCallback((): boolean => instance instanceof core.classes.Project, [instance]);
     const isTask = useCallback((): boolean => instance instanceof core.classes.Task, [instance]);
 
     useEffect(() => {
         if (instance) {
-            setDefaultStorageLocation(instance.sourceStorage.location);
-            setDefaultStorageCloudId(instance.sourceStorage.cloudStorageId);
+            dispatchReducer(reducerActions.setDefaultStorageLocation(instance.sourceStorage.location));
+            dispatchReducer(reducerActions.setDefaultStorageCloudId(instance.sourceStorage.cloudStorageId));
             let type: 'project' | 'task' | 'job' = 'job';
 
             if (isProject()) {
@@ -117,16 +332,16 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
             } else if (isTask()) {
                 type = 'task';
             }
-            setInstanceType(`${type} #${instance.id}`);
+            dispatchReducer(reducerActions.setInstanceType(`${type} #${instance.id}`));
         }
     }, [instance, resource]);
 
     useEffect(() => {
-        setHelpMessage(
+        dispatchReducer(reducerActions.setHelpMessage(
             // eslint-disable-next-line prefer-template
             `Import from ${(defaultStorageLocation) ? defaultStorageLocation.split('_')[0] : 'local'} ` +
             `storage ${(defaultStorageCloudId) ? `№${defaultStorageCloudId}` : ''}`,
-        );
+        ));
     }, [defaultStorageLocation, defaultStorageCloudId]);
 
     const uploadLocalFile = (): JSX.Element => (
@@ -156,16 +371,12 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                                 `${selectedLoader.format.toLowerCase()} extension can be used`,
                         );
                     } else {
-                        setFile(_file);
-                        setUploadParams({
-                            ...uploadParams,
-                            file: _file,
-                        } as UploadParams);
+                        dispatchReducer(reducerActions.setFile(_file));
                     }
                     return false;
                 }}
                 onRemove={() => {
-                    setFile(null);
+                    dispatchReducer(reducerActions.setFile(null));
                 }}
             >
                 <p className='ant-upload-drag-icon'>
@@ -215,20 +426,18 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                 placeholder='Dataset file name'
                 className='cvat-modal-import-filename-input'
                 onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-                    setUploadParams({
-                        ...uploadParams,
-                        fileName: e.target.value || '',
-                    } as UploadParams);
+                    dispatchReducer(reducerActions.setFileName(e.target.value || ''));
                 }}
             />
         </Form.Item>
     );
 
     const closeModal = useCallback((): void => {
-        setUseDefaultSettings(true);
-        setSelectedSourceStorageLocation(StorageLocation.LOCAL);
+        dispatchReducer(reducerActions.setUseDefaultSettings(true));
+        dispatchReducer(reducerActions.setSelectedSourceStorageLocation(StorageLocation.LOCAL));
         form.resetFields();
-        setFile(null);
+        dispatchReducer(reducerActions.setFile(null));
+        dispatchReducer(reducerActions.setFileName(''));
         dispatch(importActions.closeImportDatasetModal(instance));
     }, [form, instance]);
 
@@ -338,11 +547,8 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                                 const [loader] = importers.filter(
                                     (importer: any): boolean => importer.name === format,
                                 );
-                                setSelectedLoader(loader);
-                                setUploadParams({
-                                    ...uploadParams,
-                                    selectedFormat: format,
-                                } as UploadParams);
+                                dispatchReducer(reducerActions.setSelectedLoader(loader));
+                                dispatchReducer(reducerActions.setSelectedFormat(format));
                             }}
                         >
                             {importers
@@ -381,10 +587,7 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                         >
                             <Switch
                                 onChange={(value: boolean) => {
-                                    setUploadParams({
-                                        ...uploadParams,
-                                        convMaskToPoly: value,
-                                    } as UploadParams);
+                                    dispatchReducer(reducerActions.setConvMaskToPoly(value));
                                 }}
                             />
                         </Form.Item>
@@ -401,11 +604,7 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                         >
                             <Switch
                                 onChange={(value: boolean) => {
-                                    setUseDefaultSettings(value);
-                                    setUploadParams({
-                                        ...uploadParams,
-                                        useDefaultSettings: value,
-                                    } as UploadParams);
+                                    dispatchReducer(reducerActions.setUseDefaultSettings(value));
                                 }}
                             />
                         </Form.Item>
@@ -419,16 +618,15 @@ function ImportDatasetModal(props: StateToProps): JSX.Element {
                             locationName={['sourceStorage', 'location']}
                             selectCloudStorageName={['sourceStorage', 'cloudStorageId']}
                             onChangeStorage={(value: StorageData) => {
-                                setUploadParams({
-                                    ...uploadParams,
-                                    sourceStorage: new Storage({
-                                        location: value?.location || defaultStorageLocation,
-                                        cloudStorageId: (value.location) ? value.cloudStorageId : defaultStorageCloudId,
-                                    }),
-                                } as UploadParams);
+                                dispatchReducer(reducerActions.setSourceStorage(new Storage({
+                                    location: value?.location || defaultStorageLocation,
+                                    cloudStorageId: (value.location) ? value.cloudStorageId : defaultStorageCloudId,
+                                })));
                             }}
                             locationValue={selectedSourceStorageLocation}
-                            onChangeLocationValue={(value: StorageLocation) => setSelectedSourceStorageLocation(value)}
+                            onChangeLocationValue={(value: StorageLocation) => {
+                                dispatchReducer(reducerActions.setSelectedSourceStorageLocation(value));
+                            }}
                         />
                     )}
                     { !loadFromLocal && renderCustomName() }


### PR DESCRIPTION
Refactor code to use useReducer instead of useState. Fixes #7428
'file' and 'fileName' in the uploadParams were not set to null after import. To avoid this change the code to set 'file' and 'fileName' to null after importing is done.

<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This change is required to make the code clear. The previous code uses many `useState` to manage the state but this version uses `useReducer` to manage all the states.
In the previous code `file` and `fileName` in the `uploadParams` were not set to null after importing was done but this version set it to null so it can not use the previous file while importing annotation.
it solves issue #7428

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
The changes have been tested manually. The code was tested using different sequences of annotation uploads. The state of each parameter is tested by logging its state to the console.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~ 
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary~~
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
