### PR TITLE
Fix video manifests getting ignored during task creation

### DIFF
--- a/changelog.d/20251226_144915_roman.md
+++ b/changelog.d/20251226_144915_roman.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- When creating a task, manifest files uploaded alongside videos are no longer ignored
+  (<https://github.com/cvat-ai/cvat/pull/10162>)

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -1048,7 +1048,7 @@ def create_thread(
                     update_status('Validating the input manifest file')
 
                     manifest = VideoManifestValidator(
-                        source_path=os.path.join(upload_dir, media_files[0]),
+                        source_path=upload_dir / media_files[0],
                         manifest_path=db_data.get_manifest_path()
                     )
                     manifest.init_index()


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
`VideoManifestValidator` expects an `Openable` as the `source_path`, but here a string is passed. This would normally crash, but it's inside a `try...except` block that suppresses all exceptions, so what actually happens is that every time a video is uploaded together with a manifest, that manifest is ignored and CVAT tries to generate a new one.

This error handling should probably be improved, but for now, just restore intended functionality.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
