### PR TITLE
set annotation of nginx to 800MB upload file maximum to avoid 413

### DIFF
--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -501,7 +501,9 @@ ingress:
   ## annotations:
   ##   kubernetes.io/ingress.class: nginx
   ##
-  annotations: {}
+  annotations:
+    nginx.ingress.kubernetes.io/proxy-body-size: 800m # choose a higher value based on your data size
+  
   ## @param ingress.className IngressClass that will be used to implement the Ingress (Kubernetes 1.18+)
   ## This is supported in Kubernetes 1.18+ and required if you have more than one IngressClass marked as the default for your cluster
   ## ref: https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/


### PR DESCRIPTION

### Motivation and context

This change increases the allowed client request body size for the NGINX ingress to **800 MB** by adding the annotation:

```yaml
nginx.ingress.kubernetes.io/proxy-body-size: 800m
```

Previously, large file uploads (e.g., video datasets) could trigger a **`413 Request Entity Too Large`** error when creating tasks in CVAT.  
Raising this limit ensures smoother uploads and avoids task creation failures for larger datasets.  

No functional or behavioral changes to CVAT itself — only configuration improvement for more robust deployments.

https://github.com/cvat-ai/cvat/issues/9923
---

### How has this been tested?

- Applied the updated annotation in a CVAT deployment on Kubernetes (Helm-based).  
- Verified successful creation of tasks with large file uploads (>100 MB).  
- Confirmed no regressions in task creation or ingress routing.  
- Environment:  
  - **CVAT:** latest `develop` branch  

---

### Checklist
- [x] I submit my changes into the `develop` branch  
- [ ] I have created a changelog fragment 
- [ ] I have updated the documentation accordingly (deployment/Helm configuration)  
- [x] I have tested the change in a real deployment environment  
- [x] I have linked related issues (if applicable)

---

### License
- [x] I submit _my code changes_ under the same [MIT License](https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
