### PR TITLE
Fixed remove underlying pixels feature

### DIFF
--- a/changelog.d/20240319_142812_klakhov_fix_remove_underlying_pixels.md
+++ b/changelog.d/20240319_142812_klakhov_fix_remove_underlying_pixels.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Remove underlying pixels feature is not applied immediately
+  (<https://github.com/opencv/cvat/pull/7637>)

--- a/cvat-ui/package.json
+++ b/cvat-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cvat-ui",
-  "version": "1.63.2",
+  "version": "1.63.3",
   "description": "CVAT single-page application",
   "main": "src/index.tsx",
   "scripts": {

--- a/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-tools.tsx
+++ b/cvat-ui/src/components/annotation-page/canvas/views/canvas2d/brush-tools.tsx
@@ -83,7 +83,6 @@ function BrushTools(): React.ReactPortal | null {
 
     useEffect(() => {
         const label = labels.find((_label: any) => _label.id === defaultLabelID);
-        getCore().config.removeUnderlyingMaskPixels.enabled = removeUnderlyingPixels;
         if (visible && label && canvasInstance instanceof Canvas) {
             const onUpdateConfiguration = ({ brushTool }: any): void => {
                 if (brushTool?.size) {
@@ -121,6 +120,10 @@ function BrushTools(): React.ReactPortal | null {
             }
         }
     }, [currentTool, brushSize, brushForm, visible, defaultLabelID, editableState]);
+
+    useEffect(() => {
+        getCore().config.removeUnderlyingMaskPixels.enabled = removeUnderlyingPixels;
+    }, [removeUnderlyingPixels]);
 
     useEffect(() => {
         setApplicableLabels(filterApplicableForType(LabelType.MASK, labels));


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There is a bug in remove underlying pixels feature. If we enable a feature while drawing a mask it wouldnt be applied. Only the next drawn mask will use the feature.
That happens because core config is not updated properly

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
