### PR TITLE
Use `any` as the default function label type

### DIFF
--- a/changelog.d/20250204_183545_roman_unknown_any.md
+++ b/changelog.d/20250204_183545_roman_unknown_any.md
@@ -1,0 +1,5 @@
+### Changed
+
+- When invoking Nuclio functions, labels of type `any` can now be mapped to
+  labels of all types except `skeleton`
+  (<https://github.com/cvat-ai/cvat/pull/9050>)

--- a/cvat-ui/src/components/model-runner-modal/labels-mapper.tsx
+++ b/cvat-ui/src/components/model-runner-modal/labels-mapper.tsx
@@ -39,7 +39,7 @@ function labelsCompatible(modelLabel: LabelInterface, jobLabel: LabelInterface):
     const compatibleTypes = [[LabelType.MASK, LabelType.POLYGON]];
     return modelLabelType === jobLabelType ||
         (jobLabelType === 'any' && modelLabelType !== LabelType.SKELETON) ||
-        (modelLabelType === 'unknown' && jobLabelType !== LabelType.SKELETON) || // legacy support
+        ((modelLabelType === 'any' || modelLabelType === 'unknown') && jobLabelType !== LabelType.SKELETON) || // legacy support
         compatibleTypes.some((compatible) => compatible.includes(jobLabelType) && compatible.includes(modelLabelType));
 }
 

--- a/cvat/apps/lambda_manager/views.py
+++ b/cvat/apps/lambda_manager/views.py
@@ -202,7 +202,7 @@ class LambdaFunction:
             for label in spec:
                 parsed_label = {
                     "name": label["name"],
-                    "type": label.get("type", "unknown"),
+                    "type": label.get("type", "any"),
                     "attributes": parse_attributes(label.get("attributes", [])),
                 }
                 if parsed_label["type"] == "skeleton":
@@ -312,7 +312,7 @@ class LambdaFunction:
             return (
                 model_type == db_type
                 or (db_type == "any" and model_type != "skeleton")
-                or (model_type == "unknown" and db_type != "skeleton")
+                or (model_type == "any" and db_type != "skeleton")
                 or any(
                     [
                         model_type in compatible and db_type in compatible


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, the default is `unknown`, but allowing `unknown` as a function label type value creates some complications.

* The sets of allowed label types of a task and of a function are not the same, so we have to use different enums to represent them.

* `any` and `unknown` have similar meanings, and it's not clear what the difference between them is unless you search the code (AFAIK it's not documented anywhere).

The sole benefit of having a separate `unknown` label type seems to be that function labels of type `any` are only allowed to be mapped to task labels of type `any`, while function labels of type `unknown` can be mapped to task labels of any type. But it doesn't seem like a useful distinction. Functions with both `unknown` and `any` label types can produce any shape types, so if we allow one of them, it makes sense to also allow the other.

In addition, functions that can produce _multiple_ shape types for a single label are probably going to be rare, so I think it's reasonable to assume that a function with an `any`-typed label will still produce a single shape type and therefore can be mapped to a label with a specific type (although the user is responsible for ensuring that the types actually match).

To sum up, I don't think the additional complexity introduced by the `unknown` type is worth it. So let's remove it and use `any` instead.

This PR keeps some `unknown`-related logic in the UI, since there's some code in the Enterprise backend that also uses `unknown` as a label type. If this patch is accepted, I'll replace those uses with `any` too, then go back and remove the remaining logic here.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
