### PR TITLE
Prevent potential text overflow on Requests page

### DIFF
--- a/cvat-ui/src/components/requests-page/styles.scss
+++ b/cvat-ui/src/components/requests-page/styles.scss
@@ -111,3 +111,14 @@
         transform: translate(-50%, -50%);
     }
 }
+/* Defensive fix: prevent text overflow on Requests page */
+.cvat-requests-page {
+  .cvat-resource-list-wrapper {
+    min-width: 0; // allow flex children to shrink properly
+  }
+
+  .cvat-resource-list-wrapper * {
+    overflow-wrap: anywhere;
+    word-break: break-word;
+  }
+}


### PR DESCRIPTION
### Problem
Request list layout may overflow on smaller screens or with long
request descriptions.

Resolved #10158

### Solution
- Enabled flex item shrinking
- Added safe text wrapping

### Testing
- Verified Requests page rendering
- Tested resizing and pagination
