### PR TITLE
Upgrade nuclio image version for serverless docker-compose

### DIFF
--- a/components/serverless/docker-compose.serverless.yml
+++ b/components/serverless/docker-compose.serverless.yml
@@ -1,7 +1,7 @@
 services:
   nuclio:
     container_name: nuclio
-    image: quay.io/nuclio/dashboard:1.16.0-amd64
+    image: quay.io/nuclio/dashboard:1.15.9-amd64
     restart: always
     networks:
       - cvat


### PR DESCRIPTION
Fixes https://github.com/cvat-ai/cvat/issues/10033

Very similar to the issue with traefik: 
- https://github.com/traefik/traefik/issues/12253
- https://github.com/cvat-ai/cvat/pull/10018

### Tests
It now runs fine on our local instance with the latest docker version.

### Checklist
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment 
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
