### PR TITLE
Remove unnecessary fields from the `/api/lambda/functions` response

### DIFF
--- a/cvat-core/src/core-types.ts
+++ b/cvat-core/src/core-types.ts
@@ -37,7 +37,6 @@ export interface SerializedModel {
     name?: string;
     labels_v2?: MLModelLabel[];
     version?: number;
-    framework?: string;
     description?: string;
     kind?: ModelKind;
     type?: string;

--- a/cvat-core/src/ml-model.ts
+++ b/cvat-core/src/ml-model.ts
@@ -35,10 +35,6 @@ export default class MLModel {
         return this.serialized.version;
     }
 
-    public get framework(): string {
-        return this.serialized.framework;
-    }
-
     public get description(): string {
         return this.serialized.description;
     }

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -36,9 +36,8 @@ id_function_non_unique_labels = "test-model-has-non-unique-labels"
 id_function_state_building = "test-model-has-state-building"
 id_function_state_error = "test-model-has-state-error"
 
-expected_keys_in_response_all_functions = ["id", "kind", "labels", "description", "framework", "name"]
+expected_keys_in_response_all_functions = ["id", "kind", "labels_v2", "description", "name"]
 expected_keys_in_response_function_interactor = expected_keys_in_response_all_functions + ["min_pos_points", "startswith_box"]
-expected_keys_in_response_function_tracker = expected_keys_in_response_all_functions + ["state"]
 expected_keys_in_response_requests = ["id", "function", "status", "progress", "enqueued", "started", "ended", "exc_info"]
 
 path = os.path.join(os.path.dirname(__file__), 'assets', 'tasks.json')
@@ -246,9 +245,6 @@ class _LambdaTestCaseBase(APITestCase):
         kind = data["kind"]
         if kind == "interactor":
             for key in expected_keys_in_response_function_interactor:
-                self.assertIn(key, data)
-        elif kind == "tracker":
-            for key in expected_keys_in_response_function_tracker:
                 self.assertIn(key, data)
         else:
             for key in expected_keys_in_response_all_functions:

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -185,14 +185,10 @@ class LambdaFunction:
                 raise ValidationError(
                     "`{}` lambda function has non-unique attributes for label {}".format(self.id, label),
                     code=status.HTTP_404_NOT_FOUND)
-        # state of the function
-        self.state = data['status']['state']
         # description of the function
         self.description = data['spec']['description']
         # http port to access the serverless function
         self.port = data["status"].get("httpPort")
-        # framework which is used for the function (e.g. tensorflow, openvino)
-        self.framework = meta_anno.get('framework')
         # display name for the function
         self.name = meta_anno.get('name', self.id)
         self.min_pos_points = int(meta_anno.get('min_pos_points', 1))
@@ -207,10 +203,8 @@ class LambdaFunction:
         response = {
             'id': self.id,
             'kind': str(self.kind),
-            'labels': [label['name'] for label in self.labels],
             'labels_v2': self.labels,
             'description': self.description,
-            'framework': self.framework,
             'name': self.name,
             'version': self.version
         }
@@ -222,15 +216,6 @@ class LambdaFunction:
                 'startswith_box': self.startswith_box,
                 'help_message': self.help_message,
                 'animated_gif': self.animated_gif
-            })
-
-        if self.kind is LambdaType.TRACKER:
-            response.update({
-                'state': self.state
-            })
-        if self.kind is LambdaType.DETECTOR:
-            response.update({
-                'attributes': self.func_attributes
             })
 
         return response

--- a/serverless/onnx/WongKinYiu/yolov7/nuclio/function-gpu.yaml
+++ b/serverless/onnx/WongKinYiu/yolov7/nuclio/function-gpu.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: YOLO v7
     type: detector
-    framework: onnx
     spec: |
       [
         { "id": 0, "name": "person", "type": "rectangle" },

--- a/serverless/onnx/WongKinYiu/yolov7/nuclio/function.yaml
+++ b/serverless/onnx/WongKinYiu/yolov7/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: YOLO v7
     type: detector
-    framework: onnx
     spec: |
       [
         { "id": 0, "name": "person", "type": "rectangle" },

--- a/serverless/openvino/dextr/nuclio/function.yaml
+++ b/serverless/openvino/dextr/nuclio/function.yaml
@@ -6,7 +6,6 @@ metadata:
     version: 2
     type: interactor
     spec:
-    framework: openvino
     min_pos_points: 4
     animated_gif: https://raw.githubusercontent.com/opencv/cvat/0fbb19ae3846a017853d52e187f0ce149adced7d/site/content/en/images/dextr_example.gif
     help_message: The interactor allows to get a mask of an object using its extreme points (more or equal than 4). You can add a point left-clicking the image

--- a/serverless/openvino/omz/intel/face-detection-0205/nuclio/function.yaml
+++ b/serverless/openvino/omz/intel/face-detection-0205/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Attributed face detection
     type: detector
-    framework: openvino
     spec: |
       [
         { "id": 0, "name": "face", "type": "rectangle", "attributes": [

--- a/serverless/openvino/omz/intel/person-reidentification-retail-0277/nuclio/function.yaml
+++ b/serverless/openvino/omz/intel/person-reidentification-retail-0277/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Person reidentification
     type: reid
-    framework: openvino
     spec:
 
 spec:

--- a/serverless/openvino/omz/intel/semantic-segmentation-adas-0001/nuclio/function.yaml
+++ b/serverless/openvino/omz/intel/semantic-segmentation-adas-0001/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Semantic segmentation for ADAS
     type: detector
-    framework: openvino
     spec: |
       [
         { "id": 0, "name": "road", "type": "mask" },

--- a/serverless/openvino/omz/intel/text-detection-0004/nuclio/function.yaml
+++ b/serverless/openvino/omz/intel/text-detection-0004/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Text detection v4
     type: detector
-    framework: openvino
     spec: |
       [
         { "id": 1, "name": "text", "type": "mask" }

--- a/serverless/openvino/omz/public/faster_rcnn_inception_resnet_v2_atrous_coco/nuclio/function.yaml
+++ b/serverless/openvino/omz/public/faster_rcnn_inception_resnet_v2_atrous_coco/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Faster RCNN
     type: detector
-    framework: openvino
     spec: |
       [
         { "id": 1, "name": "person", "type": "rectangle" },

--- a/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/function.yaml
+++ b/serverless/openvino/omz/public/mask_rcnn_inception_resnet_v2_atrous_coco/nuclio/function.yaml
@@ -7,7 +7,6 @@ metadata:
   annotations:
     name: Mask RCNN
     type: detector
-    framework: openvino
     spec: |
       [
         { "id": 1, "name": "person", "type": "mask" },

--- a/serverless/openvino/omz/public/yolo-v3-tf/nuclio/function.yaml
+++ b/serverless/openvino/omz/public/yolo-v3-tf/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: YOLO v3
     type: detector
-    framework: openvino
     spec: |
       [
         { "id": 0, "name": "person", "type": "rectangle" },

--- a/serverless/pytorch/dschoerk/transt/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/dschoerk/transt/nuclio/function-gpu.yaml
@@ -5,7 +5,6 @@ metadata:
     name: TransT
     type: tracker
     spec:
-    framework: pytorch
 
 spec:
   description: Fast Online Object Tracking and Segmentation

--- a/serverless/pytorch/dschoerk/transt/nuclio/function.yaml
+++ b/serverless/pytorch/dschoerk/transt/nuclio/function.yaml
@@ -5,7 +5,6 @@ metadata:
     name: TransT
     type: tracker
     spec:
-    framework: pytorch
 
 spec:
   description: Fast Online Object Tracking and Segmentation

--- a/serverless/pytorch/facebookresearch/detectron2/retinanet_r101/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/facebookresearch/detectron2/retinanet_r101/nuclio/function-gpu.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: RetinaNet R101
     type: detector
-    framework: pytorch
     spec: |
       [
         { "id": 1, "name": "person", "type": "rectangle" },

--- a/serverless/pytorch/facebookresearch/detectron2/retinanet_r101/nuclio/function.yaml
+++ b/serverless/pytorch/facebookresearch/detectron2/retinanet_r101/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: RetinaNet R101
     type: detector
-    framework: pytorch
     spec: |
       [
         { "id": 1, "name": "person", "type": "rectangle" },

--- a/serverless/pytorch/facebookresearch/sam/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/function-gpu.yaml
@@ -10,7 +10,6 @@ metadata:
     version: 2
     type: interactor
     spec:
-    framework: pytorch
     min_pos_points: 1
     min_neg_points: 0
     animated_gif: https://raw.githubusercontent.com/cvat-ai/cvat/develop/site/content/en/images/hrnet_example.gif

--- a/serverless/pytorch/facebookresearch/sam/nuclio/function.yaml
+++ b/serverless/pytorch/facebookresearch/sam/nuclio/function.yaml
@@ -10,7 +10,6 @@ metadata:
     version: 2
     type: interactor
     spec:
-    framework: pytorch
     min_pos_points: 1
     min_neg_points: 0
     animated_gif: https://raw.githubusercontent.com/cvat-ai/cvat/develop/site/content/en/images/hrnet_example.gif

--- a/serverless/pytorch/foolwood/siammask/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/foolwood/siammask/nuclio/function-gpu.yaml
@@ -5,7 +5,6 @@ metadata:
     name: SiamMask
     type: tracker
     spec:
-    framework: pytorch
 
 spec:
   description: Fast Online Object Tracking and Segmentation

--- a/serverless/pytorch/foolwood/siammask/nuclio/function.yaml
+++ b/serverless/pytorch/foolwood/siammask/nuclio/function.yaml
@@ -5,7 +5,6 @@ metadata:
     name: SiamMask
     type: tracker
     spec:
-    framework: pytorch
 
 spec:
   description: Fast Online Object Tracking and Segmentation

--- a/serverless/pytorch/mmpose/hrnet32/nuclio/function.yaml
+++ b/serverless/pytorch/mmpose/hrnet32/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Human pose estimation
     type: detector
-    framework: pytorch
     spec: |
       [
         {

--- a/serverless/pytorch/saic-vul/fbrs/nuclio/function.yaml
+++ b/serverless/pytorch/saic-vul/fbrs/nuclio/function.yaml
@@ -6,7 +6,6 @@ metadata:
     version: 2
     type: interactor
     spec:
-    framework: pytorch
     min_pos_points: 1
     min_neg_points: 0
     animated_gif: https://raw.githubusercontent.com/cvat-ai/cvat/0fbb19ae3846a017853d52e187f0ce149adced7d/site/content/en/images/fbrs_example.gif

--- a/serverless/pytorch/saic-vul/hrnet/nuclio/function-gpu.yaml
+++ b/serverless/pytorch/saic-vul/hrnet/nuclio/function-gpu.yaml
@@ -6,7 +6,6 @@ metadata:
     version: 2
     type: interactor
     spec:
-    framework: pytorch
     min_pos_points: 1
     min_neg_points: 0
     animated_gif: https://raw.githubusercontent.com/cvat-ai/cvat/develop/site/content/en/images/hrnet_example.gif

--- a/serverless/pytorch/saic-vul/hrnet/nuclio/function.yaml
+++ b/serverless/pytorch/saic-vul/hrnet/nuclio/function.yaml
@@ -6,7 +6,6 @@ metadata:
     version: 2
     type: interactor
     spec:
-    framework: pytorch
     min_pos_points: 1
     min_neg_points: 0
     animated_gif: https://raw.githubusercontent.com/cvat-ai/cvat/develop/site/content/en/images/hrnet_example.gif

--- a/serverless/pytorch/shiyinzhang/iog/nuclio/function.yaml
+++ b/serverless/pytorch/shiyinzhang/iog/nuclio/function.yaml
@@ -6,7 +6,6 @@ metadata:
     version: 2
     type: interactor
     spec:
-    framework: pytorch
     min_pos_points: 1
     min_neg_points: 0
     startswith_box: true

--- a/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/function-gpu.yaml
+++ b/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/function-gpu.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Faster RCNN via Tensorflow
     type: detector
-    framework: tensorflow
     spec: |
       [
         { "id": 1, "name": "person", "type": "rectangle" },

--- a/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/function.yaml
+++ b/serverless/tensorflow/faster_rcnn_inception_v2_coco/nuclio/function.yaml
@@ -4,7 +4,6 @@ metadata:
   annotations:
     name: Faster RCNN via Tensorflow
     type: detector
-    framework: tensorflow
     spec: |
       [
         { "id": 1, "name": "person", "type": "rectangle" },

--- a/site/content/en/docs/manual/advanced/serverless-tutorial.md
+++ b/site/content/en/docs/manual/advanced/serverless-tutorial.md
@@ -440,7 +440,6 @@ metadata:
   annotations:
     name: RetinaNet R101
     type: detector
-    framework: pytorch
     spec: |
       [
         { "id": 1, "name": "person" },


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Remove several fields that haven't been used for one reason or another:

* `labels` and `attributes` have been replaced by `labels_v2`. Keeping them around nearly triples the response length.

* `framework` hasn't been used by the UI since #5635, and IMO was never useful to begin with. There are no decisions that the UI can take based on this field, so it's essentially just a freeform text field, and we already have a freeform text field - `description`. (Which... the UI doesn't display either. But it could!)

  Remove the `framework` field from the function descriptions as well, since it has no other purpose.

* `state` has, as far I could determine, never been used by the UI. I could see a field like this potentially being useful (e.g. the UI could still display a function, but prevent it from being used if it's unavailable), but since none of that is implemented right now, I see no reason to have this field in the API.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))
- [ ] I have increased versions of npm packages if it is necessary
  ([cvat-canvas](https://github.com/cvat-ai/cvat/tree/develop/cvat-canvas#versioning),
  [cvat-core](https://github.com/cvat-ai/cvat/tree/develop/cvat-core#versioning),
  [cvat-data](https://github.com/cvat-ai/cvat/tree/develop/cvat-data#versioning) and
  [cvat-ui](https://github.com/cvat-ai/cvat/tree/develop/cvat-ui#versioning))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed framework-specific annotations from various serverless function configurations and metadata files to streamline setup and reduce dependencies on specific frameworks.

- **Documentation**
  - Updated serverless tutorial to reflect the removal of the `framework: pytorch` entry for the RetinaNet R101 detector.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->