### PR TITLE
fix(serverless): remove Nuclio dashboard port binding

### DIFF
--- a/components/serverless/docker-compose.serverless.yml
+++ b/components/serverless/docker-compose.serverless.yml
@@ -13,8 +13,6 @@ services:
       no_proxy: ${no_proxy:-}
       NUCLIO_CHECK_FUNCTION_CONTAINERS_HEALTHINESS: 'true'
       NUCLIO_DASHBOARD_DEFAULT_FUNCTION_MOUNT_MODE: 'volume'
-    ports:
-      - '8070:8070'
     logging:
       driver: "json-file"
       options:

--- a/site/content/en/docs/administration/community/advanced/installation_automatic_annotation.md
+++ b/site/content/en/docs/administration/community/advanced/installation_automatic_annotation.md
@@ -87,10 +87,51 @@ If you did, make sure all containers are stopped by `docker compose down`.
   Important requirement: you should have the latest versions of Docker Desktop, Nvidia drivers for WSL,
   and the latest updates from the Windows Insider Preview Dev channel.
 
+**Accessing the Nuclio Dashboard (Advanced):**
+
+By default, the Nuclio dashboard port is **not published** to the host.
+CVAT communicates with Nuclio over the internal Docker network,
+so the dashboard is not required for normal operation.
+
+If you need direct access to the Nuclio dashboard
+(e.g. for debugging, manual function management, or when running Nuclio on a separate machine),
+create a `docker-compose.serverless.override.yml` file with the following contents:
+
+```yaml
+services:
+  nuclio:
+    ports:
+      - '127.0.0.1:8070:8070'
+```
+
+Then include it when starting CVAT:
+
+```bash
+docker compose -f docker-compose.yml \
+  -f components/serverless/docker-compose.serverless.yml \
+  -f docker-compose.serverless.override.yml up -d
+```
+
+The dashboard will be available at [localhost:8070](http://localhost:8070).
+
+{{% alert title="Warning" color="warning" %}}
+The Nuclio dashboard **does not require authentication**.
+Do not bind the port to `0.0.0.0` (e.g. `8070:8070`) on a machine reachable from the internet,
+as this would allow anyone to deploy and manage serverless functions on your server.
+{{% /alert %}}
+
 **Troubleshooting Nuclio Functions:**
 
-- You can open nuclio dashboard at [localhost:8070](http://localhost:8070).
-  Make sure status of your functions are up and running without any error.
+- Check the status of your functions using the `nuctl` CLI:
+
+  ```bash
+  nuctl get functions --platform local
+  ```
+
+  Make sure your functions are in a `ready` state with no errors.
+  If you have enabled access to the Nuclio dashboard (see above), you can also
+  check function status at [localhost:8070](http://localhost:8070).
+
 - Test your deployed DL model as a serverless function. The command below should work on Linux and Mac OS.
 
   ```bash

--- a/site/content/en/docs/guides/serverless-tutorial.md
+++ b/site/content/en/docs/guides/serverless-tutorial.md
@@ -80,7 +80,7 @@ cvat_db      docker-entrypoint.sh postgres    Up             5432/tcp
 cvat_proxy   /docker-entrypoint.sh /bin ...   Up             0.0.0.0:8080->80/tcp,:::8080->80/tcp
 cvat_redis   docker-entrypoint.sh redis ...   Up             6379/tcp
 cvat_ui      /docker-entrypoint.sh ngin ...   Up             80/tcp
-nuclio       /docker-entrypoint.sh sh - ...   Up (healthy)   80/tcp, 0.0.0.0:8070->8070/tcp,:::8070->8070/tcp
+nuclio       /docker-entrypoint.sh sh - ...   Up (healthy)   80/tcp, 8070/tcp
 ```
 
 Next step is to deploy builtin serverless functions using Nuclio command
@@ -838,7 +838,7 @@ docker ps --filter NAME=^nuclio$
 ```
 ```
 CONTAINER ID   IMAGE                                   COMMAND                  CREATED       STATUS                    PORTS                                               NAMES
-7ab0c076c927   quay.io/nuclio/dashboard:1.5.16-amd64   "/docker-entrypoint.…"   6 weeks ago   Up 46 minutes (healthy)   80/tcp, 0.0.0.0:8070->8070/tcp, :::8070->8070/tcp   nuclio
+7ab0c076c927   quay.io/nuclio/dashboard:1.5.16-amd64   "/docker-entrypoint.…"   6 weeks ago   Up 46 minutes (healthy)   80/tcp, 8070/tcp   nuclio
 ```
 
 Be sure that the model, which doesn't work, is healthy. In my case Inside Outside


### PR DESCRIPTION
## Summary

The default `docker-compose.serverless.yml` published the Nuclio dashboard port (`8070`) on the host. Because the Nuclio dashboard does not require authentication, any machine that can reach the host could access it and deploy or manage serverless functions.

Since CVAT communicates with Nuclio over the internal Docker network, the published port is not needed for normal operation. This PR removes the port binding entirely.

## Motivation

I discovered this vulnerability the hard way: an attacker exploited the exposed, unauthenticated Nuclio dashboard on my server to deploy **xmrig** cryptocurrency-mining containers (cryptojacking). Investigating the unexpected resource consumption led me to the open port and the root cause described above.

## Changes

- `components/serverless/docker-compose.serverless.yml`: removed the `ports` section from the `nuclio` service.
- `site/.../installation_automatic_annotation.md`: added an **"Accessing the Nuclio Dashboard (Advanced)"** section explaining how to re-enable the port via a compose override file, with a security warning against binding to `0.0.0.0`. Updated the troubleshooting section to use `nuctl get functions` as the primary status check instead of the dashboard.
- `site/.../serverless-tutorial.md`: updated `docker ps` output examples to reflect the removed port binding.

## Test plan

- [x] Verify CVAT can still invoke serverless functions without the published port (container-to-container communication is unaffected).
- [x] Confirm the Nuclio dashboard is **not** reachable from the host on port 8070 by default.
- [ ] Verify the documented override file (`docker-compose.serverless.override.yml`) correctly re-enables dashboard access at `localhost:8070`.