### PR TITLE
UI: Don't pass the shapes to the lambda function when continuing tracking

### DIFF
--- a/changelog.d/20250619_171731_roman_either_states_or_shapes.md
+++ b/changelog.d/20250619_171731_roman_either_states_or_shapes.md
@@ -1,0 +1,5 @@
+### Changed
+
+- Nuclio tracker functions are no longer passed the previous frame's shapes
+  when continuing the tracking
+  (<https://github.com/cvat-ai/cvat/pull/9548>)

--- a/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
+++ b/cvat-ui/src/components/annotation-page/standard-workspace/controls-side-bar/tools-control.tsx
@@ -830,7 +830,6 @@ export class ToolsControlComponent extends React.PureComponent<Props, State> {
                         // eslint-disable-next-line no-await-in-loop
                         const response = await core.lambda.call(jobInstance.taskId, tracker, {
                             frame,
-                            shapes: trackableObjects.shapes,
                             states: trackableObjects.states,
                             job: jobInstance.id,
                         }) as TrackerResults;

--- a/cvat/apps/lambda_manager/tests/test_lambda.py
+++ b/cvat/apps/lambda_manager/tests/test_lambda.py
@@ -786,7 +786,6 @@ class LambdaTestCases(_LambdaTestCaseBase):
         data = {
             "task": self.main_task["id"],
             "frame": 0,
-            "shapes": [{"type": "rectangle", "points": [12.12, 34.45, 54.0, 76.12]}],
             "states": [signer.sign("{}")],
         }
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Currently, the UI always passes the current shape points when calling the tracker function. When initializing the tracking state, this makes sense.

However, when continuing tracking, the utility of this is dubious.

* The point coordinates passed in this way are those for the _previous_ frame; however, the function does not have access to that frame itself. Therefore, it cannot examine the pixel data that the shape covers.

* In every case, these shapes are data that the function has already seen: it's either the shape that the function received in the initial request, or the shape that the function has output in the previous request. Therefore, if the function really needs this data, it can already ensure access to it by including it into the tracking state.

OTOH, including the shapes has some downsides:

* It's unnecessary data bloating the request. For rectangles, this isn't a big deal, but for, say, masks the extra data could be significant.

* It complicates the mental model for the tracker API.

Because of all this, this patch removes the passing of the shapes.

This is a breaking change. However, none of the example trackers in this repository use the previous-frame shapes, and neither does the private SAM2 tracker, so chances are that most 3rd-party trackers won't either. I have included compatibility code that passes a dummy `shapes` array to the Nuclio function, so that code that relies on its _length_ will still work.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I have tried using TransT and SiamMask (and they still work).

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
