### PR TITLE
SDK: Make the default retry logic more robust

### DIFF
--- a/changelog.d/20251009_135408_roman_sdk_retry.md
+++ b/changelog.d/20251009_135408_roman_sdk_retry.md
@@ -1,0 +1,4 @@
+### Changed
+
+- \[SDK\] Enabled retrying on some server error statuses by default 
+  (<https://github.com/cvat-ai/cvat/pull/9880>)

--- a/cvat-sdk/gen/templates/openapi-generator/configuration.mustache
+++ b/cvat-sdk/gen/templates/openapi-generator/configuration.mustache
@@ -8,6 +8,7 @@ import multiprocessing
 import sys
 import typing
 import urllib3
+import urllib3.util
 
 from http import client as http_client
 from {{packageName}}.exceptions import ApiValueError
@@ -316,7 +317,9 @@ class Configuration:
         self.safe_chars_for_path_param = ''
         """Safe chars for path_param"""
 
-        self.retries = None
+        self.retries = urllib3.util.Retry(
+            total=3, status_forcelist=(502, 503, 504), backoff_factor=0.5
+        )
         """Adding retries to override urllib3 default value 3"""
 
         # Enable client side validation


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
1. Add some typical transient server error status codes to the `status_forcelist` setting to enable retries for them. This will make the SDK more reliable when dealing with a flaky server. urllib3 will only retry requests with idempotent methods, so this seems reasonably safe.

   By default, urllib3 will already retry on 503, but only if the `Retry-After` header is set; including it in `status_forcelist` will make the retries unconditional.

   The 500 code is explicitly not included, as it typically indicates an unhandled exception on the server. Retrying the request in this case is likely to just trigger the exception again.

2. Add delay settings to prevent the SDK hammering the server with retries. Note that urllib3 will use the `Retry-After` header instead if it's available.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
