### PR TITLE
e2e consensus fix: scroll on 'more' button

### DIFF
--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1881,7 +1881,6 @@ Cypress.Commands.add('mergeConsensusJob', (jobID, status = 202) => {
     cy.intercept('POST', '/api/consensus/merges**').as('mergeJob');
     getJobItemMoreButton().scrollIntoView();
     getJobItemMoreButton().click();
-    // test commit
 
     cy.get('.cvat-job-item-menu').should('exist').and('be.visible');
     cy.contains('li', 'Merge consensus job').should('exist').and('be.visible')


### PR DESCRIPTION
### Motivation and context

#10129 applied the scrolling to the dropdown instead of the 'more' menu, this PR fixes it
If this happens again, we would just scroll explicitly before `cy.get('.ant-dropdown')...`

### How has this been tested?


### Checklist

- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
