### PR TITLE
SegmentFrameProvider: don't depend on the specific VideoReader class

### DIFF
--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -141,19 +141,13 @@ class IFrameProvider(metaclass=ABCMeta):
             raise RuntimeError(f"Failed to encode image to '{ext}' format")
         return BytesIO(result.tobytes())
 
-    def _convert_frame(
-        self, frame: Any, reader_class: type[IMediaReader], out_type: FrameOutputType
-    ) -> AnyFrame:
+    def _convert_frame(self, frame: Any, out_type: FrameOutputType) -> AnyFrame:
         if out_type == FrameOutputType.BUFFER:
-            return (
-                self._av_frame_to_png_bytes(frame)
-                if issubclass(reader_class, VideoReader)
-                else frame
-            )
+            return self._av_frame_to_png_bytes(frame) if isinstance(frame, av.VideoFrame) else frame
         elif out_type == FrameOutputType.PIL:
-            return frame.to_image() if issubclass(reader_class, VideoReader) else Image.open(frame)
+            return frame.to_image() if isinstance(frame, av.VideoFrame) else Image.open(frame)
         elif out_type == FrameOutputType.NUMPY_ARRAY:
-            if issubclass(reader_class, VideoReader):
+            if isinstance(frame, av.VideoFrame):
                 image = frame.to_ndarray(format="bgr24")
             else:
                 image = np.array(Image.open(frame))
@@ -339,7 +333,7 @@ class TaskFrameProvider(IFrameProvider):
                 ):
                     continue
 
-                frame, frame_name, _ = segment_frame_provider._get_raw_frame(
+                frame, frame_name = segment_frame_provider._get_raw_frame(
                     task_chunk_frames_with_rel_numbers[task_chunk_frame_id], quality=quality
                 )
                 task_chunk_frames[task_chunk_frame_id] = (frame, frame_name, None)
@@ -601,12 +595,12 @@ class SegmentFrameProvider(IFrameProvider):
         frame_number: int,
         *,
         quality: models.FrameQuality = models.FrameQuality.ORIGINAL,
-    ) -> tuple[Any, str, type[IMediaReader]]:
+    ) -> tuple[Any, str]:
         _, chunk_number, frame_offset = self.validate_frame_number(frame_number)
         loader = self._loaders[quality]
         chunk_reader = loader.load(chunk_number)
         frame, frame_name, _ = chunk_reader[frame_offset]
-        return frame, frame_name, loader.reader_class
+        return frame, frame_name
 
     def get_frame(
         self,
@@ -617,13 +611,16 @@ class SegmentFrameProvider(IFrameProvider):
     ) -> DataWithMeta[AnyFrame]:
         return_type = DataWithMeta[AnyFrame]
 
-        frame, frame_name, reader_class = self._get_raw_frame(frame_number, quality=quality)
+        frame, frame_name = self._get_raw_frame(frame_number, quality=quality)
 
-        frame = self._convert_frame(frame, reader_class, out_type)
-        if issubclass(reader_class, VideoReader):
-            return return_type(frame, mime=self.VIDEO_FRAME_MIME)
+        if isinstance(frame, av.VideoFrame):
+            mime = self.VIDEO_FRAME_MIME
+        else:
+            mime = mimetypes.guess_type(frame_name)[0]
 
-        return return_type(frame, mime=mimetypes.guess_type(frame_name)[0])
+        frame = self._convert_frame(frame, out_type)
+
+        return return_type(frame, mime=mime)
 
     def get_frame_context_images_chunk(
         self,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
It seems that it's far simpler to check the type of the frame itself rather than the type of the reader.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
