### PR TITLE
cvat-sdk: use PEP 604 syntax for optionals/unions

### DIFF
--- a/cvat-sdk/cvat_sdk/attributes.py
+++ b/cvat-sdk/cvat_sdk/attributes.py
@@ -5,7 +5,6 @@
 from __future__ import annotations
 
 from collections.abc import Callable, Mapping
-from typing import Union
 
 from . import models
 
@@ -108,7 +107,7 @@ def number_attribute_values(min_value: int, max_value: int, /, step: int = 1) ->
 
 
 def attribute_vals_from_dict(
-    id_to_value: Mapping[int, Union[str, int, bool]], /
+    id_to_value: Mapping[int, str | int | bool], /
 ) -> list[models.AttributeValRequest]:
     """
     Returns a list of AttributeValRequest objects with given IDs and values.
@@ -119,7 +118,7 @@ def attribute_vals_from_dict(
     for attributes with input type "number" and "checkbox", respectively.
     """
 
-    def val_as_string(v: Union[str, int, bool]) -> str:
+    def val_as_string(v: str | int | bool) -> str:
         if v is True:
             return "true"
         if v is False:

--- a/cvat-sdk/cvat_sdk/auto_annotation/driver.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/driver.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Callable, Mapping, Sequence
-from typing import Optional, TypeAlias, Union, cast
+from typing import TypeAlias, cast
 
 import attrs
 
@@ -33,11 +33,9 @@ class _AttributeNameMapping:
 @attrs.frozen
 class _SublabelNameMapping:
     name: str
-    attributes: Optional[Mapping[str, _AttributeNameMapping]] = attrs.field(
-        kw_only=True, default=None
-    )
+    attributes: Mapping[str, _AttributeNameMapping] | None = attrs.field(kw_only=True, default=None)
 
-    def map_attribute(self, name: str) -> Optional[_AttributeNameMapping]:
+    def map_attribute(self, name: str) -> _AttributeNameMapping | None:
         if self.attributes is None:
             return _AttributeNameMapping(name)
 
@@ -57,11 +55,9 @@ class _SublabelNameMapping:
 
 @attrs.frozen
 class _LabelNameMapping(_SublabelNameMapping):
-    sublabels: Optional[Mapping[str, _SublabelNameMapping]] = attrs.field(
-        kw_only=True, default=None
-    )
+    sublabels: Mapping[str, _SublabelNameMapping] | None = attrs.field(kw_only=True, default=None)
 
-    def map_sublabel(self, name: str) -> Optional[_SublabelNameMapping]:
+    def map_sublabel(self, name: str) -> _SublabelNameMapping | None:
         if self.sublabels is None:
             return _SublabelNameMapping(name)
 
@@ -81,9 +77,9 @@ class _LabelNameMapping(_SublabelNameMapping):
 
 @attrs.frozen
 class _SpecNameMapping:
-    labels: Optional[Mapping[str, _LabelNameMapping]] = attrs.field(kw_only=True, default=None)
+    labels: Mapping[str, _LabelNameMapping] | None = attrs.field(kw_only=True, default=None)
 
-    def map_label(self, name: str) -> Optional[_LabelNameMapping]:
+    def map_label(self, name: str) -> _LabelNameMapping | None:
         if self.labels is None:
             return _LabelNameMapping(name)
 
@@ -103,15 +99,15 @@ class _AnnotationMapper:
     @attrs.frozen
     class _SublabelIdMapping:
         id: int
-        attributes: Mapping[int, Optional[_AnnotationMapper._AttributeIdMapping]]
+        attributes: Mapping[int, _AnnotationMapper._AttributeIdMapping | None]
 
     @attrs.frozen
     class _LabelIdMapping(_SublabelIdMapping):
-        sublabels: Mapping[int, Optional[_AnnotationMapper._SublabelIdMapping]]
+        sublabels: Mapping[int, _AnnotationMapper._SublabelIdMapping | None]
         expected_num_elements: int
         expected_type: str
 
-    _SpecIdMapping: TypeAlias = Mapping[int, Optional[_LabelIdMapping]]
+    _SpecIdMapping: TypeAlias = Mapping[int, _LabelIdMapping | None]
 
     _spec_id_mapping: _SpecIdMapping
 
@@ -173,7 +169,7 @@ class _AnnotationMapper:
 
         def attribute_mapping(
             fun_attr: models.IAttribute,
-        ) -> Optional[_AnnotationMapper._AttributeIdMapping]:
+        ) -> _AnnotationMapper._AttributeIdMapping | None:
             attr_desc = f"attribute {fun_attr.name!r} of {sl_desc}"
 
             attr_nm = sl_nm.map_attribute(fun_attr.name)
@@ -220,7 +216,7 @@ class _AnnotationMapper:
 
         def sublabel_mapping(
             fun_sl: models.ISublabel,
-        ) -> Optional[_AnnotationMapper._SublabelIdMapping]:
+        ) -> _AnnotationMapper._SublabelIdMapping | None:
             sl_desc = f"sublabel {fun_sl.name!r} of {label_desc}"
 
             sublabel_nm = label_nm.map_sublabel(fun_sl.name)
@@ -267,7 +263,7 @@ class _AnnotationMapper:
 
         def label_id_mapping(
             fun_label: models.ILabel,
-        ) -> Optional[_AnnotationMapper._LabelIdMapping]:
+        ) -> _AnnotationMapper._LabelIdMapping | None:
             label_desc = f"label {fun_label.name!r}"
 
             label_nm = spec_nm.map_label(fun_label.name)
@@ -344,7 +340,7 @@ class _AnnotationMapper:
 
     def _remap_attributes(
         self,
-        annotation: Union[DetectionAnnotation, models.SubLabeledShapeRequest],
+        annotation: DetectionAnnotation | models.SubLabeledShapeRequest,
         label_id_mapping: _SublabelIdMapping,
     ) -> None:
         seen_attr_ids = set()
@@ -519,7 +515,7 @@ class _AnnotationMapper:
 @attrs.frozen(kw_only=True)
 class _DetectionFunctionContextImpl(DetectionFunctionContext):
     frame_name: str
-    conf_threshold: Optional[float] = None
+    conf_threshold: float | None = None
     conv_mask_to_poly: bool = False
 
 
@@ -528,10 +524,10 @@ def annotate_task(
     task_id: int,
     function: DetectionFunction,
     *,
-    pbar: Optional[ProgressReporter] = None,
+    pbar: ProgressReporter | None = None,
     clear_existing: bool = False,
     allow_unmatched_labels: bool = False,
-    conf_threshold: Optional[float] = None,
+    conf_threshold: float | None = None,
     conv_mask_to_poly: bool = False,
 ) -> None:
     """

--- a/cvat-sdk/cvat_sdk/auto_annotation/interface.py
+++ b/cvat-sdk/cvat_sdk/auto_annotation/interface.py
@@ -4,7 +4,7 @@
 
 import abc
 from collections.abc import Sequence, Set
-from typing import Optional, Protocol, TypeAlias, TypeVar, Union
+from typing import Protocol, TypeAlias, TypeVar
 
 import attrs
 import PIL.Image
@@ -147,7 +147,7 @@ class DetectionFunctionContext(metaclass=abc.ABCMeta):
 
     @property
     @abc.abstractmethod
-    def conf_threshold(self) -> Optional[float]:
+    def conf_threshold(self) -> float | None:
         """
         The confidence threshold that the function should use for filtering
         detections.
@@ -173,7 +173,7 @@ class DetectionFunctionContext(metaclass=abc.ABCMeta):
         """
 
 
-DetectionAnnotation: TypeAlias = Union[models.LabeledImageRequest, models.LabeledShapeRequest]
+DetectionAnnotation: TypeAlias = models.LabeledImageRequest | models.LabeledShapeRequest
 
 
 class DetectionFunction(AutoAnnotationFunction, Protocol):
@@ -375,7 +375,7 @@ class TrackingFunction(AutoAnnotationFunction, Protocol[_PreprocessedImage, _Tra
         context: TrackingFunctionShapeContext,
         pp_image: _PreprocessedImage,
         state: _TrackingState,
-    ) -> Optional[TrackableShape]:
+    ) -> TrackableShape | None:
         """
         Predicts the position of a previously-analyzed shape on a new image.
 

--- a/cvat-sdk/cvat_sdk/core/client.py
+++ b/cvat-sdk/cvat_sdk/core/client.py
@@ -12,7 +12,7 @@ from collections.abc import Generator, Sequence
 from contextlib import contextmanager, suppress
 from pathlib import Path
 from time import sleep
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, TypeVar
 from urllib.parse import urlsplit
 
 import attrs
@@ -53,7 +53,7 @@ class Config:
     allow_unsupported_server: bool = True
     """Allow to use SDK with an unsupported server version. If disabled, raise an exception"""
 
-    verify_ssl: Optional[bool] = None
+    verify_ssl: bool | None = None
     """Whether to verify host SSL certificate or not"""
 
     cache_dir: Path = attrs.field(converter=Path, default=_DEFAULT_CACHE_DIR)
@@ -105,8 +105,8 @@ class Client:
         self,
         url: str,
         *,
-        logger: Optional[logging.Logger] = None,
-        config: Optional[Config] = None,
+        logger: logging.Logger | None = None,
+        config: Config | None = None,
         check_server_version: bool = True,
     ) -> None:
         self.logger = logger or logging.getLogger(__name__)
@@ -134,7 +134,7 @@ class Client:
     _ORG_SLUG_HEADER = "X-Organization"
 
     @property
-    def organization_slug(self) -> Optional[str]:
+    def organization_slug(self) -> str | None:
         """
         If this is set to a slug for an organization,
         all requests will be made in the context of that organization.
@@ -147,7 +147,7 @@ class Client:
         return self.api_client.default_headers.get(self._ORG_SLUG_HEADER)
 
     @organization_slug.setter
-    def organization_slug(self, org_slug: Optional[str]):
+    def organization_slug(self, org_slug: str | None):
         if org_slug is None:
             self.api_client.default_headers.pop(self._ORG_SLUG_HEADER, None)
         else:
@@ -276,8 +276,8 @@ class Client:
         self: Client,
         rq_id: str,
         *,
-        status_check_period: Optional[int] = None,
-        log_prefix: Optional[str] = None,
+        status_check_period: int | None = None,
+        log_prefix: str | None = None,
     ) -> tuple[models.Request, urllib3.HTTPResponse]:
         if status_check_period is None:
             status_check_period = self.config.status_check_period
@@ -302,7 +302,7 @@ class Client:
 
         return request, response
 
-    def check_server_version(self, fail_if_unsupported: Optional[bool] = None) -> None:
+    def check_server_version(self, fail_if_unsupported: bool | None = None) -> None:
         if fail_if_unsupported is None:
             fail_if_unsupported = not self.config.allow_unsupported_server
 
@@ -391,9 +391,9 @@ class CVAT_API_V2:
         self,
         path: str,
         *,
-        psub: Optional[Sequence[Any]] = None,
-        kwsub: Optional[dict[str, Any]] = None,
-        query_params: Optional[dict[str, Any]] = None,
+        psub: Sequence[Any] | None = None,
+        kwsub: dict[str, Any] | None = None,
+        query_params: dict[str, Any] | None = None,
     ) -> str:
         url = self.host + path
         if psub or kwsub:
@@ -406,9 +406,9 @@ class CVAT_API_V2:
 def make_client(
     host: str,
     *,
-    port: Optional[int] = None,
-    credentials: Union[Credentials, tuple[str, str], None] = None,
-    access_token: Optional[str] = None,
+    port: int | None = None,
+    credentials: Credentials | tuple[str, str] | None = None,
+    access_token: str | None = None,
 ) -> Client:
     """
     Create a Client object with the specified parameters.

--- a/cvat-sdk/cvat_sdk/core/downloading.py
+++ b/cvat-sdk/cvat_sdk/core/downloading.py
@@ -10,7 +10,7 @@ import os
 import re
 from contextlib import closing
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import urllib3
 
@@ -80,7 +80,7 @@ class Downloader:
         output_path: Path,
         *,
         timeout: int = 60,
-        pbar: Optional[ProgressReporter] = None,
+        pbar: ProgressReporter | None = None,
     ) -> Path:
         """
         Downloads the file from url into a temporary file, then renames it to the requested name.
@@ -139,9 +139,9 @@ class Downloader:
         self,
         endpoint: Endpoint,
         *,
-        url_params: Optional[dict[str, Any]] = None,
-        query_params: Optional[dict[str, Any]] = None,
-        status_check_period: Optional[int] = None,
+        url_params: dict[str, Any] | None = None,
+        query_params: dict[str, Any] | None = None,
+        status_check_period: int | None = None,
     ):
         client = self._client
         if status_check_period is None:
@@ -177,10 +177,10 @@ class Downloader:
         endpoint: Endpoint,
         filename: Path,
         *,
-        url_params: Optional[dict[str, Any]] = None,
-        query_params: Optional[dict[str, Any]] = None,
-        pbar: Optional[ProgressReporter] = None,
-        status_check_period: Optional[int] = None,
+        url_params: dict[str, Any] | None = None,
+        query_params: dict[str, Any] | None = None,
+        pbar: ProgressReporter | None = None,
+        status_check_period: int | None = None,
     ) -> Path:
         client = self._client
 

--- a/cvat-sdk/cvat_sdk/core/helpers.py
+++ b/cvat-sdk/cvat_sdk/core/helpers.py
@@ -8,7 +8,7 @@ import io
 import json
 import warnings
 from collections.abc import Iterable
-from typing import Any, Optional, Union
+from typing import Any
 
 import tqdm
 import urllib3
@@ -20,7 +20,7 @@ from cvat_sdk.core.progress import BaseProgressReporter, ProgressReporter
 
 def get_paginated_collection(
     endpoint: Endpoint, *, return_json: bool = False, **kwargs
-) -> Union[list, list[dict[str, Any]]]:
+) -> list | list[dict[str, Any]]:
     """
     Accumulates results from all the pages
     """
@@ -49,7 +49,7 @@ def get_paginated_collection(
 
 
 class _BaseTqdmProgressReporter(BaseProgressReporter):
-    tqdm: Optional[tqdm.tqdm]
+    tqdm: tqdm.tqdm | None
 
     def report_status(self, progress: int):
         super().report_status(progress)
@@ -67,7 +67,7 @@ class TqdmProgressReporter(_BaseTqdmProgressReporter):
 
         self.tqdm = instance
 
-    def start2(self, total: int, *, desc: Optional[str] = None, **kwargs) -> None:
+    def start2(self, total: int, *, desc: str | None = None, **kwargs) -> None:
         super().start2(total=total, desc=desc, **kwargs)
 
         self.tqdm.reset(total)
@@ -79,7 +79,7 @@ class TqdmProgressReporter(_BaseTqdmProgressReporter):
 
 
 class DeferredTqdmProgressReporter(_BaseTqdmProgressReporter):
-    def __init__(self, tqdm_args: Optional[dict] = None) -> None:
+    def __init__(self, tqdm_args: dict | None = None) -> None:
         super().__init__()
         self.tqdm_args = tqdm_args or {}
         self.tqdm = None
@@ -88,7 +88,7 @@ class DeferredTqdmProgressReporter(_BaseTqdmProgressReporter):
         self,
         total: int,
         *,
-        desc: Optional[str] = None,
+        desc: str | None = None,
         unit: str = "it",
         unit_scale: bool = False,
         unit_divisor: int = 1000,
@@ -142,7 +142,7 @@ class StreamWithProgress:
         return self.stream.tell()
 
 
-def expect_status(codes: Union[int, Iterable[int]], response: urllib3.HTTPResponse) -> None:
+def expect_status(codes: int | Iterable[int], response: urllib3.HTTPResponse) -> None:
     if not hasattr(codes, "__iter__"):
         codes = [codes]
 

--- a/cvat-sdk/cvat_sdk/core/progress.py
+++ b/cvat-sdk/cvat_sdk/core/progress.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 
 import contextlib
 from collections.abc import Generator, Iterable
-from typing import Optional, TypeVar
+from typing import TypeVar
 
 T = TypeVar("T")
 
@@ -43,7 +43,7 @@ class ProgressReporter:
         finally:
             self.finish()
 
-    def start(self, total: int, *, desc: Optional[str] = None) -> None:
+    def start(self, total: int, *, desc: str | None = None) -> None:
         """
         This is a compatibility method. Override start2 instead.
         """
@@ -53,7 +53,7 @@ class ProgressReporter:
         self,
         total: int,
         *,
-        desc: Optional[str] = None,
+        desc: str | None = None,
         unit: str = "it",
         unit_scale: bool = False,
         unit_divisor: int = 1000,
@@ -108,7 +108,7 @@ class BaseProgressReporter(ProgressReporter):
         self,
         total: int,
         *,
-        desc: Optional[str] = None,
+        desc: str | None = None,
         unit: str = "it",
         unit_scale: bool = False,
         unit_divisor: int = 1000,

--- a/cvat-sdk/cvat_sdk/core/proxies/annotations.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/annotations.py
@@ -5,7 +5,6 @@
 from abc import ABC
 from collections.abc import Sequence
 from enum import Enum
-from typing import Optional
 
 from cvat_sdk import models
 from cvat_sdk.core.proxies.model_proxy import _EntityT
@@ -39,7 +38,7 @@ class AnnotationCrudMixin(ABC):
             patched_labeled_data_request=data,
         )
 
-    def remove_annotations(self: _EntityT, *, ids: Optional[Sequence[int]] = None):
+    def remove_annotations(self: _EntityT, *, ids: Sequence[int] | None = None):
         if ids:
             anns = self.get_annotations()
 

--- a/cvat-sdk/cvat_sdk/core/proxies/jobs.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/jobs.py
@@ -8,7 +8,7 @@ import io
 import mimetypes
 from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from PIL import Image
 
@@ -48,9 +48,9 @@ class Job(
         format_name: str,
         filename: StrPath,
         *,
-        conv_mask_to_poly: Optional[bool] = None,
-        status_check_period: Optional[int] = None,
-        pbar: Optional[ProgressReporter] = None,
+        conv_mask_to_poly: bool | None = None,
+        status_check_period: int | None = None,
+        pbar: ProgressReporter | None = None,
     ):
         """
         Upload annotations for a job in the specified format (e.g. 'YOLO 1.1').
@@ -74,7 +74,7 @@ class Job(
         self,
         frame_id: int,
         *,
-        quality: Optional[str] = None,
+        quality: str | None = None,
     ) -> io.RawIOBase:
         (_, response) = self.api.retrieve_data(
             self.id, number=frame_id, quality=quality, type="frame"
@@ -91,11 +91,11 @@ class Job(
         self,
         frame_ids: Sequence[int],
         *,
-        image_extension: Optional[str] = None,
+        image_extension: str | None = None,
         outdir: StrPath = ".",
         quality: str = "original",
         filename_pattern: str = "frame_{frame_id:06d}{frame_ext}",
-    ) -> Optional[list[Image.Image]]:
+    ) -> list[Image.Image] | None:
         """
         Download the requested frame numbers for a job and save images as outdir/filename_pattern
         """

--- a/cvat-sdk/cvat_sdk/core/proxies/model_proxy.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/model_proxy.py
@@ -9,16 +9,7 @@ from abc import ABC
 from collections.abc import Callable, Sequence
 from copy import deepcopy
 from pathlib import Path
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Generic,
-    Literal,
-    Optional,
-    TypeVar,
-    Union,
-    overload,
-)
+from typing import TYPE_CHECKING, Any, Generic, Literal, TypeVar, overload
 
 from typing_extensions import Self
 
@@ -99,7 +90,7 @@ class Repo(ModelProxy[ModelType, ApiType]):
 
 
 def build_model_bases(
-    mt: type[ModelType], at: type[ApiType], *, api_member_name: Optional[str] = None
+    mt: type[ModelType], at: type[ApiType], *, api_member_name: str | None = None
 ) -> tuple[type[Entity[ModelType, ApiType]], type[Repo[ModelType, ApiType]]]:
     """
     Helps to remove code duplication in declarations of derived classes
@@ -124,7 +115,7 @@ _EntityT = TypeVar("_EntityT", bound=Entity)
 
 
 class ModelCreateMixin(Generic[_EntityT, IModel]):
-    def create(self: Repo, spec: Union[dict[str, Any], IModel]) -> _EntityT:
+    def create(self: Repo, spec: dict[str, Any] | IModel) -> _EntityT:
         """
         Creates a new object on the server and returns the corresponding local object
         """
@@ -150,7 +141,7 @@ class ModelListMixin(Generic[_EntityT]):
     @overload
     def list(self: Repo, *, return_json: Literal[True] = False) -> list[Any]: ...
 
-    def list(self: Repo, *, return_json: bool = False) -> list[Union[_EntityT, Any]]:
+    def list(self: Repo, *, return_json: bool = False) -> list[_EntityT | Any]:
         """
         Retrieves all objects from the server and returns them in basic or JSON format.
         """
@@ -191,7 +182,7 @@ class ModelUpdateMixin(ABC, Generic[IModel]):
     def _model_partial_update_arg(self: Entity) -> str: ...
 
     def _export_update_fields(
-        self: Entity, overrides: Optional[Union[dict[str, Any], IModel]] = None
+        self: Entity, overrides: dict[str, Any] | IModel | None = None
     ) -> dict[str, Any]:
         # TODO: support field conversion and assignment updating
         # fields = to_json(self._model)
@@ -211,7 +202,7 @@ class ModelUpdateMixin(ABC, Generic[IModel]):
         (self._model, _) = self.api.retrieve(id=getattr(self, self._model_id_field))
         return self
 
-    def update(self: Entity, values: Union[dict[str, Any], IModel]) -> Self:
+    def update(self: Entity, values: dict[str, Any] | IModel) -> Self:
         """
         Commits model changes to the server
 
@@ -243,12 +234,12 @@ class _ExportMixin(Generic[_EntityT]):
         endpoint: Callable,
         filename: StrPath,
         *,
-        pbar: Optional[ProgressReporter] = None,
-        status_check_period: Optional[int] = None,
-        location: Optional[Location] = None,
-        cloud_storage_id: Optional[int] = None,
+        pbar: ProgressReporter | None = None,
+        status_check_period: int | None = None,
+        location: Location | None = None,
+        cloud_storage_id: int | None = None,
         **query_params,
-    ) -> Optional[Path]:
+    ) -> Path | None:
         query_params = {
             **query_params,
             **({"location": location} if location else {}),
@@ -314,12 +305,12 @@ class ExportDatasetMixin(_ExportMixin):
         format_name: str,
         filename: StrPath,
         *,
-        pbar: Optional[ProgressReporter] = None,
-        status_check_period: Optional[int] = None,
+        pbar: ProgressReporter | None = None,
+        status_check_period: int | None = None,
         include_images: bool = True,
-        location: Optional[Location] = None,
-        cloud_storage_id: Optional[int] = None,
-    ) -> Optional[Path]:
+        location: Location | None = None,
+        cloud_storage_id: int | None = None,
+    ) -> Path | None:
         """
         Export a dataset in the specified format (e.g. 'YOLO 1.1').
         By default, a result file will be downloaded based on the default configuration.
@@ -371,11 +362,11 @@ class DownloadBackupMixin(_ExportMixin):
         filename: StrPath,
         *,
         status_check_period: int = None,
-        pbar: Optional[ProgressReporter] = None,
-        location: Optional[str] = None,
-        cloud_storage_id: Optional[int] = None,
+        pbar: ProgressReporter | None = None,
+        location: str | None = None,
+        cloud_storage_id: int | None = None,
         lightweight: bool = False,
-    ) -> Optional[Path]:
+    ) -> Path | None:
         """
         Create a resource backup and download it locally or upload to a cloud storage.
         By default, a result file will be downloaded based on the default configuration.

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import io
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from cvat_sdk.api_client import apis, models
 from cvat_sdk.core.helpers import get_paginated_collection
@@ -49,9 +49,9 @@ class Project(
         format_name: str,
         filename: StrPath,
         *,
-        conv_mask_to_poly: Optional[bool] = None,
-        status_check_period: Optional[int] = None,
-        pbar: Optional[ProgressReporter] = None,
+        conv_mask_to_poly: bool | None = None,
+        status_check_period: int | None = None,
+        pbar: ProgressReporter | None = None,
     ):
         """
         Import dataset for a project in the specified format (e.g. 'YOLO 1.1').
@@ -111,8 +111,8 @@ class ProjectsRepo(
         dataset_path: str = "",
         dataset_format: str = "CVAT XML 1.1",
         status_check_period: int = None,
-        pbar: Optional[ProgressReporter] = None,
-        conv_mask_to_poly: Optional[bool] = None,
+        pbar: ProgressReporter | None = None,
+        conv_mask_to_poly: bool | None = None,
     ) -> Project:
         """
         Create a new project with the given name and labels JSON and
@@ -140,7 +140,7 @@ class ProjectsRepo(
         filename: StrPath,
         *,
         status_check_period: int = None,
-        pbar: Optional[ProgressReporter] = None,
+        pbar: ProgressReporter | None = None,
     ) -> Project:
         """
         Import a project from a backup file

--- a/cvat-sdk/cvat_sdk/core/proxies/tasks.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/tasks.py
@@ -12,7 +12,7 @@ import shutil
 from collections.abc import Sequence
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from PIL import Image
 
@@ -72,10 +72,10 @@ class Task(
         resources: Sequence[StrPath],
         *,
         resource_type: ResourceType = ResourceType.LOCAL,
-        pbar: Optional[ProgressReporter] = None,
-        params: Optional[dict[str, Any]] = None,
+        pbar: ProgressReporter | None = None,
+        params: dict[str, Any] | None = None,
         wait_for_completion: bool = True,
-        status_check_period: Optional[int] = None,
+        status_check_period: int | None = None,
     ) -> None:
         """
         Add local, remote, or shared files to an existing task.
@@ -151,9 +151,9 @@ class Task(
         format_name: str,
         filename: StrPath,
         *,
-        conv_mask_to_poly: Optional[bool] = None,
-        status_check_period: Optional[int] = None,
-        pbar: Optional[ProgressReporter] = None,
+        conv_mask_to_poly: bool | None = None,
+        status_check_period: int | None = None,
+        pbar: ProgressReporter | None = None,
     ):
         """
         Upload annotations for a task in the specified format (e.g. 'YOLO 1.1').
@@ -177,7 +177,7 @@ class Task(
         self,
         frame_id: int,
         *,
-        quality: Optional[str] = None,
+        quality: str | None = None,
     ) -> io.RawIOBase:
         params = {}
         if quality:
@@ -196,7 +196,7 @@ class Task(
         chunk_id: int,
         output_file: SupportsWrite[bytes],
         *,
-        quality: Optional[str] = None,
+        quality: str | None = None,
     ) -> None:
         params = {}
         if quality:
@@ -212,11 +212,11 @@ class Task(
         self,
         frame_ids: Sequence[int],
         *,
-        image_extension: Optional[str] = None,
+        image_extension: str | None = None,
         outdir: StrPath = ".",
         quality: str = "original",
         filename_pattern: str = "frame_{frame_id:06d}{frame_ext}",
-    ) -> Optional[list[Image.Image]]:
+    ) -> list[Image.Image] | None:
         """
         Download the requested frame numbers for a task and save images as outdir/filename_pattern
         """
@@ -285,11 +285,11 @@ class TasksRepo(
         resources: Sequence[StrPath],
         *,
         resource_type: ResourceType = ResourceType.LOCAL,
-        data_params: Optional[dict[str, Any]] = None,
+        data_params: dict[str, Any] | None = None,
         annotation_path: str = "",
         annotation_format: str = "CVAT XML 1.1",
         status_check_period: int = None,
-        pbar: Optional[ProgressReporter] = None,
+        pbar: ProgressReporter | None = None,
     ) -> Task:
         """
         Create a new task with the given name and labels JSON and
@@ -338,7 +338,7 @@ class TasksRepo(
         filename: StrPath,
         *,
         status_check_period: int = None,
-        pbar: Optional[ProgressReporter] = None,
+        pbar: ProgressReporter | None = None,
     ) -> Task:
         """
         Import a task from a backup file

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -11,7 +11,7 @@ import os
 from contextlib import AbstractContextManager
 from http import HTTPStatus
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 import urllib3
 
@@ -132,8 +132,8 @@ class Uploader:
         *,
         meta: dict[str, Any],
         query_params: dict[str, Any] = None,
-        fields: Optional[dict[str, Any]] = None,
-        pbar: Optional[ProgressReporter] = None,
+        fields: dict[str, Any] | None = None,
+        pbar: ProgressReporter | None = None,
         logger=None,
     ) -> urllib3.HTTPResponse:
         """
@@ -225,10 +225,10 @@ class AnnotationUploader(Uploader):
         filename: Path,
         format_name: str,
         *,
-        conv_mask_to_poly: Optional[bool] = None,
-        url_params: Optional[dict[str, Any]] = None,
-        pbar: Optional[ProgressReporter] = None,
-        status_check_period: Optional[int] = None,
+        conv_mask_to_poly: bool | None = None,
+        url_params: dict[str, Any] | None = None,
+        pbar: ProgressReporter | None = None,
+        status_check_period: int | None = None,
     ):
         url = self._client.api_map.make_endpoint_url(endpoint.path, kwsub=url_params)
         params = {"format": format_name, "filename": filename.name}
@@ -252,10 +252,10 @@ class DatasetUploader(Uploader):
         filename: Path,
         format_name: str,
         *,
-        url_params: Optional[dict[str, Any]] = None,
-        conv_mask_to_poly: Optional[bool] = None,
-        pbar: Optional[ProgressReporter] = None,
-        status_check_period: Optional[int] = None,
+        url_params: dict[str, Any] | None = None,
+        conv_mask_to_poly: bool | None = None,
+        pbar: ProgressReporter | None = None,
+        status_check_period: int | None = None,
     ):
         url = self._client.api_map.make_endpoint_url(upload_endpoint.path, kwsub=url_params)
         params = {"format": format_name, "filename": filename.name}
@@ -282,7 +282,7 @@ class DataUploader(Uploader):
         url: str,
         resources: list[Path],
         *,
-        pbar: Optional[ProgressReporter] = None,
+        pbar: ProgressReporter | None = None,
         **kwargs,
     ):
         bulk_file_groups, separate_files, total_size = self._split_files_by_requests(resources)

--- a/cvat-sdk/cvat_sdk/core/utils.py
+++ b/cvat-sdk/cvat_sdk/core/utils.py
@@ -8,7 +8,7 @@ import contextlib
 import itertools
 import os
 from collections.abc import Generator, Sequence
-from typing import IO, Any, BinaryIO, Literal, TextIO, Union, overload
+from typing import IO, Any, BinaryIO, Literal, TextIO, overload
 
 
 def filter_dict(
@@ -19,19 +19,19 @@ def filter_dict(
 
 @overload
 def atomic_writer(
-    path: Union[os.PathLike, str], mode: Literal["wb"]
+    path: os.PathLike | str, mode: Literal["wb"]
 ) -> contextlib.AbstractContextManager[BinaryIO]: ...
 
 
 @overload
 def atomic_writer(
-    path: Union[os.PathLike, str], mode: Literal["w"], encoding: str = "UTF-8"
+    path: os.PathLike | str, mode: Literal["w"], encoding: str = "UTF-8"
 ) -> contextlib.AbstractContextManager[TextIO]: ...
 
 
 @contextlib.contextmanager
 def atomic_writer(
-    path: Union[os.PathLike, str], mode: Literal["w", "wb"], encoding: str = "UTF-8"
+    path: os.PathLike | str, mode: Literal["w", "wb"], encoding: str = "UTF-8"
 ) -> Generator[IO, None, None]:
     """
     Returns a context manager that, when entered, returns a handle to a temporary

--- a/cvat-sdk/cvat_sdk/datasets/caching.py
+++ b/cvat-sdk/cvat_sdk/datasets/caching.py
@@ -9,7 +9,7 @@ from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Mapping
 from enum import Enum, auto
 from pathlib import Path
-from typing import Any, TypeVar, Union, cast
+from typing import Any, TypeVar, cast
 
 from attrs import define
 
@@ -52,7 +52,7 @@ class _CacheObjectModel(metaclass=ABCMeta):
     def load(cls, obj: _CacheObject): ...
 
 
-_ModelType = TypeVar("_ModelType", bound=Union[OpenApiModel, _CacheObjectModel])
+_ModelType = TypeVar("_ModelType", bound=OpenApiModel | _CacheObjectModel)
 
 
 class CacheManager(metaclass=ABCMeta):

--- a/cvat-sdk/cvat_sdk/datasets/common.py
+++ b/cvat-sdk/cvat_sdk/datasets/common.py
@@ -4,10 +4,8 @@
 
 import abc
 from enum import Enum, auto
-from typing import Optional
 
 import attrs
-import attrs.validators
 import PIL.Image
 
 import cvat_sdk.core
@@ -54,7 +52,7 @@ class Sample:
     frame_name: str
     """File name of the frame in its task."""
 
-    annotations: Optional[FrameAnnotations]
+    annotations: FrameAnnotations | None
     """
     Annotations belonging to the frame.
 

--- a/cvat-sdk/cvat_sdk/masks.py
+++ b/cvat-sdk/cvat_sdk/masks.py
@@ -4,13 +4,12 @@
 
 import math
 from collections.abc import Sequence
-from typing import Optional
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 
 
-def encode_mask(bitmap: ArrayLike, /, bbox: Optional[Sequence[float]] = None) -> list[float]:
+def encode_mask(bitmap: ArrayLike, /, bbox: Sequence[float] | None = None) -> list[float]:
     """
     Encodes an image mask into an array of numbers suitable for the "points"
     attribute of a LabeledShapeRequest object of type "mask".

--- a/cvat-sdk/cvat_sdk/pytorch/project_dataset.py
+++ b/cvat-sdk/cvat_sdk/pytorch/project_dataset.py
@@ -4,14 +4,12 @@
 
 import os
 from collections.abc import Callable, Container, Mapping
-from typing import Optional
 
 import torch
 import torch.utils.data
 import torchvision.datasets
 
 import cvat_sdk.core
-import cvat_sdk.core.exceptions
 import cvat_sdk.models as models
 from cvat_sdk.datasets.caching import UpdatePolicy, make_cache_manager
 from cvat_sdk.pytorch.task_dataset import TaskVisionDataset
@@ -37,12 +35,12 @@ class ProjectVisionDataset(torchvision.datasets.VisionDataset):
         client: cvat_sdk.core.Client,
         project_id: int,
         *,
-        transforms: Optional[Callable] = None,
-        transform: Optional[Callable] = None,
-        target_transform: Optional[Callable] = None,
+        transforms: Callable | None = None,
+        transform: Callable | None = None,
+        target_transform: Callable | None = None,
         label_name_to_index: Mapping[str, int] = None,
-        task_filter: Optional[Callable[[models.ITaskRead], bool]] = None,
-        include_subsets: Optional[Container[str]] = None,
+        task_filter: Callable[[models.ITaskRead], bool] | None = None,
+        include_subsets: Container[str] | None = None,
         update_policy: UpdatePolicy = UpdatePolicy.IF_MISSING_OR_STALE,
     ) -> None:
         """

--- a/cvat-sdk/cvat_sdk/pytorch/task_dataset.py
+++ b/cvat-sdk/cvat_sdk/pytorch/task_dataset.py
@@ -5,12 +5,10 @@
 import os
 import types
 from collections.abc import Callable, Mapping
-from typing import Optional
 
 import torchvision.datasets
 
 import cvat_sdk.core
-import cvat_sdk.core.exceptions
 from cvat_sdk.datasets.caching import UpdatePolicy, make_cache_manager
 from cvat_sdk.datasets.task_dataset import TaskDataset
 from cvat_sdk.pytorch.common import Target
@@ -44,9 +42,9 @@ class TaskVisionDataset(torchvision.datasets.VisionDataset):
         client: cvat_sdk.core.Client,
         task_id: int,
         *,
-        transforms: Optional[Callable] = None,
-        transform: Optional[Callable] = None,
-        target_transform: Optional[Callable] = None,
+        transforms: Callable | None = None,
+        transform: Callable | None = None,
+        target_transform: Callable | None = None,
         label_name_to_index: Mapping[str, int] = None,
         update_policy: UpdatePolicy = UpdatePolicy.IF_MISSING_OR_STALE,
     ) -> None:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a continuation of #10060.

I kept the old syntax in generator templates, because I can't run Ruff on them. The old syntax is not deprecated, so it shouldn't be a problem.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
