### PR TITLE
handle chunk_size parameter in task factory for e2e tests

### DIFF
--- a/tests/cypress/support/default-specs.js
+++ b/tests/cypress/support/default-specs.js
@@ -14,6 +14,7 @@ function defaultTaskSpec({
     segmentSize,
     validationParams,
     projectID,
+    chunkSize,
 }) {
     const convertedAttrs = [];
     if (attributes !== undefined) {
@@ -38,6 +39,9 @@ function defaultTaskSpec({
 
     if (segmentSize) {
         taskSpec.segment_size = segmentSize;
+    }
+    if (chunkSize) {
+        taskSpec.data_chunk_size = chunkSize;
     }
 
     const dataSpec = {


### PR DESCRIPTION
### Motivation and context
Update e2e util `defaultTaskSpec` to handle TasksAPI's `chunk_size` parameter. 
This is needed to test features related to UI pre-loading of client media.


### How has this been tested?
confirmed by checking that request `GET tasks/data/meta` contains `data_chunk_size` that was sent in the test launch.
refactoring pr, tests should pass


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
