### PR TITLE
Stop replacing quote characters with "&quot;" in the raw label editor

### DIFF
--- a/changelog.d/20260119_182947_roman_stop_escaping_quotes.md
+++ b/changelog.d/20260119_182947_roman_stop_escaping_quotes.md
@@ -1,0 +1,5 @@
+### Fixed
+
+- In the raw label editor, double quote characters inside SVG strings are no
+  longer displayed as "\&quot;"
+  (<https://github.com/cvat-ai/cvat/pull/10198>)

--- a/cvat-ui/src/components/labels-editor/common.ts
+++ b/cvat-ui/src/components/labels-editor/common.ts
@@ -130,7 +130,7 @@ export function validateParsedLabel(label: SerializedLabel): void {
         const sublabelIds = label.sublabels
             .map((sublabel: SerializedLabel) => sublabel.id)
             .filter((sublabelId: number | undefined) => sublabelId !== undefined);
-        const matches = label.svg.matchAll(/data-label-id=&quot;([\d]+)&quot;/g);
+        const matches = label.svg.matchAll(/data-label-id="([\d]+)"/g);
         for (const match of matches) {
             const refersToId = +match[1];
             if (!sublabelIds.includes(refersToId)) {

--- a/cvat-ui/src/components/labels-editor/raw-viewer.tsx
+++ b/cvat-ui/src/components/labels-editor/raw-viewer.tsx
@@ -42,11 +42,11 @@ function transformSkeletonSVG(value: string): string {
         return value;
     }
 
-    const matches = data.matchAll(/data-label-id=&quot;([\d]+)&quot;/g);
+    const matches = data.matchAll(/data-label-id=\\"([\d]+)\\"/g);
     for (const match of matches) {
         if (idNameMapping[match[1]]) {
             data = data.replace(
-                match[0], `data-label-name=&quot;${idNameMapping[match[1]]}&quot;`,
+                match[0], `data-label-name=\\"${idNameMapping[match[1]]}\\"`,
             );
         }
     }
@@ -90,7 +90,6 @@ function convertLabels(labels: LabelOptColor[]): LabelOptColor[] {
         (label: LabelOptColor): LabelOptColor => ({
             ...label,
             id: (label.id as number) < 0 ? undefined : label.id,
-            svg: label.svg ? label.svg.replaceAll('"', '&quot;') : undefined,
             attributes: label.attributes.map(
                 (attribute: any): SerializedAttribute => ({
                     ...attribute,
@@ -127,9 +126,6 @@ export default class RawViewer extends React.PureComponent<Props> {
         const labelIds: number[] = [];
         const attrIds: number[] = [];
         for (const label of parsed) {
-            if (label.svg) {
-                label.svg = label.svg.replaceAll('&quot;', '"');
-            }
             label.id = label.id || idGenerator();
             if (label.id >= 0) {
                 labelIds.push(label.id);


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This behavior is confusing, because the SVG string displayed in the editor is not what actually gets sent to the server. In fact, since the UI replaces, e.g. `x1="0"` with `x1=&quot;0&quot;`, it's not even valid XML.

While the editor undoes the transformation before saving, it seems unnecessary to do the transformation in the first place.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I checked that:

1. SVG strings are correctly displayed in the raw editor.
2. The code that checks that `data-label-id` is valid still works as expected.
3. The code that replaces `data-label-id` with `data-label-name` upon pasting also works as expected.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
