### PR TITLE
tests: use PEP 604 syntax for optionals/unions

### DIFF
--- a/tests/python/cli/util.py
+++ b/tests/python/cli/util.py
@@ -11,7 +11,7 @@ import threading
 import unittest
 from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import pytest
 import requests
@@ -22,7 +22,7 @@ from shared.utils.helpers import generate_image_file
 
 
 def run_cli(
-    test: Union[unittest.TestCase, Any],
+    test: unittest.TestCase | Any,
     *args: str,
     expected_code: int = 0,
 ) -> None:
@@ -121,7 +121,7 @@ class TestCliBase:
         cmd: str,
         *args: str,
         expected_code: int = 0,
-        organization: Optional[str] = None,
+        organization: str | None = None,
         authenticate: bool = True,
     ) -> str:
         common_args = [

--- a/tests/python/rest_api/_test_base.py
+++ b/tests/python/rest_api/_test_base.py
@@ -4,7 +4,6 @@ import os
 from collections.abc import Generator, Mapping, Sequence
 from contextlib import closing
 from functools import partial
-from typing import Optional
 
 import numpy as np
 import pytest
@@ -29,16 +28,16 @@ class TestTasksBase:
         self,
         request: pytest.FixtureRequest,
         *,
-        frame_count: Optional[int] = 10,
-        image_files: Optional[Sequence[io.BytesIO]] = None,
-        related_files: Optional[Mapping[int, Sequence[io.BytesIO]]] = None,
-        start_frame: Optional[int] = None,
-        stop_frame: Optional[int] = None,
-        step: Optional[int] = None,
-        segment_size: Optional[int] = None,
-        server_files: Optional[Sequence[str]] = None,
-        cloud_storage_id: Optional[int] = None,
-        job_replication: Optional[int] = None,
+        frame_count: int | None = 10,
+        image_files: Sequence[io.BytesIO] | None = None,
+        related_files: Mapping[int, Sequence[io.BytesIO]] | None = None,
+        start_frame: int | None = None,
+        stop_frame: int | None = None,
+        step: int | None = None,
+        segment_size: int | None = None,
+        server_files: Sequence[str] | None = None,
+        cloud_storage_id: int | None = None,
+        job_replication: int | None = None,
         **data_kwargs,
     ) -> Generator[tuple[ImagesTaskSpec, int], None, None]:
         task_params = {
@@ -125,7 +124,7 @@ class TestTasksBase:
     @parametrize("stop_frame", [15, 26])
     @parametrize("start_frame", [3, 7])
     def fxt_uploaded_images_task_with_segments_start_stop_step(
-        self, request: pytest.FixtureRequest, start_frame: int, stop_frame: Optional[int], step: int
+        self, request: pytest.FixtureRequest, start_frame: int, stop_frame: int | None, step: int
     ) -> Generator[tuple[ITaskSpec, int], None, None]:
         yield from self._image_task_fxt_base(
             request=request,
@@ -146,12 +145,12 @@ class TestTasksBase:
         self,
         request: pytest.FixtureRequest,
         *,
-        start_frame: Optional[int] = None,
-        step: Optional[int] = None,
+        start_frame: int | None = None,
+        step: int | None = None,
         random_seed: int = 42,
-        image_files: Optional[Sequence[io.BytesIO]] = None,
-        server_files: Optional[Sequence[str]] = None,
-        cloud_storage_id: Optional[int] = None,
+        image_files: Sequence[io.BytesIO] | None = None,
+        server_files: Sequence[str] | None = None,
+        cloud_storage_id: int | None = None,
         **kwargs,
     ) -> Generator[tuple[ITaskSpec, int], None, None]:
         validation_params = models.DataRequestValidationParams._from_openapi_data(
@@ -230,7 +229,7 @@ class TestTasksBase:
     @fixture(scope="class")
     @parametrize("start_frame, step", [(2, 3)])
     def fxt_uploaded_images_task_with_honeypots_and_segments_start_step(
-        self, request: pytest.FixtureRequest, start_frame: Optional[int], step: Optional[int]
+        self, request: pytest.FixtureRequest, start_frame: int | None, step: int | None
     ) -> Generator[tuple[ITaskSpec, int], None, None]:
         yield from self._image_task_with_honeypots_and_segments_base(
             request, start_frame=start_frame, step=step
@@ -321,10 +320,10 @@ class TestTasksBase:
         self,
         request: pytest.FixtureRequest,
         *,
-        start_frame: Optional[int] = None,
-        step: Optional[int] = None,
+        start_frame: int | None = None,
+        step: int | None = None,
         frame_selection_method: str = "random_uniform",
-        job_replication: Optional[int] = None,
+        job_replication: int | None = None,
     ) -> Generator[tuple[ITaskSpec, int], None, None]:
         used_frames_count = 16
         total_frame_count = (start_frame or 0) + used_frames_count * (step or 1)
@@ -491,8 +490,8 @@ class TestTasksBase:
     def fxt_uploaded_images_task_with_gt_and_segments_start_step(
         self,
         request: pytest.FixtureRequest,
-        start_frame: Optional[int],
-        step: Optional[int],
+        start_frame: int | None,
+        step: int | None,
         frame_selection_method: str,
     ) -> Generator[tuple[ITaskSpec, int], None, None]:
         yield from self._uploaded_images_task_with_gt_and_segments_base(
@@ -507,10 +506,10 @@ class TestTasksBase:
         request: pytest.FixtureRequest,
         *,
         frame_count: int = 10,
-        segment_size: Optional[int] = None,
-        start_frame: Optional[int] = None,
-        stop_frame: Optional[int] = None,
-        step: Optional[int] = None,
+        segment_size: int | None = None,
+        start_frame: int | None = None,
+        stop_frame: int | None = None,
+        step: int | None = None,
     ) -> Generator[tuple[VideoTaskSpec, int], None, None]:
         task_params = {
             "name": f"{request.node.name}[{request.fixturename}]",
@@ -569,7 +568,7 @@ class TestTasksBase:
     @parametrize("stop_frame", [15, 26])
     @parametrize("start_frame", [3, 7])
     def fxt_uploaded_video_task_with_segments_start_stop_step(
-        self, request: pytest.FixtureRequest, start_frame: int, stop_frame: Optional[int], step: int
+        self, request: pytest.FixtureRequest, start_frame: int, stop_frame: int | None, step: int
     ) -> Generator[tuple[ITaskSpec, int], None, None]:
         yield from self._uploaded_video_task_fxt_base(
             request=request,

--- a/tests/python/rest_api/test_auth.py
+++ b/tests/python/rest_api/test_auth.py
@@ -6,7 +6,6 @@ import json
 from collections.abc import Generator
 from contextlib import contextmanager
 from http import HTTPStatus
-from typing import Optional
 from unittest import mock
 
 import pytest
@@ -45,7 +44,7 @@ class TestTokenAuth:
 
     @classmethod
     @contextmanager
-    def make_client(cls, username: Optional[str] = None) -> Generator[ApiClient, None, None]:
+    def make_client(cls, username: str | None = None) -> Generator[ApiClient, None, None]:
         with ApiClient(Configuration(host=BASE_URL)) as api_client:
             if username:
                 cls.login(api_client, username)
@@ -124,7 +123,7 @@ class TestSessionAuth:
 
     @classmethod
     @contextmanager
-    def make_client(cls, username: Optional[str] = None) -> Generator[ApiClient, None, None]:
+    def make_client(cls, username: str | None = None) -> Generator[ApiClient, None, None]:
         with ApiClient(Configuration(host=BASE_URL)) as api_client:
             if username:
                 cls.login(api_client, username)
@@ -194,7 +193,7 @@ class TestSessionAuth:
 class TestAccessTokenAuth:
     @classmethod
     @contextmanager
-    def make_client(cls, *, token: Optional[str] = None) -> Generator[ApiClient, None, None]:
+    def make_client(cls, *, token: str | None = None) -> Generator[ApiClient, None, None]:
         with ApiClient(Configuration(host=BASE_URL)) as api_client:
             if token:
                 api_client.configuration.access_token = token

--- a/tests/python/rest_api/test_cloud_storages.py
+++ b/tests/python/rest_api/test_cloud_storages.py
@@ -7,7 +7,7 @@ import io
 import json
 from functools import partial
 from http import HTTPStatus
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from cvat_sdk.api_client import ApiClient, models
@@ -430,7 +430,7 @@ class TestGetCloudStorageContent:
     def _test_get_cloud_storage_content(
         self,
         cloud_storage_id: int,
-        manifest: Optional[str] = None,
+        manifest: str | None = None,
         **kwargs,
     ):
         with make_api_client(self.USER) as api_client:
@@ -641,11 +641,11 @@ class TestGetCloudStorageContent:
     def test_get_cloud_storage_content(
         self,
         cloud_storage_id: int,
-        manifest: Optional[str],
-        prefix: Optional[str],
-        default_bucket_prefix: Optional[str],
-        page_size: Optional[int],
-        expected_content: Optional[Any],
+        manifest: str | None,
+        prefix: str | None,
+        default_bucket_prefix: str | None,
+        page_size: int | None,
+        expected_content: Any | None,
         cloud_storages,
     ):
         if default_bucket_prefix:

--- a/tests/python/rest_api/test_consensus.py
+++ b/tests/python/rest_api/test_consensus.py
@@ -7,7 +7,7 @@ from copy import deepcopy
 from functools import partial
 from http import HTTPStatus
 from itertools import product
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 import urllib3
@@ -31,8 +31,8 @@ class _PermissionTestBase:
     def merge(
         self,
         *,
-        task_id: Optional[int] = None,
-        job_id: Optional[int] = None,
+        task_id: int | None = None,
+        job_id: int | None = None,
         user: str,
         raise_on_error: bool = True,
         wait_result: bool = True,
@@ -69,8 +69,8 @@ class _PermissionTestBase:
     def request_merge(
         self,
         *,
-        task_id: Optional[int] = None,
-        job_id: Optional[int] = None,
+        task_id: int | None = None,
+        job_id: int | None = None,
         user: str,
     ) -> str:
         response = self.merge(user=user, task_id=task_id, job_id=job_id, wait_result=False)
@@ -79,7 +79,7 @@ class _PermissionTestBase:
     @pytest.fixture
     def find_sandbox_task(self, tasks, jobs, users, is_task_staff):
         def _find(
-            is_staff: bool, *, has_consensus_jobs: Optional[bool] = None
+            is_staff: bool, *, has_consensus_jobs: bool | None = None
         ) -> tuple[dict[str, Any], dict[str, Any]]:
             task = next(
                 t
@@ -115,7 +115,7 @@ class _PermissionTestBase:
         self, restore_db_per_function, tasks, jobs, users, is_org_member, is_task_staff, admin_user
     ):
         def _find(
-            is_staff: bool, user_org_role: str, *, has_consensus_jobs: Optional[bool] = None
+            is_staff: bool, user_org_role: str, *, has_consensus_jobs: bool | None = None
         ) -> tuple[dict[str, Any], dict[str, Any]]:
             for user in users:
                 if user["is_superuser"]:
@@ -248,14 +248,10 @@ class TestPostConsensusMerge(_PermissionTestBase):
 
         assert "No annotated consensus jobs found for parent job" in capture.value.body
 
-    def _test_merge_200(
-        self, user: str, *, task_id: Optional[int] = None, job_id: Optional[int] = None
-    ):
+    def _test_merge_200(self, user: str, *, task_id: int | None = None, job_id: int | None = None):
         return self.merge(user=user, task_id=task_id, job_id=job_id)
 
-    def _test_merge_403(
-        self, user: str, *, task_id: Optional[int] = None, job_id: Optional[int] = None
-    ):
+    def _test_merge_403(self, user: str, *, task_id: int | None = None, job_id: int | None = None):
         response = self.merge(user=user, task_id=task_id, job_id=job_id, raise_on_error=False)
         assert response.status == HTTPStatus.FORBIDDEN
         return response
@@ -437,7 +433,7 @@ class TestSimpleConsensusSettingsFilters(CollectionSimpleFilterTestBase):
 
 class TestListSettings(_PermissionTestBase):
     def _test_list_settings_200(
-        self, user: str, task_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
+        self, user: str, task_id: int, *, expected_data: dict[str, Any] | None = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             actual = get_paginated_collection(
@@ -494,7 +490,7 @@ class TestListSettings(_PermissionTestBase):
 
 class TestGetSettings(_PermissionTestBase):
     def _test_get_settings_200(
-        self, user: str, obj_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
+        self, user: str, obj_id: int, *, expected_data: dict[str, Any] | None = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.consensus_api.retrieve_settings(obj_id, **kwargs)
@@ -556,7 +552,7 @@ class TestPatchSettings(_PermissionTestBase):
         obj_id: int,
         data: dict[str, Any],
         *,
-        expected_data: Optional[dict[str, Any]] = None,
+        expected_data: dict[str, Any] | None = None,
         **kwargs,
     ):
         with make_api_client(user) as api_client:

--- a/tests/python/rest_api/test_jobs.py
+++ b/tests/python/rest_api/test_jobs.py
@@ -15,7 +15,7 @@ from datetime import datetime
 from http import HTTPStatus
 from io import BytesIO
 from itertools import groupby, product
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pytest
@@ -544,7 +544,7 @@ class TestDeleteJobs:
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetJobs:
     def _test_get_job_200(
-        self, user, jid, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
+        self, user, jid, *, expected_data: dict[str, Any] | None = None, **kwargs
     ):
         with make_api_client(user) as client:
             (_, response) = client.jobs_api.retrieve(jid, **kwargs)
@@ -1450,7 +1450,7 @@ class TestJobDataset:
         *,
         local_download: bool = True,
         **kwargs,
-    ) -> Optional[bytes]:
+    ) -> bytes | None:
         dataset = export_job_dataset(username, save_images=True, id=jid, **kwargs)
         if local_download:
             assert zipfile.is_zipfile(io.BytesIO(dataset))
@@ -1462,7 +1462,7 @@ class TestJobDataset:
     @staticmethod
     def _test_export_annotations(
         username: str, jid: int, *, local_download: bool = True, **kwargs
-    ) -> Optional[bytes]:
+    ) -> bytes | None:
         dataset = export_job_dataset(username, save_images=False, id=jid, **kwargs)
         if local_download:
             assert zipfile.is_zipfile(io.BytesIO(dataset))

--- a/tests/python/rest_api/test_labels.py
+++ b/tests/python/rest_api/test_labels.py
@@ -7,7 +7,7 @@ import json
 from copy import deepcopy
 from http import HTTPStatus
 from types import SimpleNamespace
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from cvat_sdk import exceptions, models
@@ -69,7 +69,7 @@ class _TestLabelsPermissionsBase:
 
         return labels_by_source
 
-    def _get_source_info(self, source: str, *, org_id: Optional[int] = None):
+    def _get_source_info(self, source: str, *, org_id: int | None = None):
         if source == "task":
             sources = self.tasks_by_org
             is_source_staff = self.is_task_staff

--- a/tests/python/rest_api/test_organizations.py
+++ b/tests/python/rest_api/test_organizations.py
@@ -6,7 +6,6 @@
 import json
 from copy import deepcopy
 from http import HTTPStatus
-from typing import Optional
 
 import pytest
 from cvat_sdk.api_client.api_client import ApiClient, Endpoint
@@ -40,9 +39,9 @@ class TestMetadataOrganizations:
     )
     def test_can_send_options_request(
         self,
-        privilege: Optional[str],
-        role: Optional[str],
-        is_member: Optional[bool],
+        privilege: str | None,
+        role: str | None,
+        is_member: bool | None,
         find_users,
         organizations,
     ):
@@ -87,9 +86,9 @@ class TestGetOrganizations:
     )
     def test_can_see_specific_organization(
         self,
-        privilege: Optional[str],
-        role: Optional[str],
-        is_member: Optional[bool],
+        privilege: str | None,
+        role: str | None,
+        is_member: bool | None,
         is_allow: bool,
         find_users,
         organizations,
@@ -189,9 +188,9 @@ class TestPatchOrganizations:
     )
     def test_can_update_specific_organization(
         self,
-        privilege: Optional[str],
-        role: Optional[str],
-        is_member: Optional[bool],
+        privilege: str | None,
+        role: str | None,
+        is_member: bool | None,
         is_allow: bool,
         find_users,
         request_data,
@@ -241,9 +240,9 @@ class TestDeleteOrganizations:
     )
     def test_can_delete(
         self,
-        privilege: Optional[str],
-        role: Optional[str],
-        is_member: Optional[bool],
+        privilege: str | None,
+        role: str | None,
+        is_member: bool | None,
         is_allow: bool,
         find_users,
     ):

--- a/tests/python/rest_api/test_projects.py
+++ b/tests/python/rest_api/test_projects.py
@@ -17,7 +17,6 @@ from itertools import product
 from operator import itemgetter
 from os.path import basename
 from time import sleep
-from typing import Optional
 
 import allure
 import pytest
@@ -206,7 +205,7 @@ class TestGetPostProjectBackup:
         *,
         local_download: bool = True,
         **kwargs,
-    ) -> Optional[bytes]:
+    ) -> bytes | None:
         backup = export_project_backup(username, id=pid, **kwargs)
         if local_download:
             assert zipfile.is_zipfile(io.BytesIO(backup))
@@ -470,7 +469,7 @@ class TestPostProjects:
         return json.loads(response.data)
 
     @classmethod
-    def _create_org(cls, api_client: ApiClient, members: Optional[dict[str, str]] = None) -> str:
+    def _create_org(cls, api_client: ApiClient, members: dict[str, str] | None = None) -> str:
         with api_client:
             (_, response) = api_client.organizations_api.create(
                 models.OrganizationWriteRequest(slug="test_org_roles"), _parse_response=False
@@ -597,7 +596,7 @@ class TestImportExportDatasetProject:
         *,
         local_download: bool = True,
         **kwargs,
-    ) -> Optional[bytes]:
+    ) -> bytes | None:
         dataset = export_project_dataset(username, save_images=True, id=pid, **kwargs)
         if local_download:
             assert zipfile.is_zipfile(io.BytesIO(dataset))
@@ -609,7 +608,7 @@ class TestImportExportDatasetProject:
     @staticmethod
     def _test_export_annotations(
         username: str, pid: int, *, local_download: bool = True, **kwargs
-    ) -> Optional[bytes]:
+    ) -> bytes | None:
         dataset = export_project_dataset(username, save_images=False, id=pid, **kwargs)
         if local_download:
             assert zipfile.is_zipfile(io.BytesIO(dataset))
@@ -1564,8 +1563,8 @@ class TestPatchProject:
         projects,
         find_users,
     ):
-        project_id: Optional[int] = None
-        username: Optional[str] = None
+        project_id: int | None = None
+        username: str | None = None
 
         for project in projects:
             if project_id is not None:
@@ -1609,8 +1608,8 @@ class TestPatchProject:
         find_users,
         filter_projects,
     ):
-        username: Optional[str] = None
-        project_id: Optional[int] = None
+        username: str | None = None
+        project_id: int | None = None
 
         projects = filter_projects(organization=None)
         users = find_users(exclude_privilege="admin")

--- a/tests/python/rest_api/test_quality_control.py
+++ b/tests/python/rest_api/test_quality_control.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from functools import partial
 from http import HTTPStatus
 from itertools import groupby, product
-from typing import Any, Optional
+from typing import Any
 
 import pytest
 from cvat_sdk.api_client import exceptions, models
@@ -30,7 +30,7 @@ from .utils import (
 
 class _PermissionTestBase:
     def create_quality_report(
-        self, *, user: str, task_id: Optional[int] = None, project_id: Optional[int] = None
+        self, *, user: str, task_id: int | None = None, project_id: int | None = None
     ) -> dict:
         assert task_id is not None or project_id is not None
 
@@ -102,7 +102,7 @@ class _PermissionTestBase:
     @pytest.fixture(scope="class")
     def find_sandbox_task(self, tasks, jobs, users, is_task_staff):
         def _find(
-            is_staff: bool, *, has_gt_jobs: Optional[bool] = None
+            is_staff: bool, *, has_gt_jobs: bool | None = None
         ) -> tuple[dict[str, Any], dict[str, Any]]:
             task = next(
                 t
@@ -134,7 +134,7 @@ class _PermissionTestBase:
     @pytest.fixture(scope="class")
     def find_org_task(self, tasks, jobs, users, is_org_member, is_task_staff):
         def _find(
-            is_staff: bool, user_org_role: str, *, has_gt_jobs: Optional[bool] = None
+            is_staff: bool, user_org_role: str, *, has_gt_jobs: bool | None = None
         ) -> tuple[dict[str, Any], dict[str, Any]]:
             for user in users:
                 if user["is_superuser"]:
@@ -175,7 +175,7 @@ class _PermissionTestBase:
     @pytest.fixture(scope="class")
     def find_sandbox_project(self, projects, tasks, users, labels, is_project_staff):
         def _find(
-            is_staff: bool, has_gt_jobs: Optional[bool] = False
+            is_staff: bool, has_gt_jobs: bool | None = False
         ) -> tuple[dict[str, Any], dict[str, Any]]:
             project = next(
                 p
@@ -217,7 +217,7 @@ class _PermissionTestBase:
         is_project_staff,
     ):
         def _find(
-            is_staff: bool, user_org_role: str, has_gt_jobs: Optional[bool] = False
+            is_staff: bool, user_org_role: str, has_gt_jobs: bool | None = False
         ) -> tuple[dict[str, Any], dict[str, Any]]:
             project = None
 
@@ -428,7 +428,7 @@ class TestListQualityReports(_PermissionTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetQualityReports(_PermissionTestBase):
     def _test_get_report_200(
-        self, user: str, obj_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
+        self, user: str, obj_id: int, *, expected_data: dict[str, Any] | None = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.quality_api.retrieve_report(obj_id, **kwargs)
@@ -487,7 +487,7 @@ class TestGetQualityReports(_PermissionTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetQualityReportData(_PermissionTestBase):
     def _test_get_report_data_200(
-        self, user: str, obj_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
+        self, user: str, obj_id: int, *, expected_data: dict[str, Any] | None = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.quality_api.retrieve_report_data(obj_id, **kwargs)
@@ -1262,7 +1262,7 @@ class TestSimpleQualitySettingsFilters(CollectionSimpleFilterTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestListSettings(_PermissionTestBase):
     def _test_list_settings_200(
-        self, user: str, task_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
+        self, user: str, task_id: int, *, expected_data: dict[str, Any] | None = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             actual = get_paginated_collection(
@@ -1324,7 +1324,7 @@ class TestListSettings(_PermissionTestBase):
 @pytest.mark.usefixtures("restore_db_per_class")
 class TestGetSettings(_PermissionTestBase):
     def _test_get_settings_200(
-        self, user: str, obj_id: int, *, expected_data: Optional[dict[str, Any]] = None, **kwargs
+        self, user: str, obj_id: int, *, expected_data: dict[str, Any] | None = None, **kwargs
     ):
         with make_api_client(user) as api_client:
             (_, response) = api_client.quality_api.retrieve_settings(obj_id, **kwargs)
@@ -1391,7 +1391,7 @@ class TestPatchSettings(_PermissionTestBase):
         obj_id: int,
         data: dict[str, Any],
         *,
-        expected_data: Optional[dict[str, Any]] = None,
+        expected_data: dict[str, Any] | None = None,
         **kwargs,
     ):
         with make_api_client(user) as api_client:

--- a/tests/python/rest_api/test_requests.py
+++ b/tests/python/rest_api/test_requests.py
@@ -5,7 +5,6 @@
 import io
 import json
 from http import HTTPStatus
-from typing import Optional
 from urllib.parse import parse_qsl, urlparse
 
 import pytest
@@ -370,7 +369,7 @@ class TestGetRequests:
         *,
         action: str,
         target_type: str,
-        subresource: Optional[str] = None,
+        subresource: str | None = None,
     ):
         with make_api_client(username) as api_client:
             bg_requests, _ = api_client.requests_api.list(

--- a/tests/python/rest_api/test_resource_import_export.py
+++ b/tests/python/rest_api/test_resource_import_export.py
@@ -6,7 +6,7 @@
 from collections.abc import Callable
 from http import HTTPStatus
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 from uuid import uuid4
 
 import pytest
@@ -408,7 +408,7 @@ class TestUploads:
         users: Container,
         *,
         get_owner_func: Callable = lambda r: r["owner"],
-        user_to_skip: Optional[int] = None,
+        user_to_skip: int | None = None,
     ) -> tuple[dict, int]:
         for resource in resources:
             malefactor = get_owner_func(resource)
@@ -630,13 +630,13 @@ class TestUploads:
     )
     def test_user_can_use_only_own_uploads(
         self,
-        src_resource_id: Optional[int],
+        src_resource_id: int | None,
         archive_path: Path,
         owner: dict,
         malefactor: dict,
-        dst_resource_id: Optional[str],
+        dst_resource_id: str | None,
         endpoint_path: str,
-        query_params: Optional[dict],
+        query_params: dict | None,
     ):
         with (
             make_sdk_client(owner["username"]) as owner_client,

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -16,7 +16,7 @@ from http import HTTPStatus
 from itertools import chain, groupby, product
 from pathlib import Path
 from tempfile import TemporaryDirectory
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pytest
@@ -601,11 +601,11 @@ class TestPostTaskData:
         sorting_method: str = "lexicographical",
         data_type: str = "image",
         video_frame_count: int = 10,
-        server_files_exclude: Optional[list[str]] = None,
+        server_files_exclude: list[str] | None = None,
         org: str = "",
-        filenames: Optional[list[str]] = None,
-        task_spec_kwargs: Optional[dict[str, Any]] = None,
-        data_spec_kwargs: Optional[dict[str, Any]] = None,
+        filenames: list[str] | None = None,
+        task_spec_kwargs: dict[str, Any] | None = None,
+        data_spec_kwargs: dict[str, Any] | None = None,
     ) -> tuple[int, Any]:
         s3_client = s3.make_client(bucket=cloud_storage["resource"])
         if data_type == "video":
@@ -713,7 +713,7 @@ class TestPostTaskData:
         use_cache: bool,
         use_manifest: bool,
         server_files: list[str],
-        server_files_exclude: Optional[list[str]],
+        server_files_exclude: list[str] | None,
         task_size: int,
         org: str,
         cloud_storages,

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -22,7 +22,7 @@ from operator import itemgetter
 from pathlib import Path, PurePosixPath
 from tempfile import NamedTemporaryFile, TemporaryDirectory
 from time import sleep, time
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 import pytest
@@ -738,7 +738,7 @@ class TestGetTaskDataset:
         *,
         local_download: bool = True,
         **kwargs,
-    ) -> Optional[bytes]:
+    ) -> bytes | None:
         dataset = export_task_dataset(username, save_images=True, id=task_id, **kwargs)
         if local_download:
             assert zipfile.is_zipfile(io.BytesIO(dataset))
@@ -2735,8 +2735,8 @@ class TestPatchTask:
         is_allow = is_task_owner or is_project_owner
         has_project = is_project_owner or is_project_assignee
 
-        username: Optional[str] = None
-        task_id: Optional[int] = None
+        username: str | None = None
+        task_id: int | None = None
 
         filtered_users = (
             (find_users(role="worker") + find_users(role="supervisor"))
@@ -3135,7 +3135,7 @@ class TestImportTaskAnnotations:
         ],
     )
     def test_check_import_error_on_wrong_file_structure(
-        self, tasks_with_shapes: Iterable, format_name: str, specific_info_included: Optional[bool]
+        self, tasks_with_shapes: Iterable, format_name: str, specific_info_included: bool | None
     ):
         task_id = tasks_with_shapes[0]["id"]
 
@@ -4200,7 +4200,7 @@ class TestPatchExportFrames(TestTasksBase):
         media_type: SourceDataType,
         step: int,
         frame_count: int,
-        start_frame: Optional[int],
+        start_frame: int | None,
     ) -> Generator[tuple[ITaskSpec, Task, str], None, None]:
         args = dict(request=request, frame_count=frame_count, step=step, start_frame=start_frame)
 

--- a/tests/python/rest_api/test_users.py
+++ b/tests/python/rest_api/test_users.py
@@ -4,8 +4,8 @@
 # SPDX-License-Identifier: MIT
 
 import json
-import typing
 from http import HTTPStatus
+from typing import Literal
 
 import pytest
 from cvat_sdk.api_client.api_client import ApiClient, Endpoint
@@ -23,7 +23,7 @@ class TestGetUsers:
         self,
         user,
         data,
-        id_: typing.Union[typing.Literal["self"], int, None] = None,
+        id_: Literal["self"] | int | None = None,
         *,
         exclude_paths="",
         **kwargs,
@@ -45,9 +45,7 @@ class TestGetUsers:
 
         assert DeepDiff(data, response_data, ignore_order=True, exclude_paths=exclude_paths) == {}
 
-    def _test_cannot_see(
-        self, user, id_: typing.Union[typing.Literal["self"], int, None] = None, **kwargs
-    ):
+    def _test_cannot_see(self, user, id_: Literal["self"] | int | None = None, **kwargs):
         with make_api_client(user) as api_client:
             # TODO: refactor into several functions
             if id_ == "self":

--- a/tests/python/rest_api/utils.py
+++ b/tests/python/rest_api/utils.py
@@ -9,7 +9,7 @@ from copy import deepcopy
 from http import HTTPStatus
 from io import BytesIO
 from time import sleep
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, TypeAlias, TypeVar
 
 import requests
 from cvat_sdk.api_client import apis, models
@@ -102,7 +102,7 @@ def export_v2(
     wait_result: bool = True,
     download_result: bool = True,
     **kwargs,
-) -> Union[bytes, str]:
+) -> bytes | str:
     """Export datasets|annotations|backups using the second version of export API
 
     Args:
@@ -138,14 +138,14 @@ def export_v2(
 
 
 def export_dataset(
-    api: Union[ProjectsApi, TasksApi, JobsApi],
+    api: ProjectsApi | TasksApi | JobsApi,
     *,
     save_images: bool,
     max_retries: int = 300,
     interval: float = DEFAULT_INTERVAL,
     format: str = "CVAT for images 1.1",  # pylint: disable=redefined-builtin
     **kwargs,
-) -> Optional[bytes]:
+) -> bytes | None:
     return export_v2(
         api.create_dataset_export_endpoint,
         max_retries=max_retries,
@@ -158,38 +158,38 @@ def export_dataset(
 
 # FUTURE-TODO: support username: optional, api_client: optional
 # tODO: make func signature more userfrendly
-def export_project_dataset(username: str, *args, **kwargs) -> Optional[bytes]:
+def export_project_dataset(username: str, *args, **kwargs) -> bytes | None:
     with make_api_client(username) as api_client:
         return export_dataset(api_client.projects_api, *args, **kwargs)
 
 
-def export_task_dataset(username: str, *args, **kwargs) -> Optional[bytes]:
+def export_task_dataset(username: str, *args, **kwargs) -> bytes | None:
     with make_api_client(username) as api_client:
         return export_dataset(api_client.tasks_api, *args, **kwargs)
 
 
-def export_job_dataset(username: str, *args, **kwargs) -> Optional[bytes]:
+def export_job_dataset(username: str, *args, **kwargs) -> bytes | None:
     with make_api_client(username) as api_client:
         return export_dataset(api_client.jobs_api, *args, **kwargs)
 
 
 def export_backup(
-    api: Union[ProjectsApi, TasksApi],
+    api: ProjectsApi | TasksApi,
     *,
     max_retries: int = DEFAULT_RETRIES,
     interval: float = DEFAULT_INTERVAL,
     **kwargs,
-) -> Optional[bytes]:
+) -> bytes | None:
     endpoint = api.create_backup_export_endpoint
     return export_v2(endpoint, max_retries=max_retries, interval=interval, **kwargs)
 
 
-def export_project_backup(username: str, *args, **kwargs) -> Optional[bytes]:
+def export_project_backup(username: str, *args, **kwargs) -> bytes | None:
     with make_api_client(username) as api_client:
         return export_backup(api_client.projects_api, *args, **kwargs)
 
 
-def export_task_backup(username: str, *args, **kwargs) -> Optional[bytes]:
+def export_task_backup(username: str, *args, **kwargs) -> bytes | None:
     with make_api_client(username) as api_client:
         return export_backup(api_client.tasks_api, *args, **kwargs)
 
@@ -202,7 +202,7 @@ def import_resource(
     expect_forbidden: bool = False,
     wait_result: bool = True,
     **kwargs,
-) -> Optional[models.Request]:
+) -> models.Request | None:
     # initialize background process and ensure that the first request returns 403 code if request should be forbidden
     (_, response) = endpoint.call_with_http_info(
         **kwargs,
@@ -242,7 +242,7 @@ def import_resource(
 
 
 def import_backup(
-    api: Union[ProjectsApi, TasksApi],
+    api: ProjectsApi | TasksApi,
     *,
     max_retries: int = DEFAULT_RETRIES,
     interval: float = DEFAULT_INTERVAL,
@@ -293,7 +293,7 @@ def import_job_annotations(username: str, file_content: BytesIO, **kwargs):
         )
 
 
-FieldPath = Sequence[Union[str, Callable]]
+FieldPath: TypeAlias = Sequence[str | Callable]
 
 
 class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
@@ -312,7 +312,7 @@ class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
             return get_paginated_collection(self._get_endpoint(api_client), **kwargs)
 
     @classmethod
-    def _get_field(cls, d: dict[str, Any], path: Union[str, FieldPath]) -> Optional[Any]:
+    def _get_field(cls, d: dict[str, Any], path: str | FieldPath) -> Any | None:
         assert path
         for key in path:
             if isinstance(d, dict):
@@ -367,7 +367,7 @@ class CollectionSimpleFilterTestBase(metaclass=ABCMeta):
         assert diff == {}, diff
 
     def _test_can_use_simple_filter_for_object_list(
-        self, field: str, field_values: Optional[list[Any]] = None
+        self, field: str, field_values: list[Any] | None = None
     ):
         gt_objects = []
         field_path = self._map_field(field)
@@ -517,7 +517,7 @@ _T2 = TypeVar("_T2")
 
 
 def unique(
-    it: Union[Iterator[_T], Iterable[_T]], *, key: Callable[[_T], Hashable] = None
+    it: Iterator[_T] | Iterable[_T], *, key: Callable[[_T], Hashable] = None
 ) -> Iterable[_T]:
     return {key(v): v for v in it}.values()
 
@@ -558,8 +558,8 @@ def get_cloud_storage_content(
     username: str,
     cloud_storage_id: int,
     *,
-    manifest: Optional[str] = None,
-    prefix: Optional[str] = None,
+    manifest: str | None = None,
+    prefix: str | None = None,
 ) -> list[str]:
     kwargs = {}
 
@@ -585,7 +585,7 @@ def export_events(
     max_retries: int = 100,
     interval: float = 0.1,
     **kwargs,
-) -> Optional[bytes]:
+) -> bytes | None:
     if api_version == 1:
         endpoint = api_client.events_api.list_endpoint
         query_id = ""
@@ -628,7 +628,7 @@ def export_events(
 
 
 def iter_exclude(
-    it: Iterable[_T], excludes: Iterable[_T2], *, key: Optional[Callable[[_T], _T2]] = None
+    it: Iterable[_T], excludes: Iterable[_T2], *, key: Callable[[_T], _T2] | None = None
 ) -> Iterable[_T]:
     excludes = set(excludes)
 

--- a/tests/python/sdk/common.py
+++ b/tests/python/sdk/common.py
@@ -4,7 +4,7 @@
 import io
 import zipfile
 from pathlib import Path
-from typing import Optional, Union
+from typing import TypeAlias
 
 import pytest
 from cvat_sdk.core.proxies.jobs import Job
@@ -19,7 +19,7 @@ from shared.utils.s3 import make_client as make_s3_client
 
 from .util import make_pbar
 
-ProjectOrTaskOrJob = Union[Project, Task, Job]
+ProjectOrTaskOrJob: TypeAlias = Project | Task | Job
 
 
 class TestDatasetExport:
@@ -59,7 +59,7 @@ class TestDatasetExport:
         format_name: str,
         file_path: Path,
         include_images: bool,
-        location: Optional[Location],
+        location: Location | None,
         request: pytest.FixtureRequest,
         cloud_storages: CloudStorageAssets,
     ):

--- a/tests/python/sdk/test_jobs.py
+++ b/tests/python/sdk/test_jobs.py
@@ -5,7 +5,6 @@
 import io
 from logging import Logger
 from pathlib import Path
-from typing import Optional
 
 import pytest
 from cvat_sdk import Client
@@ -133,7 +132,7 @@ class TestJobUsecases(TestDatasetExport):
         format_name: str,
         include_images: bool,
         task: Task,
-        location: Optional[Location],
+        location: Location | None,
         request: pytest.FixtureRequest,
         cloud_storages: CloudStorageAssets,
     ):

--- a/tests/python/sdk/test_progress.py
+++ b/tests/python/sdk/test_progress.py
@@ -4,7 +4,6 @@
 
 import io
 import warnings
-from typing import Optional
 
 import tqdm
 from cvat_sdk.core.helpers import DeferredTqdmProgressReporter, TqdmProgressReporter
@@ -57,7 +56,7 @@ def test_deferred_tqdm_reporter():
 
 class _LegacyProgressReporter(ProgressReporter):
     # overriding start instead of start2
-    def start(self, total: int, *, desc: Optional[str] = None) -> None:
+    def start(self, total: int, *, desc: str | None = None) -> None:
         self.total = total
         self.desc = desc
         self.progress = 0

--- a/tests/python/sdk/test_projects.py
+++ b/tests/python/sdk/test_projects.py
@@ -5,7 +5,6 @@
 import io
 from logging import Logger
 from pathlib import Path
-from typing import Optional
 
 import pytest
 from cvat_sdk import Client, models
@@ -288,7 +287,7 @@ class TestProjectUsecases(TestDatasetExport):
         format_name: str,
         include_images: bool,
         project: Project,
-        location: Optional[Location],
+        location: Location | None,
         request: pytest.FixtureRequest,
         cloud_storages: CloudStorageAssets,
     ):

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -7,7 +7,6 @@ import os.path as osp
 import zipfile
 from logging import Logger
 from pathlib import Path
-from typing import Optional
 
 import pytest
 from cvat_sdk import Client, models
@@ -303,7 +302,7 @@ class TestTaskUsecases(TestDatasetExport):
         format_name: str,
         include_images: bool,
         task: Task,
-        location: Optional[Location],
+        location: Location | None,
         request: pytest.FixtureRequest,
         cloud_storages: CloudStorageAssets,
     ):
@@ -395,7 +394,7 @@ class TestTaskUsecases(TestDatasetExport):
     @pytest.mark.parametrize("quality", ("compressed", "original"))
     @pytest.mark.parametrize("image_extension", (None, "bmp"))
     def test_can_download_frames(
-        self, fxt_new_task: Task, quality: str, image_extension: Optional[str]
+        self, fxt_new_task: Task, quality: str, image_extension: str | None
     ):
         fxt_new_task.download_frames(
             [0],

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -10,7 +10,6 @@ from http import HTTPStatus
 from pathlib import Path
 from subprocess import PIPE, CalledProcessError, run
 from time import sleep
-from typing import Union
 
 import pytest
 import requests
@@ -159,20 +158,20 @@ def docker_exec(container, command, capture_output=True):
     return _run(f"docker exec -u root {PREFIX}_{container}_1 {command}", capture_output)
 
 
-def docker_exec_cvat(command: Union[list[str], str]):
+def docker_exec_cvat(command: list[str] | str):
     base = f"docker exec {PREFIX}_cvat_server_1"
     _command = f"{base} {command}" if isinstance(command, str) else base.split() + command
     return _run(_command)
 
 
-def kube_exec_cvat(command: Union[list[str], str]):
+def kube_exec_cvat(command: list[str] | str):
     pod_name = _kube_get_server_pod_name()
     base = f"kubectl exec {pod_name} --"
     _command = f"{base} {command}" if isinstance(command, str) else base.split() + command
     return _run(_command)
 
 
-def container_exec_cvat(request: pytest.FixtureRequest, command: Union[list[str], str]):
+def container_exec_cvat(request: pytest.FixtureRequest, command: list[str] | str):
     platform = request.config.getoption("--platform")
     if platform == "local":
         return docker_exec_cvat(command)

--- a/tests/python/shared/tasks/base.py
+++ b/tests/python/shared/tasks/base.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-from typing import Any, Union
+from typing import Any
 
 import attrs
 from cvat_sdk.api_client import models
@@ -13,8 +13,8 @@ from shared.tasks.utils import parse_frame_step
 
 @attrs.define
 class TaskSpecBase(ITaskSpec):
-    _params: Union[dict, models.TaskWriteRequest]
-    _data_params: Union[dict, models.DataRequest]
+    _params: dict | models.TaskWriteRequest
+    _data_params: dict | models.DataRequest
     size: int = attrs.field(kw_only=True)
 
     @property

--- a/tests/python/shared/tasks/types.py
+++ b/tests/python/shared/tasks/types.py
@@ -5,7 +5,7 @@
 import io
 from collections.abc import Callable
 from contextlib import closing
-from typing import ClassVar, Optional
+from typing import ClassVar
 
 import attrs
 from PIL import Image
@@ -34,7 +34,7 @@ class ImagesTaskSpec(TaskSpecBase):
     source_data_type: ClassVar[SourceDataType] = SourceDataType.images
 
     _get_frame: Callable[[int], bytes] = attrs.field(kw_only=True)
-    get_related_files: Optional[Callable[[int], dict[str, bytes]]] = attrs.field(
+    get_related_files: Callable[[int], dict[str, bytes]] | None = attrs.field(
         kw_only=True, default=None
     )
 

--- a/tests/python/shared/utils/config.py
+++ b/tests/python/shared/utils/config.py
@@ -5,7 +5,6 @@
 from collections.abc import Generator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
 
 import requests
 from cvat_sdk.api_client import ApiClient, Configuration
@@ -72,10 +71,10 @@ def server_get(username, endpoint, **kwargs):
 
 
 def make_api_client(
-    user: Optional[str] = None,
+    user: str | None = None,
     *,
-    password: Optional[str] = None,
-    access_token: Optional[str] = None,
+    password: str | None = None,
+    access_token: str | None = None,
 ) -> ApiClient:
     assert (
         sum([bool(access_token), bool(user)]) <= 1

--- a/tests/python/shared/utils/helpers.py
+++ b/tests/python/shared/utils/helpers.py
@@ -6,7 +6,6 @@ import subprocess
 from collections.abc import Generator
 from contextlib import closing
 from io import BytesIO
-from typing import Optional
 
 import av
 import av.video.reformatter
@@ -28,9 +27,9 @@ def generate_image_file(filename="image.png", size=(100, 50), color=(0, 0, 0)):
 def generate_image_files(
     count: int,
     *,
-    prefixes: Optional[list[str]] = None,
-    filenames: Optional[list[str]] = None,
-    sizes: Optional[list[tuple[int, int]]] = None,
+    prefixes: list[str] | None = None,
+    filenames: list[str] | None = None,
+    sizes: list[tuple[int, int]] | None = None,
 ) -> list[BytesIO]:
     assert not (prefixes and filenames), "prefixes cannot be used together with filenames"
     assert not prefixes or len(prefixes) == count

--- a/tests/python/shared/utils/s3.py
+++ b/tests/python/shared/utils/s3.py
@@ -3,7 +3,6 @@
 # SPDX-License-Identifier: MIT
 
 from io import BytesIO
-from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -13,7 +12,7 @@ from shared.utils.config import MINIO_ENDPOINT_URL, MINIO_KEY, MINIO_SECRET_KEY
 
 class S3Client:
     def __init__(
-        self, endpoint_url: str, *, access_key: str, secret_key: str, bucket: Optional[str] = None
+        self, endpoint_url: str, *, access_key: str, secret_key: str, bucket: str | None = None
     ) -> None:
         self.client = self._make_boto_client(
             endpoint_url=endpoint_url, access_key=access_key, secret_key=secret_key
@@ -30,17 +29,17 @@ class S3Client:
         )
         return s3.meta.client
 
-    def create_file(self, filename: str, data: bytes = b"", *, bucket: Optional[str] = None):
+    def create_file(self, filename: str, data: bytes = b"", *, bucket: str | None = None):
         bucket = bucket or self.bucket
         assert bucket
         self.client.put_object(Body=data, Bucket=bucket, Key=filename)
 
-    def remove_file(self, filename: str, *, bucket: Optional[str] = None):
+    def remove_file(self, filename: str, *, bucket: str | None = None):
         bucket = bucket or self.bucket
         assert bucket
         self.client.delete_object(Bucket=bucket, Key=filename)
 
-    def file_exists(self, filename: str, *, bucket: Optional[str] = None) -> bool:
+    def file_exists(self, filename: str, *, bucket: str | None = None) -> bool:
         bucket = bucket or self.bucket
         assert bucket
         try:
@@ -52,7 +51,7 @@ class S3Client:
             else:
                 raise
 
-    def download_fileobj(self, key: str, *, bucket: Optional[str] = None) -> bytes:
+    def download_fileobj(self, key: str, *, bucket: str | None = None) -> bytes:
         bucket = bucket or self.bucket
         assert bucket
         with BytesIO() as data:
@@ -60,7 +59,7 @@ class S3Client:
             return data.getvalue()
 
 
-def make_client(*, bucket: Optional[str] = None) -> S3Client:
+def make_client(*, bucket: str | None = None) -> S3Client:
     return S3Client(
         endpoint_url=MINIO_ENDPOINT_URL,
         access_key=MINIO_KEY,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a continuation of #10060.

I also added a couple of `TypeAlias` annotations where appropriate, and changed the import style in `test_users.py` to be more consistent with other files.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
