### PR TITLE
Fix bulk actions progress bar test

### DIFF
--- a/tests/cypress/e2e/features/bulk_actions.js
+++ b/tests/cypress/e2e/features/bulk_actions.js
@@ -206,6 +206,8 @@ context('Bulk actions in UI', () => {
         });
 
         it('Delete all tasks, ensure deletion', () => {
+            cy.intercept('DELETE', '/api/tasks/**').as('deleteTask');
+
             getBulkActionsMenu().within(() => {
                 cy.contains(`Delete (${numberOfObjects})`).click();
             });
@@ -213,11 +215,15 @@ context('Bulk actions in UI', () => {
             cy.get('.cvat-modal-confirm-delete-task')
                 .should('be.visible').within(() => {
                     cy.contains(`Delete ${numberOfObjects} selected tasks`);
-                    cy.contains('Delete selected')
-                        .should('be.visible')
-                        .click();
                 });
-            cy.get('.cvat-bulk-progress-wrapper').should('be.visible');
+            cy.contains('Delete selected')
+                .should('be.visible')
+                .click();
+            cy.wait('@deleteTask').then(() => {
+                cy.get('.cvat-bulk-progress-wrapper').should('be.visible');
+            });
+            cy.wait('@deleteTask');
+
             cy.get('.cvat-tasks-list-item').each(($el) => {
                 cy.wrap($el)
                     .invoke('attr', 'style')


### PR DESCRIPTION
The progress bar appears and disappears very quickly when bulk deleting, occasionally leading to cypress still looking for the progress bar. This adds an intercept to the first request in the batch so that cypress doesn't miss it


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
