### PR TITLE
add links to allow terminal links inside vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -46,5 +46,13 @@
     "python.testing.cwd": "${workspaceFolder}/tests",
     "cSpell.words": [
         "crowdsourcing"
+    ],
+    "terminal.integrated.allowedLinkSchemes": [
+        "file",
+        "http",
+        "https",
+        "vscode",
+        "vscode-insiders",
+        "webpack"
     ]
 }


### PR DESCRIPTION
New feature to extend link navigation in vscode terminal
https://code.visualstudio.com/updates/v1_89#_expanded-ansi-hyperlink-support

Useful for clicking through file links like `webpack:///` and javascript/typescript `file:///`. Allows to quickly navigate to a file from e.g. terminal logs