### PR TITLE
Fix WebGL issue in 3d e2e tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -357,29 +357,12 @@ jobs:
             (( max_tries-- ))
           done
 
-      # - name: DEBUG, Start Xvfb
-      #   run: |
-      #     export DISPLAY=':99.0'
-      #     Xvfb :99 -screen 0 1920x1080x24 &
-
-      # - name: Install Mesa drivers
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y mesa-utils libgl1-mesa-dri
-
-      # - name: DEBUG, run tmate
-      #   uses: mxschmitt/action-tmate@v3
-      #   with:
-      #     limit-access-to-actor: true
-
       - name: Run E2E tests
         env:
           DJANGO_SU_NAME: 'admin'
           DJANGO_SU_EMAIL: 'admin@localhost.company'
           DJANGO_SU_PASSWORD: '12qwaszx'
 
-        # debug stmt to launch only 3d tests
-        if: ${{ startsWith(matrix.specs, 'canvas3d_') }}
         run: |
           docker exec -i cvat_server /bin/bash -c "echo \"from django.contrib.auth.models import User; User.objects.create_superuser('${DJANGO_SU_NAME}', '${DJANGO_SU_EMAIL}', '${DJANGO_SU_PASSWORD}')\" | python3 ~/manage.py shell"
           cd ./tests

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -97,6 +97,9 @@ module.exports = (on, config) => {
             if (browser.isHeadless) {
                 launchOptions.args.push('--disable-gpu');
             }
+            // fix 'Error creating WebGL context'
+            // which started after Chromium 144
+            // https://chromium.googlesource.com/chromium/src/+/refs/heads/main/docs/gpu/swiftshader.md
             launchOptions.args.push('--enable-unsafe-swiftshader');
         }
         return launchOptions;


### PR DESCRIPTION
### Motivation and context

Suddenly, we've been getting e2e test failures in tests connected to 3d functionality.
Cypress runner crashed with exception 'Error WebGL context could not be created'

The issues lied most probably in a Chrome bug that led to tests acting up with cypress using `--disable-gpu` by default.
`SwitfShader` software implementation helped preserve WebGL acceleration but send it to CPU instead of GPU

### How has this been tested?

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
