### PR TITLE
Fix a typing problem in VideoReader

### DIFF
--- a/cvat/apps/engine/media_extractors.py
+++ b/cvat/apps/engine/media_extractors.py
@@ -258,7 +258,7 @@ class IMediaReader(ABC):
         self._dimension = dimension
 
     @abstractmethod
-    def __iter__(self):
+    def __iter__(self) -> Iterator[tuple[Any, str | None, Any]]:
         pass
 
     @abstractmethod
@@ -614,7 +614,7 @@ class VideoReader(IMediaReader):
         self,
         *,
         frame_filter: bool | Iterable[int] = True,
-    ) -> Iterator[tuple[av.VideoFrame, str, int]]:
+    ) -> Iterator[tuple[av.VideoFrame, None, int]]:
         """
         If provided, frame_filter must be an ordered sequence in the ascending order.
         'True' means using the frames configured in the reader object.
@@ -654,14 +654,14 @@ class VideoReader(IMediaReader):
                     if self._frame_size is None:
                         self._frame_size = (frame.width, frame.height)
 
-                    yield (frame, self._source_path, frame.pts)
+                    yield (frame, None, frame.pts)
 
                     next_frame_filter_frame = next(frame_filter_iter, None)
 
                 if next_frame_filter_frame is None:
                     return
 
-    def __iter__(self) -> Iterator[tuple[av.VideoFrame, str, int]]:
+    def __iter__(self) -> Iterator[tuple[av.VideoFrame, None, int]]:
         return self.iterate_frames()
 
     def get_progress(self, pos):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
`iterate_frames` is supposed to return tuples with `str` as the second element. However, what it _actually_ returns is `self._source_path`, which has the type `str | BytesIO`.

As far as I can tell, this doesn't cause any runtime problems. The `BytesIO` case only occurs when `VideoReader` is used to read a chunk, and in all code paths where this happens, the second tuple element is ignored.

Moreover, even when `self._source_path` is a string, it's not used for much. The only place I found where the second tuple element is used is when `ZipCompressedChunkWriter` uses it to add context to exceptions. But this context isn't really needed when the source is a video, and the message used is clearly intended for individual images rather than videos.

So I think it's appropriate to always return `None` instead of the video path. `ZipCompressedChunkWriter` can already handle `None` values.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
