### PR TITLE
Fix dropdown awaiting in consensus e2e tests

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1880,7 +1880,10 @@ Cypress.Commands.add('mergeConsensusJob', (jobID, status = 202) => {
         .filter(`:contains("Job #${jobID}")`)
         .find('.anticon-more').first().click();
 
-    cy.get('.ant-dropdown-menu').contains('li', 'Merge consensus job').click();
+    cy.get('.ant-dropdown-menu')
+        .should('exist').and('be.visible')
+        .contains('li', 'Merge consensus job')
+        .click();
     cy.get('.cvat-modal-confirm-consensus-merge-job')
         .contains('button', 'Merge')
         .click();


### PR DESCRIPTION
### Motivation and context

Consensus.js started faiing sporadically, it's connected with untimely cy.get to consensus job dropdown. Added assertions to wait for it to become visible

### How has this been tested?


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
