### PR TITLE
[GSoC2024] added entry to changelog.md for PR fixing accumulation of confusion matrix across jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- scriv-insert-here -->
 
+<a id='unreleased'></a>
+## \[Unreleased\]
+
+### Fixed
+
+- Accumulation of confusion matrix across all jobs in a task when creating a quality report
+  (https://github.com/opencv/cvat/pull/7604)
+
 <a id='changelog-2.11.2'></a>
 ## \[2.11.2\] - 2024-03-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Accumulation of confusion matrix across all jobs in a task when creating a quality report
-  (https://github.com/opencv/cvat/pull/7604)
+  (<https://github.com/opencv/cvat/pull/7604>)
 
 <a id='changelog-2.11.2'></a>
 ## \[2.11.2\] - 2024-03-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,14 +16,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 <!-- scriv-insert-here -->
 
-<a id='unreleased'></a>
-## \[Unreleased\]
-
-### Fixed
-
-- Accumulation of confusion matrix across all jobs in a task when creating a quality report
-  (<https://github.com/opencv/cvat/pull/7604>)
-
 <a id='changelog-2.11.2'></a>
 ## \[2.11.2\] - 2024-03-11
 

--- a/changelog.d/20240326_150326_vidit.agarwal.eee20_changelog_confusion_matrix.md
+++ b/changelog.d/20240326_150326_vidit.agarwal.eee20_changelog_confusion_matrix.md
@@ -1,0 +1,4 @@
+### Fixed <!-- pick one -->
+
+- Accumulation of confusion matrix across all jobs in a task when creating a quality report
+  (<https://github.com/opencv/cvat/pull/7604>)


### PR DESCRIPTION
Added entry to `changelog.md` for PR fixing accumulation of confusion matrix across jobs. As mentioned in https://github.com/opencv/cvat/pull/7604 this is a PR where the necessary changelog entry has been added.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
~- [ ] I have updated the documentation accordingly~
~- [ ] I have added tests to cover my changes~
~- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~
~- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
