### PR TITLE
`create_thread`: remove the `is_dataset_import` parameter

### DIFF
--- a/cvat/apps/dataset_manager/project.py
+++ b/cvat/apps/dataset_manager/project.py
@@ -109,7 +109,7 @@ class ProjectAnnotation:
         data["stop_frame"] = None
         data["server_files"] = list(map(split_name, data["server_files"]))
 
-        create_task(db_task, data, is_dataset_import=True)
+        create_task(db_task, data)
         self.db_tasks = (
             models.Task.objects.filter(project__id=self.db_project.id)
             .exclude(data=None)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
It is used 3 times, and each time appears unnecessary:

1. `data['remote_files']` implies `not is_dataset_import`, because dataset imports can't have remote files.

2. `db_data.storage == models.StorageChoice.SHARE` implies `not is_dataset_import`, because dataset imports always use `StorageChoice.LOCAL`.

3. `data['sorting_method'] == models.SortingMethod.PREDEFINED` implies `not is_dataset_import`, because dataset imports always use `LEXICOGRAPHICAL`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
