### PR TITLE
Add explicit TypeAlias annotations

### DIFF
--- a/cvat/apps/access_tokens/permissions.py
+++ b/cvat/apps/access_tokens/permissions.py
@@ -8,7 +8,7 @@ import re
 from collections.abc import Sequence
 from pathlib import Path
 from types import NoneType
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, TypeAlias
 
 from attrs import frozen
 from django.conf import settings
@@ -143,7 +143,7 @@ class PluginInfo:
     original_package: str
 
 
-PluginCollection = dict[str, list[PluginInfo]]
+PluginCollection: TypeAlias = dict[str, list[PluginInfo]]
 
 
 class AccessTokenPermissionPluginManager:

--- a/cvat/apps/consensus/intersect_merge.py
+++ b/cvat/apps/consensus/intersect_merge.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import itertools
 from abc import ABCMeta, abstractmethod
 from collections.abc import Collection, Iterable, Sequence
-from typing import ClassVar
+from typing import ClassVar, TypeAlias
 
 import attrs
 import datumaro as dm
@@ -143,7 +143,7 @@ class LabelMatcher(AnnotationMatcher):
         return [list(itertools.chain.from_iterable(sources))]
 
 
-CacheKey = tuple[int, int]
+CacheKey: TypeAlias = tuple[int, int]
 
 
 @attrs.define

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -17,7 +17,7 @@ from collections.abc import Callable, Collection, Generator, Iterator, Sequence
 from contextlib import ExitStack, closing
 from datetime import datetime, timezone
 from itertools import groupby, pairwise
-from typing import Any, overload
+from typing import Any, TypeAlias, overload
 
 import attrs
 import av
@@ -62,8 +62,8 @@ from utils.dataset_manifest import ImageManifestManager
 slogger = ServerLogManager(__name__)
 
 
-DataWithMime = tuple[io.BytesIO, str]
-_CacheItem = tuple[io.BytesIO, str, int, datetime | None]
+DataWithMime: TypeAlias = tuple[io.BytesIO, str]
+_CacheItem: TypeAlias = tuple[io.BytesIO, str, int, datetime | None]
 
 
 class CacheTooLargeDataError(Exception):

--- a/cvat/apps/engine/filters.py
+++ b/cvat/apps/engine/filters.py
@@ -8,7 +8,7 @@ import operator
 from collections.abc import Iterable, Iterator
 from functools import reduce
 from textwrap import dedent
-from typing import Any
+from typing import Any, TypeAlias
 
 from django.db import models
 from django.db.models import Q
@@ -118,7 +118,7 @@ class FilterParsingError(Exception):
 
 
 class JsonLogicFilter(filters.BaseFilterBackend):
-    Rules = dict[str, Any]
+    Rules: TypeAlias = dict[str, Any]
     filter_param = "filter"
     filter_title = _("Filter")
     filter_description = _(

--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -20,7 +20,7 @@ from dataclasses import dataclass
 from enum import IntEnum
 from fractions import Fraction
 from random import shuffle
-from typing import Any, ClassVar, Protocol, TypedDict, TypeVar
+from typing import Any, ClassVar, Protocol, TypeAlias, TypedDict, TypeVar
 
 import av
 import av.codec
@@ -1036,7 +1036,7 @@ class Mpeg4ChunkWriter(IChunkWriter):
 
         return video_stream
 
-    FrameDescriptor = tuple[av.VideoFrame, Any, Any]
+    FrameDescriptor: TypeAlias = tuple[av.VideoFrame, Any, Any]
 
     def _peek_first_frame(
         self, frame_iter: Iterator[FrameDescriptor]

--- a/cvat/apps/engine/model_utils.py
+++ b/cvat/apps/engine/model_utils.py
@@ -5,7 +5,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable, Sequence
-from typing import TypeVar, Union
+from typing import TypeAlias, TypeVar
 
 from django.conf import settings
 from django.db import models
@@ -17,7 +17,7 @@ class Undefined:
     pass
 
 
-MaybeUndefined = Union[_T, Undefined]
+MaybeUndefined: TypeAlias = _T | Undefined
 """
 Can be used to annotate dynamic class members that may be undefined in the object.
 Such fields should typically be accessed via hasattr() and getattr().

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -14,7 +14,7 @@ from contextlib import closing
 from copy import deepcopy
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, NamedTuple
+from typing import Any, NamedTuple, TypeAlias
 from urllib import parse as urlparse
 from urllib import request as urlrequest
 
@@ -57,7 +57,7 @@ from .cloud_provider import HeaderFirstMediaDownloader, db_storage_to_storage_in
 
 slogger = ServerLogManager(__name__)
 
-JobFileMapping = list[list[str]]
+JobFileMapping: TypeAlias = list[list[str]]
 
 class SegmentParams(NamedTuple):
     start_frame: int

--- a/cvat/apps/iam/permissions.py
+++ b/cvat/apps/iam/permissions.py
@@ -11,7 +11,7 @@ from collections.abc import Sequence
 from enum import Enum
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeAlias, TypeVar
 
 from attrs import define, field
 from django.apps import AppConfig
@@ -84,7 +84,7 @@ def get_membership(request, organization):
     ).first()
 
 
-IamContext = dict[str, Any]
+IamContext: TypeAlias = dict[str, Any]
 
 
 def build_iam_context(

--- a/cvat/apps/quality_control/quality_reports.py
+++ b/cvat/apps/quality_control/quality_reports.py
@@ -13,7 +13,7 @@ from contextlib import suppress
 from copy import deepcopy
 from functools import cached_property, lru_cache, partial
 from io import StringIO
-from typing import Any, ClassVar, TypeVar, cast
+from typing import Any, ClassVar, TypeAlias, TypeVar, cast
 
 import datumaro as dm
 import datumaro.components.annotations.matcher
@@ -969,11 +969,11 @@ class _MemoizingAnnotationConverter(CvatToDmAnnotationConverter):
 
 _ShapeT1 = TypeVar("_ShapeT1")
 _ShapeT2 = TypeVar("_ShapeT2")
-ShapeSimilarityFunction = Callable[
+ShapeSimilarityFunction: TypeAlias = Callable[
     [_ShapeT1, _ShapeT2], float
 ]  # (shape1, shape2) -> [0; 1], returns 0 for mismatches, 1 for matches
-LabelEqualityFunction = Callable[[_ShapeT1, _ShapeT2], bool]
-SegmentMatchingResult = tuple[
+LabelEqualityFunction: TypeAlias = Callable[[_ShapeT1, _ShapeT2], bool]
+SegmentMatchingResult: TypeAlias = tuple[
     list[tuple[_ShapeT1, _ShapeT2]],  # matches
     list[tuple[_ShapeT1, _ShapeT2]],  # mismatches
     list[_ShapeT1],  # a unmatched


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This helps typecheckers disambiguate between value assignments and type aliases, as described in PEP 613.

Also remove one last `Union` that I somehow missed before.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
