### PR TITLE
Ensure dropdown is visible before clicking in e2e consensus

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1880,9 +1880,8 @@ Cypress.Commands.add('mergeConsensusJob', (jobID, status = 202) => {
         .filter(`:contains("Job #${jobID}")`)
         .find('.anticon-more').first().click();
 
-    cy.get('.ant-dropdown-menu')
-        .should('exist').and('be.visible')
-        .contains('li', 'Merge consensus job')
+    cy.get('.ant-dropdown-menu').should('exist').and('be.visible')
+        .contains('li', 'Merge consensus job').should('exist').and('be.visible')
         .click({ scrollBehavior: 'center' });
     cy.get('.cvat-modal-confirm-consensus-merge-job')
         .contains('button', 'Merge')


### PR DESCRIPTION
### Motivation and context

On 00:30, the replica dropdown disappears before clicking on Merge Consensus Job.  This happens sporadically, e.g. [here](https://github.com/cvat-ai/cvat/actions/runs/20246081265/job/58130815807)

https://github.com/user-attachments/assets/1c7b5f25-2b3b-407b-a72e-89bcf4acbf1f

Scrolling into view before clicking should fix this. Adding UI assertions should expose the problem if it persists

### How has this been tested?

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
