### PR TITLE
Refactor GT creation in task creation

### DIFF
--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -637,6 +637,361 @@ def _find_and_filter_related_images(
     }
 
 
+def _allocate_honeypots(
+    db_task: models.Task,
+    validation_params: dict[str, Any] | None,
+    *,
+    images: list[models.Image],
+    manifest: ImageManifestManager,
+    job_file_mapping: JobFileMapping | None,
+    is_backup_restore: bool,
+) -> tuple[JobFileMapping | None, list[models.Image]]:
+    if not validation_params or validation_params["mode"] != models.ValidationMode.GT_POOL:
+        return job_file_mapping, images
+
+    db_data = db_task.require_data()
+
+    if is_backup_restore:
+        # Validation frames must be in the end of the images list. Collect their ids
+        frame_idx_map: dict[str, int] = {}
+        for i, frame_filename in enumerate(validation_params["frames"]):
+            image = images[-len(validation_params["frames"]) + i]
+            assert frame_filename == image.path
+            frame_idx_map[image.path] = image.frame
+
+        # Store information about the real frame placement in validation frames in jobs
+        for image in images[: -len(validation_params["frames"])]:
+            real_frame = frame_idx_map.get(image.path)
+            if real_frame is not None:
+                image.is_placeholder = True
+                image.real_frame = real_frame
+
+        # Exclude the previous GT job from the list of jobs to be created with normal segments
+        # It must be the last one
+        assert job_file_mapping[-1] == validation_params["frames"]
+        job_file_mapping.pop(-1)
+
+        db_data.update_validation_layout(
+            models.ValidationLayout(
+                mode=models.ValidationMode.GT_POOL,
+                frames=list(frame_idx_map.values()),
+                frames_per_job_count=validation_params["frames_per_job_count"],
+            )
+        )
+    else:
+        if db_task.mode != "annotation":
+            raise ValidationError(
+                f"validation mode '{models.ValidationMode.GT_POOL}' can only be used "
+                "with 'annotation' mode tasks"
+            )
+
+        # 1. select pool frames
+        all_frames = range(len(images))
+
+        # The RNG backend must not change to yield reproducible frame picks,
+        # so here we specify it explicitly
+        from numpy import random
+
+        seed = validation_params.get("random_seed")
+        rng = random.Generator(random.MT19937(seed=seed))
+
+        # Sort the images to be able to create reproducible results
+        images = sort(images, sorting_method=models.SortingMethod.NATURAL, func=lambda i: i.path)
+        for i, image in enumerate(images):
+            image.frame = i
+
+        pool_frames: list[int] = []
+        match validation_params["frame_selection_method"]:
+            case models.JobFrameSelectionMethod.RANDOM_UNIFORM:
+                if frame_count := validation_params.get("frame_count"):
+                    if len(images) <= frame_count:
+                        raise ValidationError(
+                            f"The number of validation frames requested ({frame_count}) "
+                            f"must be less than the number of task frames ({len(images)})"
+                        )
+                elif frame_share := validation_params.get("frame_share"):
+                    frame_count = max(1, int(len(images) * frame_share))
+                else:
+                    raise ValidationError("The number of validation frames is not specified")
+
+                pool_frames = rng.choice(
+                    all_frames, size=frame_count, shuffle=False, replace=False
+                ).tolist()
+            case models.JobFrameSelectionMethod.MANUAL:
+                known_frame_names = {frame.path: frame.frame for frame in images}
+                unknown_requested_frames = []
+                for frame_filename in validation_params["frames"]:
+                    frame_id = known_frame_names.get(frame_filename)
+                    if frame_id is None:
+                        unknown_requested_frames.append(frame_filename)
+                        continue
+
+                    pool_frames.append(frame_id)
+
+                if unknown_requested_frames:
+                    raise ValidationError(
+                        "Unknown validation frames requested: {}".format(
+                            format_list(sorted(unknown_requested_frames))
+                        )
+                    )
+            case _:
+                assert False
+
+        if len(all_frames) - len(pool_frames) < 1:
+            raise ValidationError(
+                "Cannot create task: "
+                "too few non-honeypot frames left after selecting validation frames"
+            )
+
+        # Even though the sorting is random overall,
+        # it's convenient to be able to reasonably navigate in the GT job
+        pool_frames = sort(
+            pool_frames,
+            sorting_method=models.SortingMethod.NATURAL,
+            func=lambda frame: images[frame].path,
+        )
+
+        # 2. distribute pool frames
+        if frames_per_job_count := validation_params.get("frames_per_job_count"):
+            if len(pool_frames) < frames_per_job_count and validation_params.get("frame_count"):
+                raise ValidationError(
+                    f"The requested number of validation frames per job ({frames_per_job_count}) "
+                    f"is greater than the validation pool size ({len(pool_frames)})"
+                )
+        elif frames_per_job_share := validation_params.get("frames_per_job_share"):
+            frames_per_job_count = max(1, int(frames_per_job_share * db_task.segment_size))
+        else:
+            raise ValidationError("The number of validation frames is not specified")
+
+        frames_per_job_count = min(len(pool_frames), frames_per_job_count)
+
+        non_pool_frames = sorted(
+            # set() doesn't guarantee ordering,
+            # so sort additionally before shuffling to make results reproducible
+            set(all_frames).difference(pool_frames)
+        )
+        rng.shuffle(non_pool_frames)
+
+        validation_frame_counts = {f: 0 for f in pool_frames}
+        frame_selector = HoneypotFrameSelector(validation_frame_counts, rng=rng)
+
+        # Don't use the same rng as for frame ordering to simplify random_seed maintenance in future
+        # We still use the same seed, but in this case the frame selection rng is separate
+        # from job frame ordering rng
+        job_frame_ordering_rng = random.Generator(random.MT19937(seed=seed))
+
+        # Allocate frames for jobs
+        job_file_mapping: JobFileMapping = []
+        new_db_images: list[models.Image] = []
+        validation_frames: list[int] = []
+        frame_idx_map: dict[int, int] = {}  # new to original id
+        for job_frames in take_by(non_pool_frames, chunk_size=db_task.segment_size or db_data.size):
+            job_validation_frames = list(frame_selector.select_next_frames(frames_per_job_count))
+            job_frames += job_validation_frames
+
+            job_frame_ordering_rng.shuffle(job_frames)
+
+            job_images = []
+            for job_frame in job_frames:
+                # Insert placeholder frames into the frame sequence and shift frame ids
+                image = images[job_frame]
+                image = models.Image(
+                    data=db_data, **deepcopy(model_to_dict(image, exclude=["data"]))
+                )
+                image.frame = len(new_db_images)
+
+                if job_frame in job_validation_frames:
+                    image.is_placeholder = True
+                    image.real_frame = job_frame
+                    validation_frames.append(image.frame)
+
+                job_images.append(image.path)
+                new_db_images.append(image)
+                frame_idx_map[image.frame] = job_frame
+
+            job_file_mapping.append(job_images)
+
+        # Append pool frames in the end, shift their ids, establish placeholder pointers
+        frame_id_map: dict[int, int] = {}  # original to new id
+        for pool_frame in pool_frames:
+            # Insert placeholder frames into the frame sequence and shift frame ids
+            image = images[pool_frame]
+            image = models.Image(data=db_data, **deepcopy(model_to_dict(image, exclude=["data"])))
+            new_frame_id = len(new_db_images)
+            image.frame = new_frame_id
+
+            frame_id_map[pool_frame] = new_frame_id
+
+            new_db_images.append(image)
+            frame_idx_map[image.frame] = pool_frame
+
+        pool_frames = [frame_id_map[i] for i in pool_frames if i in frame_id_map]
+
+        # Store information about the real frame placement in the validation frames
+        for validation_frame in validation_frames:
+            image = new_db_images[validation_frame]
+            assert image.is_placeholder
+            image.real_frame = frame_id_map[image.real_frame]
+
+        # Update manifest
+        manifest.reorder([images[frame_idx_map[image.frame]].path for image in new_db_images])
+
+        images = new_db_images
+        db_data.size = len(images)
+        db_data.start_frame = 0
+        db_data.stop_frame = 0
+        db_data.frame_filter = ""
+
+        db_data.update_validation_layout(
+            models.ValidationLayout(
+                mode=models.ValidationMode.GT_POOL,
+                frames=pool_frames,
+                frames_per_job_count=frames_per_job_count,
+            )
+        )
+
+    return job_file_mapping, images
+
+
+def _create_validation_jobs(
+    db_task: models.Task,
+    validation_params: dict[str, Any] | None,
+    *,
+    images: list[models.Image] | None,
+) -> None:
+    db_data = db_task.require_data()
+
+    if validation_params and validation_params["mode"] == models.ValidationMode.GT:
+
+        def _to_rel_frame(abs_frame: int) -> int:
+            return (abs_frame - db_data.start_frame) // db_data.get_frame_step()
+
+        # The RNG backend must not change to yield reproducible frame picks,
+        # so here we specify it explicitly
+        from numpy import random
+
+        seed = validation_params.get("random_seed")
+        rng = random.Generator(random.MT19937(seed=seed))
+
+        match validation_params["frame_selection_method"]:
+            case models.JobFrameSelectionMethod.RANDOM_UNIFORM:
+                all_frames = range(db_data.size)
+
+                if frame_count := validation_params.get("frame_count"):
+                    if db_data.size < frame_count:
+                        raise ValidationError(
+                            f"The number of validation frames requested ({frame_count}) "
+                            f"is greater that the number of task frames ({db_data.size})"
+                        )
+                elif frame_share := validation_params.get("frame_share"):
+                    frame_count = max(1, int(frame_share * len(all_frames)))
+                else:
+                    raise ValidationError("The number of validation frames is not specified")
+
+                validation_frames = rng.choice(
+                    all_frames, size=frame_count, shuffle=False, replace=False
+                ).tolist()
+            case models.JobFrameSelectionMethod.RANDOM_PER_JOB:
+                if frame_count := validation_params.get("frames_per_job_count"):
+                    if db_task.segment_size < frame_count:
+                        raise ValidationError(
+                            "The requested number of GT frames per job must be less "
+                            f"than task segment size ({db_task.segment_size})"
+                        )
+                elif frame_share := validation_params.get("frames_per_job_share"):
+                    frame_count = min(max(1, int(frame_share * db_task.segment_size)), db_data.size)
+                else:
+                    raise ValidationError("The number of validation frames is not specified")
+
+                validation_frames: list[int] = []
+                overlap = db_task.overlap
+                for segment in db_task.segment_set.all():
+                    segment_frames = set(map(_to_rel_frame, segment.frame_set))
+                    selected_frames = segment_frames.intersection(validation_frames)
+                    selected_count = len(selected_frames)
+
+                    missing_count = min(len(segment_frames), frame_count) - selected_count
+                    if missing_count <= 0:
+                        continue
+
+                    selectable_segment_frames = set(
+                        sorted(segment_frames)[overlap * (segment.start_frame != 0) :]
+                    ).difference(selected_frames)
+
+                    validation_frames.extend(
+                        rng.choice(
+                            tuple(selectable_segment_frames), size=missing_count, replace=False
+                        ).tolist()
+                    )
+            case models.JobFrameSelectionMethod.MANUAL:
+                if not images:
+                    raise ValidationError(
+                        "{} validation frame selection method at task creation "
+                        "is only available for image-based tasks. "
+                        "Please create the GT job after the task is created.".format(
+                            models.JobFrameSelectionMethod.MANUAL
+                        )
+                    )
+
+                validation_frames: list[int] = []
+                known_frame_names = {frame.path: _to_rel_frame(frame.frame) for frame in images}
+                unknown_requested_frames = []
+                for frame_filename in validation_params["frames"]:
+                    frame_id = known_frame_names.get(frame_filename)
+                    if frame_id is None:
+                        unknown_requested_frames.append(frame_filename)
+                        continue
+
+                    validation_frames.append(frame_id)
+
+                if unknown_requested_frames:
+                    raise ValidationError(
+                        "Unknown validation frames requested: {}".format(
+                            format_list(sorted(unknown_requested_frames))
+                        )
+                    )
+            case _:
+                assert (
+                    False
+                ), f'Unknown frame selection method {validation_params["frame_selection_method"]}'
+
+        db_data.update_validation_layout(
+            models.ValidationLayout(
+                mode=models.ValidationMode.GT,
+                frames=sorted(validation_frames),
+            )
+        )
+
+    if hasattr(db_data, "validation_layout"):
+        if db_data.validation_layout.mode == models.ValidationMode.GT:
+
+            def _to_abs_frame(rel_frame: int) -> int:
+                return rel_frame * db_data.get_frame_step() + db_data.start_frame
+
+            db_gt_segment = models.Segment(
+                task=db_task,
+                start_frame=0,
+                stop_frame=db_data.size - 1,
+                frames=list(map(_to_abs_frame, db_data.validation_layout.frames)),
+                type=models.SegmentType.SPECIFIC_FRAMES,
+            )
+        elif db_data.validation_layout.mode == models.ValidationMode.GT_POOL:
+            db_gt_segment = models.Segment(
+                task=db_task,
+                start_frame=min(db_data.validation_layout.frames),
+                stop_frame=max(db_data.validation_layout.frames),
+                type=models.SegmentType.RANGE,
+            )
+        else:
+            assert False
+
+        db_gt_segment.save()
+
+        db_gt_job = models.Job(segment=db_gt_segment, type=models.JobType.GROUND_TRUTH)
+        db_gt_job.save()
+        db_gt_job.make_dirs()
+
+
 @transaction.atomic
 def create_thread(
     db_task: int | models.Task,
@@ -1280,210 +1635,16 @@ def create_thread(
                     )
                 )
 
-    # TODO: refactor
-    # Prepare jobs
-    if validation_params and (
-        validation_params["mode"] == models.ValidationMode.GT_POOL and is_backup_restore
-    ):
-        # Validation frames must be in the end of the images list. Collect their ids
-        frame_idx_map: dict[str, int] = {}
-        for i, frame_filename in enumerate(validation_params["frames"]):
-            image = images[-len(validation_params["frames"]) + i]
-            assert frame_filename == image.path
-            frame_idx_map[image.path] = image.frame
-
-        # Store information about the real frame placement in validation frames in jobs
-        for image in images[: -len(validation_params["frames"])]:
-            real_frame = frame_idx_map.get(image.path)
-            if real_frame is not None:
-                image.is_placeholder = True
-                image.real_frame = real_frame
-
-        # Exclude the previous GT job from the list of jobs to be created with normal segments
-        # It must be the last one
-        assert job_file_mapping[-1] == validation_params["frames"]
-        job_file_mapping.pop(-1)
-
-        db_data.update_validation_layout(
-            models.ValidationLayout(
-                mode=models.ValidationMode.GT_POOL,
-                frames=list(frame_idx_map.values()),
-                frames_per_job_count=validation_params["frames_per_job_count"],
-            )
-        )
-    elif validation_params and validation_params["mode"] == models.ValidationMode.GT_POOL:
-        if db_task.mode != "annotation":
-            raise ValidationError(
-                f"validation mode '{models.ValidationMode.GT_POOL}' can only be used "
-                "with 'annotation' mode tasks"
-            )
-
-        # 1. select pool frames
-        all_frames = range(len(images))
-
-        # The RNG backend must not change to yield reproducible frame picks,
-        # so here we specify it explicitly
-        from numpy import random
-
-        seed = validation_params.get("random_seed")
-        rng = random.Generator(random.MT19937(seed=seed))
-
-        # Sort the images to be able to create reproducible results
-        images = sort(images, sorting_method=models.SortingMethod.NATURAL, func=lambda i: i.path)
-        for i, image in enumerate(images):
-            image.frame = i
-
-        pool_frames: list[int] = []
-        match validation_params["frame_selection_method"]:
-            case models.JobFrameSelectionMethod.RANDOM_UNIFORM:
-                if frame_count := validation_params.get("frame_count"):
-                    if len(images) <= frame_count:
-                        raise ValidationError(
-                            f"The number of validation frames requested ({frame_count}) "
-                            f"must be less than the number of task frames ({len(images)})"
-                        )
-                elif frame_share := validation_params.get("frame_share"):
-                    frame_count = max(1, int(len(images) * frame_share))
-                else:
-                    raise ValidationError("The number of validation frames is not specified")
-
-                pool_frames = rng.choice(
-                    all_frames, size=frame_count, shuffle=False, replace=False
-                ).tolist()
-            case models.JobFrameSelectionMethod.MANUAL:
-                known_frame_names = {frame.path: frame.frame for frame in images}
-                unknown_requested_frames = []
-                for frame_filename in validation_params["frames"]:
-                    frame_id = known_frame_names.get(frame_filename)
-                    if frame_id is None:
-                        unknown_requested_frames.append(frame_filename)
-                        continue
-
-                    pool_frames.append(frame_id)
-
-                if unknown_requested_frames:
-                    raise ValidationError(
-                        "Unknown validation frames requested: {}".format(
-                            format_list(sorted(unknown_requested_frames))
-                        )
-                    )
-            case _:
-                assert False
-
-        if len(all_frames) - len(pool_frames) < 1:
-            raise ValidationError(
-                "Cannot create task: "
-                "too few non-honeypot frames left after selecting validation frames"
-            )
-
-        # Even though the sorting is random overall,
-        # it's convenient to be able to reasonably navigate in the GT job
-        pool_frames = sort(
-            pool_frames,
-            sorting_method=models.SortingMethod.NATURAL,
-            func=lambda frame: images[frame].path,
-        )
-
-        # 2. distribute pool frames
-        if frames_per_job_count := validation_params.get("frames_per_job_count"):
-            if len(pool_frames) < frames_per_job_count and validation_params.get("frame_count"):
-                raise ValidationError(
-                    f"The requested number of validation frames per job ({frames_per_job_count}) "
-                    f"is greater than the validation pool size ({len(pool_frames)})"
-                )
-        elif frames_per_job_share := validation_params.get("frames_per_job_share"):
-            frames_per_job_count = max(1, int(frames_per_job_share * db_task.segment_size))
-        else:
-            raise ValidationError("The number of validation frames is not specified")
-
-        frames_per_job_count = min(len(pool_frames), frames_per_job_count)
-
-        non_pool_frames = sorted(
-            # set() doesn't guarantee ordering,
-            # so sort additionally before shuffling to make results reproducible
-            set(all_frames).difference(pool_frames)
-        )
-        rng.shuffle(non_pool_frames)
-
-        validation_frame_counts = {f: 0 for f in pool_frames}
-        frame_selector = HoneypotFrameSelector(validation_frame_counts, rng=rng)
-
-        # Don't use the same rng as for frame ordering to simplify random_seed maintenance in future
-        # We still use the same seed, but in this case the frame selection rng is separate
-        # from job frame ordering rng
-        job_frame_ordering_rng = random.Generator(random.MT19937(seed=seed))
-
-        # Allocate frames for jobs
-        job_file_mapping: JobFileMapping = []
-        new_db_images: list[models.Image] = []
-        validation_frames: list[int] = []
-        frame_idx_map: dict[int, int] = {}  # new to original id
-        for job_frames in take_by(non_pool_frames, chunk_size=db_task.segment_size or db_data.size):
-            job_validation_frames = list(frame_selector.select_next_frames(frames_per_job_count))
-            job_frames += job_validation_frames
-
-            job_frame_ordering_rng.shuffle(job_frames)
-
-            job_images = []
-            for job_frame in job_frames:
-                # Insert placeholder frames into the frame sequence and shift frame ids
-                image = images[job_frame]
-                image = models.Image(
-                    data=db_data, **deepcopy(model_to_dict(image, exclude=["data"]))
-                )
-                image.frame = len(new_db_images)
-
-                if job_frame in job_validation_frames:
-                    image.is_placeholder = True
-                    image.real_frame = job_frame
-                    validation_frames.append(image.frame)
-
-                job_images.append(image.path)
-                new_db_images.append(image)
-                frame_idx_map[image.frame] = job_frame
-
-            job_file_mapping.append(job_images)
-
-        # Append pool frames in the end, shift their ids, establish placeholder pointers
-        frame_id_map: dict[int, int] = {}  # original to new id
-        for pool_frame in pool_frames:
-            # Insert placeholder frames into the frame sequence and shift frame ids
-            image = images[pool_frame]
-            image = models.Image(data=db_data, **deepcopy(model_to_dict(image, exclude=["data"])))
-            new_frame_id = len(new_db_images)
-            image.frame = new_frame_id
-
-            frame_id_map[pool_frame] = new_frame_id
-
-            new_db_images.append(image)
-            frame_idx_map[image.frame] = pool_frame
-
-        pool_frames = [frame_id_map[i] for i in pool_frames if i in frame_id_map]
-
-        # Store information about the real frame placement in the validation frames
-        for validation_frame in validation_frames:
-            image = new_db_images[validation_frame]
-            assert image.is_placeholder
-            image.real_frame = frame_id_map[image.real_frame]
-
-        # Update manifest
-        manifest.reorder([images[frame_idx_map[image.frame]].path for image in new_db_images])
-
-        images = new_db_images
-        db_data.size = len(images)
-        db_data.start_frame = 0
-        db_data.stop_frame = 0
-        db_data.frame_filter = ""
-
-        db_data.update_validation_layout(
-            models.ValidationLayout(
-                mode=models.ValidationMode.GT_POOL,
-                frames=pool_frames,
-                frames_per_job_count=frames_per_job_count,
-            )
-        )
-
     if db_task.mode == "annotation":
+        job_file_mapping, images = _allocate_honeypots(
+            db_task,
+            validation_params,
+            images=images,
+            manifest=manifest,
+            job_file_mapping=job_file_mapping,
+            is_backup_restore=is_backup_restore,
+        )
+
         images = bulk_create(models.Image, images)
 
         db_related_files = [
@@ -1530,136 +1691,7 @@ def create_thread(
     _create_segments_and_jobs(
         db_task, job_file_mapping=job_file_mapping, update_status_callback=update_status
     )
-
-    if validation_params and validation_params["mode"] == models.ValidationMode.GT:
-        # The RNG backend must not change to yield reproducible frame picks,
-        # so here we specify it explicitly
-        from numpy import random
-
-        seed = validation_params.get("random_seed")
-        rng = random.Generator(random.MT19937(seed=seed))
-
-        def _to_rel_frame(abs_frame: int) -> int:
-            return (abs_frame - db_data.start_frame) // db_data.get_frame_step()
-
-        match validation_params["frame_selection_method"]:
-            case models.JobFrameSelectionMethod.RANDOM_UNIFORM:
-                all_frames = range(db_data.size)
-
-                if frame_count := validation_params.get("frame_count"):
-                    if db_data.size < frame_count:
-                        raise ValidationError(
-                            f"The number of validation frames requested ({frame_count}) "
-                            f"is greater that the number of task frames ({db_data.size})"
-                        )
-                elif frame_share := validation_params.get("frame_share"):
-                    frame_count = max(1, int(frame_share * len(all_frames)))
-                else:
-                    raise ValidationError("The number of validation frames is not specified")
-
-                validation_frames = rng.choice(
-                    all_frames, size=frame_count, shuffle=False, replace=False
-                ).tolist()
-            case models.JobFrameSelectionMethod.RANDOM_PER_JOB:
-                if frame_count := validation_params.get("frames_per_job_count"):
-                    if db_task.segment_size < frame_count:
-                        raise ValidationError(
-                            "The requested number of GT frames per job must be less "
-                            f"than task segment size ({db_task.segment_size})"
-                        )
-                elif frame_share := validation_params.get("frames_per_job_share"):
-                    frame_count = min(max(1, int(frame_share * db_task.segment_size)), db_data.size)
-                else:
-                    raise ValidationError("The number of validation frames is not specified")
-
-                validation_frames: list[int] = []
-                overlap = db_task.overlap
-                for segment in db_task.segment_set.all():
-                    segment_frames = set(map(_to_rel_frame, segment.frame_set))
-                    selected_frames = segment_frames.intersection(validation_frames)
-                    selected_count = len(selected_frames)
-
-                    missing_count = min(len(segment_frames), frame_count) - selected_count
-                    if missing_count <= 0:
-                        continue
-
-                    selectable_segment_frames = set(
-                        sorted(segment_frames)[overlap * (segment.start_frame != 0) :]
-                    ).difference(selected_frames)
-
-                    validation_frames.extend(
-                        rng.choice(
-                            tuple(selectable_segment_frames), size=missing_count, replace=False
-                        ).tolist()
-                    )
-            case models.JobFrameSelectionMethod.MANUAL:
-                if not images:
-                    raise ValidationError(
-                        "{} validation frame selection method at task creation "
-                        "is only available for image-based tasks. "
-                        "Please create the GT job after the task is created.".format(
-                            models.JobFrameSelectionMethod.MANUAL
-                        )
-                    )
-
-                validation_frames: list[int] = []
-                known_frame_names = {frame.path: _to_rel_frame(frame.frame) for frame in images}
-                unknown_requested_frames = []
-                for frame_filename in validation_params["frames"]:
-                    frame_id = known_frame_names.get(frame_filename)
-                    if frame_id is None:
-                        unknown_requested_frames.append(frame_filename)
-                        continue
-
-                    validation_frames.append(frame_id)
-
-                if unknown_requested_frames:
-                    raise ValidationError(
-                        "Unknown validation frames requested: {}".format(
-                            format_list(sorted(unknown_requested_frames))
-                        )
-                    )
-            case _:
-                assert (
-                    False
-                ), f'Unknown frame selection method {validation_params["frame_selection_method"]}'
-
-        db_data.update_validation_layout(
-            models.ValidationLayout(
-                mode=models.ValidationMode.GT,
-                frames=sorted(validation_frames),
-            )
-        )
-
-    # TODO: refactor
-    if hasattr(db_data, "validation_layout"):
-        if db_data.validation_layout.mode == models.ValidationMode.GT:
-
-            def _to_abs_frame(rel_frame: int) -> int:
-                return rel_frame * db_data.get_frame_step() + db_data.start_frame
-
-            db_gt_segment = models.Segment(
-                task=db_task,
-                start_frame=0,
-                stop_frame=db_data.size - 1,
-                frames=list(map(_to_abs_frame, db_data.validation_layout.frames)),
-                type=models.SegmentType.SPECIFIC_FRAMES,
-            )
-        elif db_data.validation_layout.mode == models.ValidationMode.GT_POOL:
-            db_gt_segment = models.Segment(
-                task=db_task,
-                start_frame=min(db_data.validation_layout.frames),
-                stop_frame=max(db_data.validation_layout.frames),
-                type=models.SegmentType.RANGE,
-            )
-        else:
-            assert False
-
-        db_gt_segment.save()
-
-        db_gt_job = models.Job(segment=db_gt_segment, type=models.JobType.GROUND_TRUTH)
-        db_gt_job.save()
-        db_gt_job.make_dirs()
+    _create_validation_jobs(db_task, validation_params, images=images)
 
     db_task.save()
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

- Extracted a couple of functions for validation layout initialization in the task
- Simplified the honeypot allocation conditions a little bit

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
