### PR TITLE
Remove `settings.TUS_DEFAULT_CHUNK_SIZE`

### DIFF
--- a/changelog.d/20251211_121925_roman_rm_default_chunk_size.md
+++ b/changelog.d/20251211_121925_roman_rm_default_chunk_size.md
@@ -1,0 +1,5 @@
+### Changed
+
+- \[Server API\] TUS upload endpoints no longer accept requests with no
+  `Content-Length` header
+  (<https://github.com/cvat-ai/cvat/pull/10098>)

--- a/cvat/apps/engine/tus.py
+++ b/cvat/apps/engine/tus.py
@@ -15,6 +15,7 @@ from uuid import UUID, uuid4
 
 import attrs
 from django.conf import settings
+from rest_framework import serializers
 
 from cvat.apps.engine.log import ServerLogManager
 from cvat.apps.engine.types import ExtendedRequest
@@ -37,7 +38,12 @@ class TusTooLargeFileError(Exception):
 class TusChunk:
     def __init__(self, request: ExtendedRequest):
         self.offset = int(request.META.get("HTTP_UPLOAD_OFFSET", 0))
-        self.size = int(request.META.get("CONTENT_LENGTH", settings.TUS_DEFAULT_CHUNK_SIZE))
+
+        try:
+            self.size = int(request.META["CONTENT_LENGTH"])
+        except KeyError as ex:
+            raise serializers.ValidationError("Content-Length header is missing") from ex
+
         self.content = request.body
 
 

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -597,7 +597,6 @@ CORS_ALLOW_HEADERS = list(default_headers) + [
 ]
 
 TUS_MAX_FILE_SIZE = 26843545600  # 25gb
-TUS_DEFAULT_CHUNK_SIZE = 104857600  # 100 mb
 
 # This setting makes request secure if X-Forwarded-Proto: 'https' header is specified by our proxy
 # More about forwarded headers - https://doc.traefik.io/traefik/getting-started/faq/#what-are-the-forwarded-headers-when-proxying-http-requests


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
The way it's used doesn't really make sense. It's used as the default value for request `Content-Length`, but there's no particular reason why a request without a `Content-Length` would have exactly 100MB of data in it.

Moreover, I don't think we should be processing requests without a `Content-Length` at all. This can only happen in two cases:

1. A request with an empty body (and no explicit length). This is useless for TUS PATCH requests, so we don't need to support it.

2. A request that uses `Transfer-Encoding: chunked`. This could potentially be handled; however, such requests can currently not reach Django, because Nginx is configured to buffer incoming request bodies (which means it will always remove the `Transfer-Encoding` from the forwarded request).

   Also, neither the UI nor the SDK will send such requests, so the usefulness of supporting this would be quite limited.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
