### PR TITLE
Handle `None` paths in `ZipCompressedChunkWriter.save_as_chunk`

### DIFF
--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -940,7 +940,7 @@ class ZipChunkWriter(IChunkWriter):
 class ZipCompressedChunkWriter(ZipChunkWriter):
     def save_as_chunk(
         self,
-        images: Iterator[tuple[Image.Image | io.IOBase | str, str, str]],
+        images: Iterator[tuple[Image.Image | io.IOBase | str, str | None, str]],
         chunk_path: str | io.IOBase,
         *,
         compress_frames: bool = True,
@@ -953,6 +953,9 @@ class ZipCompressedChunkWriter(ZipChunkWriter):
                         try:
                             image_buf = self._compress_image(image, self._image_quality)
                         except Exception as ex:
+                            if path is None:
+                                raise
+
                             raise RuntimeError(
                                 f"Exception occurred during compression of image {os.path.basename(path)!r}"
                             ) from ex
@@ -964,6 +967,7 @@ class ZipCompressedChunkWriter(ZipChunkWriter):
                     if isinstance(image, io.BytesIO):
                         image_buf, extension = self._write_pcd_file(image)
                     else:
+                        assert path is not None
                         image_buf, extension = self._write_pcd_file(path)
 
                 arcname = "{:06d}.{}".format(idx, extension)


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
When `MediaCache.prepare_custom_masked_range_segment_chunk` calls `save_as_chunk`, it passes an iterator of tuples where the second element is `None`. Therefore, `save_as_chunk` must handle this case.

The only real problem is the `os.path.basename` call inside the exception handler. Change the logic so that it doesn't happen when `path` is `None`.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
