### PR TITLE
Fixing tests for lightweight backup

### DIFF
--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -26,6 +26,7 @@ from typing import Any, Optional
 
 import numpy as np
 import pytest
+from attr.converters import to_bool
 from cvat_sdk import exceptions
 from cvat_sdk.api_client import models
 from cvat_sdk.api_client.api_client import ApiClient, Endpoint
@@ -1316,12 +1317,20 @@ class TestTaskBackups:
         assert filename.is_file()
         assert filename.stat().st_size > 0
 
-        if lightweight_backup and os.getenv("CVAT_ALLOW_STATIC_CACHE") != "true":
+        if lightweight_backup:
             with zipfile.ZipFile(filename, "r") as zf:
-                files_in_data = [
-                    os.path.split(name)[1] for name in zf.namelist() if name.startswith("data")
-                ]
-                assert files_in_data == ["manifest.jsonl"]
+                files_in_data = {
+                    name.split("data/", maxsplit=1)[1]
+                    for name in zf.namelist()
+                    if name.startswith("data/")
+                }
+
+            expected_media = {"manifest.jsonl"}
+            if to_bool(os.getenv("CVAT_ALLOW_STATIC_CACHE")):
+                # FIXME: remove extra media files
+                expected_media.update(cloud_storage_content)
+
+            assert files_in_data == expected_media
 
         self._test_can_restore_task_from_backup(task_id, lightweight_backup=lightweight_backup)
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

https://github.com/cvat-ai/cvat/pull/9535 does not correctly process lightweight backups for cloud based tasks for case when static cache is allowed. (i.e. treats them like not cloud based tasks).
It is not obvious right now how lightweight backup should behave for that case.
Fixing tests to expect current behaviour.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
