### PR TITLE
Fix QC keypoints matching when bbox IoU is zero

### DIFF
--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -1083,8 +1083,11 @@ class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
     def distance(self, a: dm.Points, b: dm.Points) -> float:
         a_bbox = self.instance_map[id(a)][1]
         b_bbox = self.instance_map[id(b)][1]
-        if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
-            return 0
+
+    # Skip bbox IoU gating for sparse / degenerate point cases
+        if a_bbox is not None and b_bbox is not None:
+            if datumaro.util.annotation_util.bbox_iou(a_bbox, b_bbox) <= 0:
+                pass  # intentionally do nothing for keypoints
 
         bbox = datumaro.util.annotation_util.mean_bbox([a_bbox, b_bbox])
         return oks(
@@ -1095,6 +1098,9 @@ class KeypointsMatcher(datumaro.components.annotations.matcher.PointsMatcher):
             visibility_a=[v == dm.Points.Visibility.visible for v in a.visibility],
             visibility_b=[v == dm.Points.Visibility.visible for v in b.visibility],
         )
+
+
+
 
 
 def _arr_div(a_arr: np.ndarray, b_arr: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
Fix QC keypoints matching when bbox IoU is zero
Related issue
Fixes  #9957


<!-- Provide a general summary of your changes in the Title above -->

This PR fixes incorrect quality control matching for keypoints and skeletons in corner cases.

Previously, keypoint matching was blocked by an early return when bounding box IoU was zero. This caused valid matches to be rejected for sparse annotations, single visible points, or nearly parallel structures.

The fix removes the bbox IoU hard gate for keypoints while preserving bbox usage for OKS scale computation.

Changes:
Removed early return 0 based on bbox IoU in KeypointsMatcher.distance
Always allow OKS-based comparison for keypoints
Keeps existing bbox logic for scale normalization


Reproduction:
Create GT and regular jobs with sparse or single-point keypoints
Run Quality Control
Observe false negatives before this fix
Observe correct matching after this fix

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.

Notes for reviewers:
This change is limited to keypoints matching only
No behavior change for boxes, polygons, or masks
Performance impact is negligible
