### PR TITLE
Split off documentation building into its own pipeline

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,66 @@
+name: Docs
+on:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+  pull_request:
+    types: [ready_for_review, opened, synchronize, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  generate_github_pages:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+          fetch-depth: 0
+
+      - name: Generate CVAT SDK
+        run: |
+          pip3 install --user -r cvat-sdk/gen/requirements.txt
+          ./cvat-sdk/gen/generate.sh
+
+      - name: Setup Hugo
+        run: |
+          wget https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0.110.0_Linux-64bit.tar.gz
+          (mkdir hugo_extended_0.110.0_Linux-64bit && tar -xf hugo_extended_0.110.0_Linux-64bit.tar.gz -C hugo_extended_0.110.0_Linux-64bit)
+
+          wget https://github.com/gohugoio/hugo/releases/download/v0.83.0/hugo_extended_0.83.0_Linux-64bit.tar.gz
+          (mkdir hugo_extended_0.83.0_Linux-64bit && tar -xf hugo_extended_0.83.0_Linux-64bit.tar.gz -C hugo_extended_0.83.0_Linux-64bit)
+
+          mkdir hugo
+          cp hugo_extended_0.110.0_Linux-64bit/hugo hugo/hugo-0.110
+          cp hugo_extended_0.83.0_Linux-64bit/hugo hugo/hugo-0.83
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18.x'
+
+      - name: Install npm packages
+        working-directory: ./site
+        run: |
+          npm ci
+
+      - name: Build docs
+        run: |
+          pip install -r site/requirements.txt
+          python site/process_sdk_docs.py
+          PATH="$PWD/hugo:$PATH" python site/build_docs.py
+        env:
+          HUGO_ENV: production
+
+      - name: Deploy
+        if: github.ref == 'refs/heads/develop'
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./public
+          force_orphan: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -385,62 +385,9 @@ jobs:
           name: cypress_screenshots_${{ matrix.specs }}
           path: ${{ github.workspace }}/tests/cypress/screenshots
 
-  generate_github_pages:
-    needs: [rest_api_testing, unit_testing, e2e_testing]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: recursive
-          fetch-depth: 0
-
-      - name: Download CVAT SDK
-        uses: actions/download-artifact@v3
-        with:
-          name: cvat_sdk
-          path: /tmp/cvat_sdk/
-
-      - name: Setup Hugo
-        run: |
-          wget https://github.com/gohugoio/hugo/releases/download/v0.110.0/hugo_extended_0.110.0_Linux-64bit.tar.gz
-          (mkdir hugo_extended_0.110.0_Linux-64bit && tar -xf hugo_extended_0.110.0_Linux-64bit.tar.gz -C hugo_extended_0.110.0_Linux-64bit)
-
-          wget https://github.com/gohugoio/hugo/releases/download/v0.83.0/hugo_extended_0.83.0_Linux-64bit.tar.gz
-          (mkdir hugo_extended_0.83.0_Linux-64bit && tar -xf hugo_extended_0.83.0_Linux-64bit.tar.gz -C hugo_extended_0.83.0_Linux-64bit)
-
-          mkdir hugo
-          cp hugo_extended_0.110.0_Linux-64bit/hugo hugo/hugo-0.110
-          cp hugo_extended_0.83.0_Linux-64bit/hugo hugo/hugo-0.83
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18.x'
-
-      - name: Install npm packages
-        working-directory: ./site
-        run: |
-          npm ci
-
-      - name: Build docs
-        run: |
-          pip install -r site/requirements.txt
-          python site/process_sdk_docs.py --input-dir /tmp/cvat_sdk/docs/ --site-root site/
-          PATH="$PWD/hugo:$PATH" python site/build_docs.py
-        env:
-          HUGO_ENV: production
-
-      - name: Deploy
-        if: github.ref == 'refs/heads/develop'
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./public
-          force_orphan: true
-
   publish_dev_images:
     if: github.ref == 'refs/heads/develop'
-    needs: [rest_api_testing, unit_testing, e2e_testing, generate_github_pages]
+    needs: [rest_api_testing, unit_testing, e2e_testing]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/opencv/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://opencv.github.io/cvat/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
It has occurred to me that the documentation build happens inside the main workflow, which is configured to ignore changes to the docs when determining whether to run. So if a PR only changes the docs... we don't build the docs. That makes no sense.

Fix this by extracting the documentation job into its own workflow, that always runs. The downside of this is that we have to duplicate the work of generating the SDK, but IMO, it's an acceptable sacrifice.

A side effect of this is that a failure to build the docs no longer prevents the publishing of Docker images, but I don't think that was needed in the first place.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~
- ~~[ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/opencv/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/opencv/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/opencv/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/opencv/cvat/tree/develop/cvat-ui#versioning))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/opencv/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
