### PR TITLE
Use `container.decode` instead of `container.demux`

### DIFF
--- a/tests/python/shared/utils/helpers.py
+++ b/tests/python/shared/utils/helpers.py
@@ -83,9 +83,8 @@ def read_video_file(file: BytesIO) -> Generator[Image.Image, None, None]:
     with av.open(file) as container:
         video_stream = container.streams.video[0]
 
-        for packet in container.demux(video_stream):
-            for frame in packet.decode():
-                yield frame.to_image()
+        for frame in container.decode(video_stream):
+            yield frame.to_image()
 
 
 def generate_manifest(path: str) -> None:


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is a helper method that pretty much just wraps the double loop over the packets and the frames in a packet. Using it makes the code simpler and enables better type inference in IDEs, because the PyAV type stubs are sufficient to infer that `container.decode(video_stream)` returns an `Iterable[VideoFrame]` (whereas `packet.decode()` is declared to return `list[SubtitleSet]` for some reason).

Also, add some imports and type annotations to ensure that the IDEs have types to infer _from_.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
