### PR TITLE
`frame_provider.py`: refactor chunk reader creation

### DIFF
--- a/cvat/apps/engine/frame_provider.py
+++ b/cvat/apps/engine/frame_provider.py
@@ -37,18 +37,18 @@ from cvat.apps.engine.utils import take_by
 
 _T = TypeVar("_T")
 
+_ReaderFactory: TypeAlias = Callable[[BytesIO], IMediaReader]
+
 
 class _ChunkLoader(metaclass=ABCMeta):
     def __init__(
         self,
-        reader_class: type[IMediaReader],
         *,
-        reader_params: dict | None = None,
+        reader_factory: _ReaderFactory,
     ) -> None:
         self.chunk_id: int | None = None
         self.chunk_reader: RandomAccessIterator | None = None
-        self.reader_class = reader_class
-        self.reader_params = reader_params
+        self.reader_factory = reader_factory
 
     def load(self, chunk_id: int) -> RandomAccessIterator[tuple[Any, str, int]]:
         if self.chunk_id != chunk_id:
@@ -56,11 +56,9 @@ class _ChunkLoader(metaclass=ABCMeta):
 
             self.chunk_id = chunk_id
             self.chunk_reader = RandomAccessIterator(
-                self.reader_class(
-                    [self.read_chunk(chunk_id)[0]],
-                    **(self.reader_params or {}),
-                )
+                self.reader_factory(self.read_chunk(chunk_id)[0])
             )
+
         return self.chunk_reader
 
     def unload(self):
@@ -76,12 +74,11 @@ class _ChunkLoader(metaclass=ABCMeta):
 class _FileChunkLoader(_ChunkLoader):
     def __init__(
         self,
-        reader_class: type[IMediaReader],
-        get_chunk_path_callback: Callable[[int], str],
         *,
-        reader_params: dict | None = None,
+        reader_factory: _ReaderFactory,
+        get_chunk_path_callback: Callable[[int], str],
     ) -> None:
-        super().__init__(reader_class, reader_params=reader_params)
+        super().__init__(reader_factory=reader_factory)
         self.get_chunk_path = get_chunk_path_callback
 
     def read_chunk(self, chunk_id: int) -> DataWithMime:
@@ -96,12 +93,11 @@ class _FileChunkLoader(_ChunkLoader):
 class _BufferChunkLoader(_ChunkLoader):
     def __init__(
         self,
-        reader_class: type[IMediaReader],
-        get_chunk_callback: Callable[[int], DataWithMime],
         *,
-        reader_params: dict | None = None,
+        reader_factory: _ReaderFactory,
+        get_chunk_callback: Callable[[int], DataWithMime],
     ) -> None:
-        super().__init__(reader_class, reader_params=reader_params)
+        super().__init__(reader_factory=reader_factory)
         self.get_chunk = get_chunk_callback
 
     def read_chunk(self, chunk_id: int) -> DataWithMime:
@@ -460,24 +456,19 @@ class TaskFrameProvider(IFrameProvider):
 
 
 class SegmentFrameProvider(IFrameProvider):
+    _READER_FACTORIES: dict[models.DataChoice, _ReaderFactory] = {
+        models.DataChoice.IMAGESET: lambda source: ZipReader([source]),
+        # disable threading to avoid unpredictable server
+        # resource consumption during reading in endpoints
+        # can be enabled for other clients
+        models.DataChoice.VIDEO: lambda source: VideoReader([source], allow_threading=False),
+    }
+
     def __init__(self, db_segment: models.Segment) -> None:
         super().__init__()
         self._db_segment = db_segment
 
         db_data = db_segment.task.require_data()
-
-        reader_class: dict[models.DataChoice, tuple[type[IMediaReader], dict | None]] = {
-            models.DataChoice.IMAGESET: (ZipReader, None),
-            models.DataChoice.VIDEO: (
-                VideoReader,
-                {
-                    "allow_threading": False
-                    # disable threading to avoid unpredictable server
-                    # resource consumption during reading in endpoints
-                    # can be enabled for other clients
-                },
-            ),
-        }
 
         if (
             db_data.storage_method
@@ -489,8 +480,7 @@ class SegmentFrameProvider(IFrameProvider):
             def make_loader(quality: models.FrameQuality) -> _ChunkLoader:
                 chunk_type = db_data.get_chunk_type(quality)
                 return _BufferChunkLoader(
-                    reader_class=reader_class[chunk_type][0],
-                    reader_params=reader_class[chunk_type][1],
+                    reader_factory=self._READER_FACTORIES[chunk_type],
                     get_chunk_callback=lambda chunk_idx: cache.get_or_set_segment_chunk(
                         db_segment, chunk_idx, quality=quality
                     ),
@@ -501,8 +491,7 @@ class SegmentFrameProvider(IFrameProvider):
             def make_loader(quality: models.FrameQuality) -> _ChunkLoader:
                 chunk_type = db_data.get_chunk_type(quality)
                 return _FileChunkLoader(
-                    reader_class=reader_class[chunk_type][0],
-                    reader_params=reader_class[chunk_type][1],
+                    reader_factory=self._READER_FACTORIES[chunk_type],
                     get_chunk_path_callback=lambda chunk_idx: db_data.get_static_segment_chunk_path(
                         chunk_idx, segment_id=db_segment.id, quality=quality
                     ),


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Instead of passing the reader class and parameters separately, pass them both in a single factory function. This results in simpler code.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
