### PR TITLE
Remove code to back up the contents of the task directory

### DIFF
--- a/changelog.d/20251112_174932_roman_no_task_dir_backup.md
+++ b/changelog.d/20251112_174932_roman_no_task_dir_backup.md
@@ -1,0 +1,6 @@
+### Changed
+
+- Files located in the `data/tasks/<id>` directory are no longer included
+  in task backups, nor extracted from such backups when restoring. Recent
+  versions of CVAT (since v2.6.2) no longer create or use such files
+  (<https://github.com/cvat-ai/cvat/pull/10001>)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
AFAICS, there is nothing currently stored there except for the `tmp` subdirectory. `tmp` should not be backed up, and it _isn't_ (because of the `recursive=False` argument). So the code effectively does nothing.

Remove the corresponding restore code, as well.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Automatic tests.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
