### PR TITLE
[GSoC24] Resolved Issue #7620 (Changed the alignment of the empty component in job page)

### DIFF
--- a/changelog.d/20240318_203856_kavikumarceo.md
+++ b/changelog.d/20240318_203856_kavikumarceo.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- The alignment of empty list component has been fixed.
+  (<https://github.com/opencv/cvat/pull/7621>)

--- a/changelog.d/20240318_203856_kavikumarceo.md
+++ b/changelog.d/20240318_203856_kavikumarceo.md
@@ -1,4 +1,4 @@
 ### Fixed
 
-- The alignment of empty list component has been fixed.
+- Incorrect alignment of empty job list component
   (<https://github.com/opencv/cvat/pull/7621>)

--- a/cvat-ui/src/components/jobs-page/jobs-page.tsx
+++ b/cvat-ui/src/components/jobs-page/jobs-page.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) 2023-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -62,12 +62,10 @@ function JobsPageComponent(): JSX.Element {
                     <Pagination
                         className='cvat-jobs-page-pagination'
                         onChange={(page: number) => {
-                            dispatch(
-                                getJobsAsync({
-                                    ...query,
-                                    page,
-                                }),
-                            );
+                            dispatch(getJobsAsync({
+                                ...query,
+                                page,
+                            }));
                         }}
                         showSizeChanger={false}
                         total={count}

--- a/cvat-ui/src/components/jobs-page/jobs-page.tsx
+++ b/cvat-ui/src/components/jobs-page/jobs-page.tsx
@@ -62,10 +62,12 @@ function JobsPageComponent(): JSX.Element {
                     <Pagination
                         className='cvat-jobs-page-pagination'
                         onChange={(page: number) => {
-                            dispatch(getJobsAsync({
-                                ...query,
-                                page,
-                            }));
+                            dispatch(
+                                getJobsAsync({
+                                    ...query,
+                                    page,
+                                }),
+                            );
                         }}
                         showSizeChanger={false}
                         total={count}
@@ -76,7 +78,18 @@ function JobsPageComponent(): JSX.Element {
                 </Col>
             </Row>
         </>
-    ) : <Empty description={<Text>No results matched your search...</Text>} />;
+    ) : (
+        <div className='cvat-empty-jobs-list'>
+            <Empty description={(
+                <Row justify='center' align='middle'>
+                    <Col>
+                        <Text>No results matched your search...</Text>
+                    </Col>
+                </Row>
+            )}
+            />
+        </div>
+    );
 
     return (
         <div className='cvat-jobs-page'>
@@ -110,9 +123,7 @@ function JobsPageComponent(): JSX.Element {
                     );
                 }}
             />
-            { fetching ? (
-                <Spin size='large' className='cvat-spinner' />
-            ) : content }
+            {fetching ? <Spin size='large' className='cvat-spinner' /> : content}
         </div>
     );
 }

--- a/cvat-ui/src/components/jobs-page/styles.scss
+++ b/cvat-ui/src/components/jobs-page/styles.scss
@@ -165,3 +165,12 @@
         }
     }
 }
+
+.cvat-empty-jobs-list {
+    .ant-empty {
+        top: 50%;
+        left: 50%;
+        position: absolute;
+        transform: translate(-50%, -50%);
+    }
+}

--- a/cvat-ui/src/components/jobs-page/styles.scss
+++ b/cvat-ui/src/components/jobs-page/styles.scss
@@ -1,5 +1,5 @@
 // Copyright (C) 2022 Intel Corporation
-// Copyright (C) 2022 CVAT.ai Corporation
+// Copyright (C) 2022-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -12,23 +12,40 @@
     width: 100%;
     overflow: auto;
 
-    > div:nth-child(1) {
-        div > {
-            .cvat-title {
-                color: $text-color;
+    .cvat-jobs-page-top-bar {
+        > div {
+            display: flex;
+            justify-content: space-between;
+
+            > div {
+                display: flex;
+                justify-content: space-between;
+                align-items: center;
+                width: 100%;
+
+                .cvat-jobs-page-search-bar {
+                    width: $grid-unit-size * 32;
+                    padding-left: $grid-unit-size * 0.5;
+                }
+
+                > div {
+                    > *:not(:last-child) {
+                        margin-right: $grid-unit-size;
+                    }
+
+                    display: flex;
+                }
             }
         }
     }
 
-    > div:nth-child(2) {
-        &.ant-empty {
+    .cvat-empty-jobs-list {
+        .ant-empty {
             position: absolute;
-            top: 40%;
+            top: 50%;
             left: 50%;
+            transform: translate(-50%, -50%);
         }
-
-        padding-bottom: $grid-unit-size;
-        padding-top: $grid-unit-size;
     }
 
     .cvat-job-page-list-item {
@@ -136,41 +153,5 @@
         bottom: $grid-unit-size * 2;
         right: $grid-unit-size;
         font-size: 16px;
-    }
-}
-
-.cvat-jobs-page-top-bar {
-    > div {
-        display: flex;
-        justify-content: space-between;
-
-        > div {
-            display: flex;
-            justify-content: space-between;
-            align-items: center;
-            width: 100%;
-
-            .cvat-jobs-page-search-bar {
-                width: $grid-unit-size * 32;
-                padding-left: $grid-unit-size * 0.5;
-            }
-
-            > div {
-                > *:not(:last-child) {
-                    margin-right: $grid-unit-size;
-                }
-
-                display: flex;
-            }
-        }
-    }
-}
-
-.cvat-empty-jobs-list {
-    .ant-empty {
-        top: 50%;
-        left: 50%;
-        position: absolute;
-        transform: translate(-50%, -50%);
     }
 }

--- a/cvat-ui/src/components/jobs-page/styles.scss
+++ b/cvat-ui/src/components/jobs-page/styles.scss
@@ -146,8 +146,8 @@
     .cvat-jobs-page-list {
         display: flex;
         flex-wrap: wrap;
-        padding-top: 8px;
-        padding-bottom: 8px;
+        padding-top: $grid-unit-size;
+        padding-bottom: $grid-unit-size;
     }
 
     .cvat-job-card-more-button {

--- a/cvat-ui/src/components/jobs-page/styles.scss
+++ b/cvat-ui/src/components/jobs-page/styles.scss
@@ -146,6 +146,8 @@
     .cvat-jobs-page-list {
         display: flex;
         flex-wrap: wrap;
+        padding-top: 8px;
+        padding-bottom: 8px;
     }
 
     .cvat-job-card-more-button {

--- a/cvat-ui/src/components/labels-editor/labels-editor.tsx
+++ b/cvat-ui/src/components/labels-editor/labels-editor.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023 CVAT.ai Corporation
+// Copyright (C) 2023-2024 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -11,6 +11,7 @@ import ModalConfirm from 'antd/lib/modal/confirm';
 import {
     EditOutlined, BuildOutlined, ExclamationCircleOutlined,
 } from '@ant-design/icons';
+import notification from 'antd/lib/notification';
 
 import { SerializedLabel, SerializedAttribute } from 'cvat-core-wrapper';
 import RawViewer from './raw-viewer';
@@ -207,6 +208,10 @@ export default class LabelsEditor extends React.PureComponent<LabelsEditorProps,
             .map((label: LabelOptColor): LabelOptColor => transformLabel(label));
 
         onSubmit(output);
+        notification.success({
+            message: 'The label has been created!',
+            className: 'cvat-notification-create-label-success',
+        });
     }
 
     public render(): JSX.Element {

--- a/cvat-ui/src/components/labels-editor/labels-editor.tsx
+++ b/cvat-ui/src/components/labels-editor/labels-editor.tsx
@@ -1,5 +1,5 @@
 // Copyright (C) 2020-2022 Intel Corporation
-// Copyright (C) 2023-2024 CVAT.ai Corporation
+// Copyright (C) 2023 CVAT.ai Corporation
 //
 // SPDX-License-Identifier: MIT
 
@@ -11,7 +11,6 @@ import ModalConfirm from 'antd/lib/modal/confirm';
 import {
     EditOutlined, BuildOutlined, ExclamationCircleOutlined,
 } from '@ant-design/icons';
-import notification from 'antd/lib/notification';
 
 import { SerializedLabel, SerializedAttribute } from 'cvat-core-wrapper';
 import RawViewer from './raw-viewer';
@@ -208,10 +207,6 @@ export default class LabelsEditor extends React.PureComponent<LabelsEditorProps,
             .map((label: LabelOptColor): LabelOptColor => transformLabel(label));
 
         onSubmit(output);
-        notification.success({
-            message: 'The label has been created!',
-            className: 'cvat-notification-create-label-success',
-        });
     }
 
     public render(): JSX.Element {


### PR DESCRIPTION
ref issue: https://github.com/opencv/cvat/issues/7620

I've created a class called `cvat-empty-jobs-list` and added it to a div to make the empty component in the job page aligned in the middle as all other pages having empty component aligned to its center.

![after ](https://github.com/opencv/cvat/assets/50093149/4e05d9c9-6049-4900-8234-66f719976310)
