### PR TITLE
`dev/check_changelog_fragments.py`: check that the PR number is filled in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -533,7 +533,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (<https://github.com/cvat-ai/cvat/pull/9521>)
 
 - Incorrect width of project field on webhook setup page
-  (<https://github.com/cvat-ai/cvat/pull/XXXX>)
+  (<https://github.com/cvat-ai/cvat/pull/9534>)
 
 - Relevant task quality reports now can be reused in project quality reports
   (<https://github.com/cvat-ai/cvat/pull/9538>)

--- a/dev/check_changelog_fragments.py
+++ b/dev/check_changelog_fragments.py
@@ -1,10 +1,13 @@
 #!/usr/bin/env python3
 
 import configparser
+import re
 import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+RE_PLACEHOLDER_PR_URL = re.compile(r"//github\.com/[\w.-]+/[\w.-]+/pull/X")
 
 
 def main():
@@ -51,6 +54,9 @@ def main():
                     else:
                         # All headers should be of the same level.
                         complain(f"header should start with {md_header_prefix!r}")
+
+                if RE_PLACEHOLDER_PR_URL.search(line):
+                    complain("pull request number should be filled in")
 
     sys.exit(0 if success else 1)
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Looks like one PR made it through with the placeholder number. Make sure this doesn't happen again.

The URL regex works with any org and repo names, so we could potentially reuse this in private repositories.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I made sure the check fires if you don't modify the default fragment created by scriv.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
