### PR TITLE
Fix engine migration 0097 for tasks using the mounted share

### DIFF
--- a/cvat/apps/engine/migrations/0097_alter_relatedfile_path.py
+++ b/cvat/apps/engine/migrations/0097_alter_relatedfile_path.py
@@ -4,27 +4,40 @@ from django.conf import settings
 from django.db import migrations, models
 from django.db.models.functions import Concat, Length, Substr
 
-path_prefix = Concat(
-    models.Value(settings.MEDIA_DATA_ROOT.as_posix() + "/"), "data_id", models.Value("/raw/")
-)
+
+def path_prefix(apps):
+    Data = apps.get_model("engine", "Data")
+
+    return models.Case(
+        models.When(
+            models.Exists(Data.objects.filter(id=models.OuterRef("data_id"), storage="share")),
+            then=models.Value(settings.SHARE_ROOT.as_posix() + "/"),
+        ),
+        default=Concat(
+            models.Value(settings.MEDIA_DATA_ROOT.as_posix() + "/"),
+            "data_id",
+            models.Value("/raw/"),
+            output_field=models.CharField(),
+        ),
+    )
 
 
 def make_path_relative(apps, schema_editor):
     RelatedFile = apps.get_model("engine", "RelatedFile")
 
     # Before we chop off the prefix, let's make sure it's actually there.
-    if files_without_prefix := RelatedFile.objects.exclude(path__startswith=path_prefix)[:10]:
+    if files_without_prefix := RelatedFile.objects.exclude(path__startswith=path_prefix(apps))[:10]:
         raise RuntimeError(
             "Found RelatedFile objects with unexpected paths. Example IDs: "
             + " ".join(str(f.id) for f in files_without_prefix)
         )
 
-    RelatedFile.objects.update(path=Substr("path", Length(path_prefix) + 1))
+    RelatedFile.objects.update(path=Substr("path", Length(path_prefix(apps)) + 1))
 
 
 def make_path_absolute(apps, schema_editor):
     RelatedFile = apps.get_model("engine", "RelatedFile")
-    RelatedFile.objects.update(path=Concat(path_prefix, "path"))
+    RelatedFile.objects.update(path=Concat(path_prefix(apps), "path"))
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
I manually verified that the migration works in both directions for both share and local tasks.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
