### PR TITLE
Fix issue #9978: Support related images from local file share

### DIFF
--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -421,6 +421,26 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
                 target_dir=target_data_dir,
             )
 
+            related_files_to_copy = []
+            for related_file in self._db_data.related_files.all():
+                related_file_path = related_file.path.path
+                if os.path.isabs(related_file_path):
+                    if related_file_path.startswith(data_dir + os.sep):
+                        if os.path.exists(related_file_path):
+                            related_files_to_copy.append(related_file_path)
+                else:
+                    related_file_path = os.path.join(data_dir, related_file_path)
+                    if os.path.exists(related_file_path):
+                        related_files_to_copy.append(related_file_path)
+
+            if related_files_to_copy:
+                self._write_files(
+                    source_dir=data_dir,
+                    zip_object=zip_object,
+                    files=related_files_to_copy,
+                    target_dir=target_data_dir,
+                )
+
             self._write_files(
                 source_dir=self._db_data.get_upload_dirname(),
                 zip_object=zip_object,

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -677,17 +677,22 @@ class MediaCache:
         decode: bool = True,
     ) -> Generator[tuple[int, tuple[PIL.Image.Image | str, str, str]], None, None]:
         data_upload_dir = db_data.get_upload_dirname()
+        raw_data_dir = db_data.get_raw_data_dirname()
 
         def _validate_ri_path(path: str) -> str:
             if os.path.isabs(path):
-                if not path.startswith(data_upload_dir + os.sep):
+                if path.startswith(raw_data_dir + os.sep):
+                    path = os.path.relpath(path, raw_data_dir)
+                elif path.startswith(data_upload_dir + os.sep):
+                    path = os.path.relpath(path, raw_data_dir)
+                else:
                     raise Exception("Invalid related image path")
-
-                path = os.path.relpath(path, data_upload_dir)
             else:
-                if not os.path.normpath(os.path.join(data_upload_dir, path)).startswith(
-                    data_upload_dir + os.sep
-                ):
+                normalized_upload_path = os.path.normpath(os.path.join(data_upload_dir, path))
+                normalized_raw_path = os.path.normpath(os.path.join(raw_data_dir, path))
+                
+                if not (normalized_raw_path.startswith(raw_data_dir + os.sep) or
+                        normalized_upload_path.startswith(data_upload_dir + os.sep)):
                     raise Exception("Invalid related image path")
 
             return path


### PR DESCRIPTION
Fixes #9978

## Changes
- Fixed path validation in `_validate_ri_path` to support SHARE storage paths by checking both `raw_data_dir` (SHARE_ROOT) and `data_upload_dir`
- Added related images to backup for SHARE storage tasks

## Testing
- Related images from local file share should now display correctly in the UI
- Related images are now included in task backups
- Backups can be imported with related images visible