### PR TITLE
Fix search frame filename test

### DIFF
--- a/tests/cypress/e2e/actions_objects2/case_search_frame_by_filename.js
+++ b/tests/cypress/e2e/actions_objects2/case_search_frame_by_filename.js
@@ -28,31 +28,34 @@ context('Search frame by filename', () => {
         return cy.then(() => {
             const actualIndicesWrapped = [];
             const actualNamesWrapped = [];
-            return cy.get('.ant-select-dropdown').should('be.visible').then(() => {
-                for (let i = 0; i <= expectedCount; i++) {
-                    cy.realPress('ArrowDown');
-                    cy.get('.ant-select-item-option-active').invoke('text').then((text) => {
-                        const split = text.split(' ');
-                        assert(split.length === 2);
-                        const [frameIdRaw, frameFilename] = split;
-                        const frameId = parseInt(frameIdRaw.replace('#', ''), 10);
-                        actualIndicesWrapped.push(frameId);
-                        actualNamesWrapped.push(frameFilename);
-                    });
-                }
-            }).then(() => {
+            return cy.get('.ant-select-dropdown')
+                .should('be.visible')
+                .and('not.have.class', 'ant-slide-up')
+                .then(() => {
+                    for (let i = 0; i <= expectedCount; i++) {
+                        cy.realPress('ArrowDown');
+                        cy.get('.ant-select-item-option-active').invoke('text').then((text) => {
+                            const split = text.split(' ');
+                            assert(split.length === 2);
+                            const [frameIdRaw, frameFilename] = split;
+                            const frameId = parseInt(frameIdRaw.replace('#', ''), 10);
+                            actualIndicesWrapped.push(frameId);
+                            actualNamesWrapped.push(frameFilename);
+                        });
+                    }
+                }).then(() => {
                 // Check that we wrapped the list correctly and found the first filename again
-                cy.wrap(actualNamesWrapped[expectedCount]).should('equal', expectedResults[0]);
-                const actualNames = actualNamesWrapped.slice(0, actualNamesWrapped.length - 1);
-                const actualIndices = actualIndicesWrapped.slice(0, actualIndicesWrapped.length - 1);
+                    cy.wrap(actualNamesWrapped[expectedCount]).should('equal', expectedResults[0]);
+                    const actualNames = actualNamesWrapped.slice(0, actualNamesWrapped.length - 1);
+                    const actualIndices = actualIndicesWrapped.slice(0, actualIndicesWrapped.length - 1);
 
-                cy.wrap(actualNames).each((actualName, i) => {
-                    cy.wrap(actualName).should('equal', expectedResults[i]);
+                    cy.wrap(actualNames).each((actualName, i) => {
+                        cy.wrap(actualName).should('equal', expectedResults[i]);
+                    });
+                    cy.wrap(actualIndices).each((actualFrameId, i) => {
+                        cy.wrap(allNames[actualFrameId]).should('equal', expectedResults[i]);
+                    });
                 });
-                cy.wrap(actualIndices).each((actualFrameId, i) => {
-                    cy.wrap(allNames[actualFrameId]).should('equal', expectedResults[i]);
-                });
-            });
         });
     }
 
@@ -104,22 +107,20 @@ context('Search frame by filename', () => {
             });
         });
 
-        it('search for present frames, scroll through',
-            { keystrokeDelay: 50 }, // search debounce
-            () => {
-                const input = '0';
-                const expectedFilenames = filenamesThatContain(input);
+        it('search for present frames, scroll through', () => {
+            const input = '0';
+            const expectedFilenames = filenamesThatContain(input);
 
-                cy.get('.cvat-frame-search-modal').find('input')
-                    .should('be.focused').type(input);
-                cy.contains(expectedFilenames[0]).then(() => {
-                    checkFrameSearchResults(expectedFilenames, allFilenames);
-                });
-                // After clearing the input, modal should stay
-                cy.get('.cvat-frame-search-modal').find('input').clear();
-                cy.get('.cvat-frame-search-modal').should('be.visible')
-                    .find('input').should('be.visible');
+            cy.get('.cvat-frame-search-modal').find('input')
+                .should('be.focused').type(input);
+            cy.contains(expectedFilenames[0]).then(() => {
+                checkFrameSearchResults(expectedFilenames, allFilenames);
             });
+            // After clearing the input, modal should stay
+            cy.get('.cvat-frame-search-modal').find('input').clear();
+            cy.get('.cvat-frame-search-modal').should('be.visible')
+                .find('input').should('be.visible');
+        });
 
         it("negative search, modal shows 'No frames found", () => {
             cy.get('.cvat-frame-search-modal').find('input').type('N');


### PR DESCRIPTION
Fix of #9485

### Motivation and context
Flaky test on our CI. 
Reason: lack of accounting for search debounce on input.
Solution: added `keystrokeDelay` before typing in search frame dropdown



### How has this been tested?
Test cases were run 10 times locally, all green

### Checklist

- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment 
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
