### PR TITLE
SDK: Fix certain uploads crashing instead of retrying on failed chunk

### DIFF
--- a/changelog.d/20260313_184640_roman_logger_crash.md
+++ b/changelog.d/20260313_184640_roman_logger_crash.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- \[SDK\] Fixed a crash in `TasksRepo.create_from_backup`,
+  `ProjectsRepo.create_from_backup`, `Task.upload_data` that could occur
+  if a recoverable error occurred during chunk uploading
+  (<https://github.com/cvat-ai/cvat/pull/10375>)

--- a/cvat-sdk/cvat_sdk/core/proxies/projects.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/projects.py
@@ -161,7 +161,6 @@ class ProjectsRepo(
             meta=params,
             query_params=params,
             pbar=pbar,
-            logger=self._client.logger.debug,
         )
 
         rq_id = json.loads(response.data).get("rq_id")

--- a/cvat-sdk/cvat_sdk/core/proxies/tasks.py
+++ b/cvat-sdk/cvat_sdk/core/proxies/tasks.py
@@ -358,7 +358,6 @@ class TasksRepo(
             meta=params,
             query_params=params,
             pbar=pbar,
-            logger=self._client.logger.debug,
         )
 
         rq_id = json.loads(response.data).get("rq_id")

--- a/cvat-sdk/cvat_sdk/core/uploading.py
+++ b/cvat-sdk/cvat_sdk/core/uploading.py
@@ -134,7 +134,6 @@ class Uploader:
         query_params: dict[str, Any] = None,
         fields: dict[str, Any] | None = None,
         pbar: ProgressReporter | None = None,
-        logger=None,
     ) -> urllib3.HTTPResponse:
         """
         Annotation uploads:
@@ -171,7 +170,7 @@ class Uploader:
         self._tus_start_upload(url, query_params=query_params)
         with self._uploading_task(pbar, file_size):
             real_filename = self._upload_file_data_with_tus(
-                url=url, filename=filename, meta=meta, pbar=pbar, logger=logger
+                url=url, filename=filename, meta=meta, pbar=pbar
             )
         query_params["filename"] = real_filename
         return self._tus_finish_upload(url, query_params=query_params, fields=fields)
@@ -182,14 +181,14 @@ class Uploader:
             total=total_size, desc="Uploading data", unit_scale=True, unit="B", unit_divisor=1024
         )
 
-    def _upload_file_data_with_tus(self, url, filename, *, meta, pbar, logger=None) -> str:
+    def _upload_file_data_with_tus(self, url, filename, *, meta, pbar) -> str:
         with open(filename, "rb") as input_file:
             return _upload_with_tus(
                 self._client.api_client,
                 create_url=url.rstrip("/") + "/",
                 metadata=meta,
                 file_stream=StreamWithProgress(input_file, pbar),
-                logger=logger or self._client.logger,
+                logger=self._client.logger,
             )
 
     def _tus_start_upload(self, url, *, query_params=None):
@@ -323,7 +322,6 @@ class DataUploader(Uploader):
                     filename,
                     meta={"filename": filename.name},
                     pbar=pbar,
-                    logger=self._client.logger.debug,
                 )
 
         return self._tus_finish_upload(url, fields=kwargs)

--- a/tests/python/rest_api/test_resource_import_export.py
+++ b/tests/python/rest_api/test_resource_import_export.py
@@ -655,7 +655,6 @@ class TestUploads:
                     url,
                     archive_path,
                     meta=params,
-                    logger=owner_client.logger.debug,
                     pbar=pbar,
                 )
 

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -3181,7 +3181,6 @@ class TestImportTaskAnnotations:
                 url,
                 filename,
                 meta=params,
-                logger=self.client.logger.debug,
                 pbar=NullProgressReporter(),
             )
 
@@ -3212,7 +3211,6 @@ class TestImportTaskAnnotations:
             url,
             filename,
             meta=params,
-            logger=self.client.logger.debug,
             pbar=NullProgressReporter(),
         )
         number_of_files = 1


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This was a regression introduced in d471db6b. I hadn't realized that the `logger` parameter of `_upload_file_data_with_tus` was a _function_ rather than a logger object, so I used it as if it was the latter.

I don't think the logger customization makes any sense here regardless, so just drop this parameter and use the client logger.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
