### PR TITLE
Improve typing of `RandomAccessIterator`

### DIFF
--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -152,28 +152,27 @@ class RandomAccessIterator(Iterator[_T]):
         self.iterator: Iterator[_T] | None = None
         self.pos: int = -1
 
-    def __iter__(self):
-        return self
-
-    def __next__(self):
+    def __next__(self) -> _T:
         return self[self.pos + 1]
 
-    def __getitem__(self, idx: int) -> _T | None:
+    def __getitem__(self, idx: int) -> _T:
         assert 0 <= idx
         if self.iterator is None or idx <= self.pos:
             self.reset()
-        v = None
-        while self.pos < idx:
+
+        while True:
             # NOTE: don't keep the last item in self, it can be expensive
             v = next(self.iterator)
             self.pos += 1
-        return v
 
-    def reset(self):
+            if self.pos == idx:
+                return v
+
+    def reset(self) -> None:
         self.close()
         self.iterator = iter(self.iterable)
 
-    def close(self):
+    def close(self) -> None:
         if self.iterator is not None:
             if close := getattr(self.iterator, "close", None):
                 close()


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
AFAICS, `__getitem__` cannot actually return `None`. Rearrange the body to convince the typechecker of that and update the type annotations.

Add return type annotations to other methods as well.

Remove `__iter__`, since it's a mixin method provided by `Iterator` for free.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
