### PR TITLE
Fix two problems with the task segmentation algorithm

### DIFF
--- a/changelog.d/20240326_133323_roman_segmentation_fix.md
+++ b/changelog.d/20240326_133323_roman_segmentation_fix.md
@@ -1,0 +1,9 @@
+### Fixed
+
+- Fixed an invalid default overlap size being selected for video tasks
+  with small segments
+  (<https://github.com/opencv/cvat/pull/7681>)
+
+- Fixed redundant jobs being created for tasks with non-zero overlap
+  in certain cases
+  (<https://github.com/opencv/cvat/pull/7681>)

--- a/tests/python/requirements.txt
+++ b/tests/python/requirements.txt
@@ -1,3 +1,4 @@
+av==12.0.0
 pytest==6.2.5
 pytest-cases==3.6.13
 pytest-timeout==2.1.0

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -40,7 +40,12 @@ from shared.utils.config import (
     patch_method,
     post_method,
 )
-from shared.utils.helpers import generate_image_file, generate_image_files, generate_manifest
+from shared.utils.helpers import (
+    generate_image_file,
+    generate_image_files,
+    generate_manifest,
+    generate_video_file,
+)
 
 from .utils import (
     CollectionSimpleFilterTestBase,
@@ -805,12 +810,12 @@ class TestPostTaskData:
         task_spec = {
             "name": f"test {self._USERNAME} with default overlap and small segment_size",
             "labels": [{"name": "car"}],
-            "segment_size": 2,
+            "segment_size": 5,
         }
 
         task_data = {
             "image_quality": 75,
-            "server_files": ["videos/video_1.mp4"],
+            "client_files": [generate_video_file(8)],
         }
 
         task_id, _ = create_task(self._USERNAME, task_spec, task_data)
@@ -823,10 +828,11 @@ class TestPostTaskData:
             jobs.sort(key=lambda job: job.start_frame)
 
             assert len(jobs) == 2
+            # overlap should be 2 frames (frames 3 & 4)
             assert jobs[0].start_frame == 0
-            assert jobs[0].stop_frame == 1
-            assert jobs[1].start_frame == 1
-            assert jobs[1].stop_frame == 2
+            assert jobs[0].stop_frame == 4
+            assert jobs[1].start_frame == 3
+            assert jobs[1].stop_frame == 7
 
     @pytest.mark.parametrize(
         "size,expected_segments",


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
1. When a task has non-zero overlap and exactly as many frames as needed to create 1 or more complete segments, the current algorithm generates a redundant segment at the end. For example, if size is 5, segment size is 3, and overlap is 1, it generates segments (0, 2), (2, 4), and (4, 4).

   The algorithm attempts to compensate for this, but it only works in the case where the segment size is unspecified (and defaults to the total size).

   Update the algorithm to handle this correctly in the general case.

2. The algorithm selects a default overlap size of 5 if the media file is a video. However, this might not be a valid value if the task has a very small segment size. In this case, a range of undesirable behaviors may occur, depending on the segment size:

   * segments getting generated such that more than 2 segments cover a single frame;

   * task creation crashing with an exception;

   * a task being created with no segments at all.

   Fix this by clamping the default overlap size the same way as a user-specified one.

Fixes #7675.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Unit tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- [x] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
