### PR TITLE
Work around many typing errors by asserting that Task.data is not None

### DIFF
--- a/cvat/apps/dataset_manager/task.py
+++ b/cvat/apps/dataset_manager/task.py
@@ -489,7 +489,7 @@ class JobAnnotation:
         if not isinstance(data, AnnotationIR):
             data = AnnotationIR(self.db_job.segment.task.dimension, data)
 
-        db_data = self.db_job.segment.task.data
+        db_data = self.db_job.segment.task.require_data()
 
         if data.tracks and db_data.validation_mode == models.ValidationMode.GT_POOL:
             # Only tags and shapes can be used in tasks with GT pool
@@ -939,7 +939,7 @@ class TaskAnnotation:
         if gt_job is None:
             raise AssertionError(f"Can't find GT job in the task {self.db_task.id}")
 
-        db_data = self.db_task.data
+        db_data = self.db_task.require_data()
         frame_step = db_data.get_frame_step()
 
         def _to_rel_frame(abs_frame: int) -> int:

--- a/cvat/apps/engine/cache.py
+++ b/cvat/apps/engine/cache.py
@@ -581,7 +581,7 @@ class MediaCache:
     def read_raw_images(
         db_task: models.Task, frame_ids: Sequence[int], *, decode: bool = True
     ) -> Generator[tuple[PIL.Image.Image | str, str, str], None, None]:
-        db_data = db_task.data
+        db_data = db_task.require_data()
         manifest_path = db_data.get_manifest_path()
 
         if os.path.isfile(manifest_path) and db_data.storage == models.StorageChoice.CLOUD_STORAGE:
@@ -768,7 +768,7 @@ class MediaCache:
                 prev_frame <= cur_frame
             ), f"Requested frame ids must be sorted, got a ({prev_frame}, {cur_frame}) pair"
 
-        db_data = db_task.data
+        db_data = db_task.require_data()
 
         if hasattr(db_data, "video"):
             source_path = os.path.join(db_data.get_raw_data_dirname(), db_data.video.path)
@@ -822,7 +822,7 @@ class MediaCache:
         self, db_segment: models.Segment, chunk_number: int, *, quality: models.FrameQuality
     ) -> DataWithMime:
         db_task = db_segment.task
-        db_data = db_task.data
+        db_data = db_task.require_data()
 
         chunk_size = db_data.chunk_size
         chunk_frame_ids = list(db_segment.frame_set)[
@@ -842,7 +842,7 @@ class MediaCache:
         self, db_segment: models.Segment, chunk_number: int, *, quality: models.FrameQuality
     ) -> DataWithMime:
         db_task = db_segment.task
-        db_data = db_task.data
+        db_data = db_task.require_data()
 
         chunk_size = db_data.chunk_size
         chunk_frame_ids = sorted(db_segment.frame_set)[
@@ -866,7 +866,7 @@ class MediaCache:
         if isinstance(db_task, int):
             db_task = models.Task.objects.get(pk=db_task)
 
-        db_data = db_task.data
+        db_data = db_task.require_data()
 
         frame_step = db_data.get_frame_step()
 
@@ -1102,7 +1102,7 @@ def prepare_chunk(
 ) -> DataWithMime:
     # TODO: refactor all chunk building into another class
 
-    db_data = db_task.data
+    db_data = db_task.require_data()
 
     writer_classes: dict[models.FrameQuality, type[IChunkWriter]] = {
         models.FrameQuality.COMPRESSED: (

--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -258,7 +258,7 @@ class TaskFrameProvider(IFrameProvider):
         if cached_chunk:
             return return_type(cached_chunk[0], cached_chunk[1])
 
-        db_data = self._db_task.data
+        db_data = self._db_task.require_data()
         step = db_data.get_frame_step()
         task_chunk_start_frame = chunk_number * db_data.chunk_size
         task_chunk_stop_frame = (chunk_number + 1) * db_data.chunk_size - 1
@@ -464,7 +464,7 @@ class SegmentFrameProvider(IFrameProvider):
         super().__init__()
         self._db_segment = db_segment
 
-        db_data = db_segment.task.data
+        db_data = db_segment.task.require_data()
 
         reader_class: dict[models.DataChoice, tuple[type[IMediaReader], dict | None]] = {
             models.DataChoice.IMAGESET: (ZipReader, None),
@@ -628,7 +628,7 @@ class SegmentFrameProvider(IFrameProvider):
     ) -> DataWithMeta[BytesIO] | None:
         self.validate_frame_number(frame_number)
 
-        db_data = self._db_segment.task.data
+        db_data = self._db_segment.task.require_data()
 
         cache = MediaCache()
         if db_data.storage_method == models.StorageMethodChoice.CACHE:
@@ -692,7 +692,7 @@ class JobFrameProvider(SegmentFrameProvider):
         if cached_chunk:
             return return_type(cached_chunk[0], cached_chunk[1])
 
-        db_data = self._db_segment.task.data
+        db_data = self._db_segment.task.require_data()
         step = db_data.get_frame_step()
         task_chunk_start_frame = chunk_number * db_data.chunk_size
         task_chunk_stop_frame = (chunk_number + 1) * db_data.chunk_size - 1

--- a/cvat/apps/engine/models.py
+++ b/cvat/apps/engine/models.py
@@ -670,6 +670,10 @@ class Task(TimestampedModel, AssignableModel, FileSystemRelatedModel):
             return True
         return self.segment_set.prefetch_related('job_set').filter(job__assignee=user_id).count() > 0
 
+    def require_data(self) -> Data:
+        assert self.data is not None
+        return self.data
+
     @cached_property
     def completed_jobs_count(self) -> int | None:
         # Requires this field to be defined externally,

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -1152,11 +1152,11 @@ class JobValidationLayoutWriteSerializer(serializers.Serializer):
         db_job = instance
         db_segment = db_job.segment
         db_task = db_segment.task
-        db_data = db_task.data
+        db_data = db_task.require_data()
 
         if not (
-            hasattr(db_job.segment.task.data, 'validation_layout') and
-            db_job.segment.task.data.validation_layout.mode == models.ValidationMode.GT_POOL
+            hasattr(db_data, 'validation_layout') and
+            db_data.validation_layout.mode == models.ValidationMode.GT_POOL
         ):
             raise serializers.ValidationError(
                 "Honeypots can only be modified if the task "
@@ -1420,7 +1420,7 @@ class JobValidationLayoutWriteSerializer(serializers.Serializer):
         initial_chunks_updated_date = db_segment.chunks_updated_date
         db_task = db_segment.task
         task_frame_provider = TaskFrameProvider(db_task)
-        db_data = db_task.data
+        db_data = db_task.require_data()
 
         def _iterate_chunk_frames():
             for chunk_frame in chunk_frames:
@@ -1477,7 +1477,7 @@ class JobValidationLayoutReadSerializer(serializers.Serializer):
             db_segment = instance.segment
             segment_frame_set = db_segment.frame_set
 
-            db_data = db_segment.task.data
+            db_data = db_segment.task.require_data()
             frame_step = db_data.get_frame_step()
 
             def _to_rel_frame(abs_frame: int) -> int:
@@ -3076,7 +3076,7 @@ class JobDataMetaWriteSerializer(serializers.ModelSerializer):
     def update(self, instance: models.Job, validated_data: dict[str, Any]) -> models.Job:
         db_segment = instance.segment
         db_task = db_segment.task
-        db_data = db_task.data
+        db_data = db_task.require_data()
 
         deleted_frames = validated_data['deleted_frames']
 

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -619,7 +619,7 @@ def create_thread(
         db_task, data, is_backup_restore=is_backup_restore
     )
 
-    db_data = db_task.data
+    db_data = db_task.require_data()
     upload_dir = db_data.get_upload_dirname() if db_data.storage != models.StorageChoice.SHARE else settings.SHARE_ROOT
     is_data_in_cloud = db_data.storage == models.StorageChoice.CLOUD_STORAGE
 
@@ -1611,7 +1611,7 @@ def _create_static_chunks(db_task: models.Task, *, media_extractor: IMediaReader
 
         fs_original.result()
 
-    db_data = db_task.data
+    db_data = db_task.require_data()
 
     if db_data.compressed_chunk_type == models.DataChoice.VIDEO:
         compressed_chunk_writer_class = Mpeg4CompressedChunkWriter

--- a/cvat/apps/engine/tests/test_rest_api.py
+++ b/cvat/apps/engine/tests/test_rest_api.py
@@ -3956,7 +3956,7 @@ class TaskDataAPITestCase(ApiTestBase):
             self.assertEqual(expected_compressed_type, task["data_compressed_chunk_type"])
             self.assertEqual(expected_original_type, task["data_original_chunk_type"])
             self.assertEqual(len(expected_image_sizes), task["size"])
-            db_data = Task.objects.get(pk=task_id).data
+            db_data = Task.objects.get(pk=task_id).require_data()
             self.assertEqual(expected_storage_method, db_data.storage_method)
             self.assertEqual(expected_uploaded_data_location, db_data.storage)
             # check if used share without copying inside and files doesn`t exist in ../raw/ and exist in share


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
There are many places in the code where a task's data is assumed to be created, but the typechecker doesn't know about it, and produces an error every time `db_data.something` is accessed. These errors are annoying and can obscure real typing issues.

Work around this by adding a task method that returns a guaranteed `Data` object (by asserting that `data` is not None), and use this method where it is appropriate.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
