### PR TITLE
UI: mark AUTO annotations as SEMI-AUTO on label change

### DIFF
--- a/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
+++ b/cvat-ui/src/containers/annotation-page/standard-workspace/objects-side-bar/object-item.tsx
@@ -27,8 +27,9 @@ import { getObjectStateColor } from 'components/annotation-page/standard-workspa
 import openCVWrapper from 'utils/opencv-wrapper/opencv-wrapper';
 import { shift } from 'utils/math';
 import {
-    Label, ObjectState, Attribute, Job, ShapeType, ObjectType,
+    Label, ObjectState, Attribute, Job, ShapeType, ObjectType, Source
 } from 'cvat-core-wrapper';
+
 import { Canvas, CanvasMode } from 'cvat-canvas-wrapper';
 import { Canvas3d } from 'cvat-canvas3d-wrapper';
 import { filterApplicableLabels } from 'utils/filter-applicable-labels';
@@ -320,6 +321,9 @@ class ObjectItemContainer extends React.PureComponent<Props, State> {
     private changeLabel = (label: any): void => {
         const { objectState } = this.props;
         objectState.label = label;
+        if (objectState.source === Source.AUTO) {
+            objectState.source = Source.SEMI_AUTO;
+        }
         this.commit();
     };
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

This change fixes an inconsistency in annotation source handling.
Currently, resizing an automatically created annotation updates its
source to SEMI-AUTO, but changing only the label/category keeps the
source as AUTO.

This PR ensures that changing an annotation’s label is treated as a
manual edit and updates the source from AUTO to SEMI-AUTO, keeping
behavior consistent with other user-driven modifications.

Closes #9172

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

This change was verified by reviewing the UI logic responsible for
updating annotation state on label change. The update mirrors existing
behavior used when annotations are resized.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
