### PR TITLE
Fix annotation scores and annotations.json date in backups

### DIFF
--- a/changelog.d/20260402_192119_mzhiltsov_fix_backups.md
+++ b/changelog.d/20260402_192119_mzhiltsov_fix_backups.md
@@ -1,0 +1,6 @@
+### Fixed
+
+- Annotation `score` is not preserved in backups
+  (<https://github.com/cvat-ai/cvat/pull/10445>)
+- Invalid date of `annotations.json` in backups
+  (<https://github.com/cvat-ai/cvat/pull/10445>)

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -772,9 +772,6 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
 
 
 class _ImporterBase:
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
     @staticmethod
     def _read_version(manifest):
         version = manifest.pop("version")

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -19,7 +19,7 @@ from enum import Enum
 from logging import Logger
 from pathlib import Path, PurePath
 from typing import Any, ClassVar
-from zipfile import ZipFile
+from zipfile import ZipFile, ZipInfo
 
 import rapidjson
 from django.conf import settings
@@ -753,7 +753,11 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
 
         annotations = serialize_annotations()
         target_annotations_file = os.path.join(target_dir, self.ANNOTATIONS_FILENAME)
-        with zip_object.open(target_annotations_file, "w") as f:
+        with zip_object.open(
+            # without this, the file will have the default timestamp (1980-01-01)
+            ZipInfo(target_annotations_file, date_time=timezone.now().timetuple()),
+            "w"
+        ) as f:
             rapidjson.dump(annotations, f)
 
     def _export_task(self, zip_obj: ZipFile, target_dir: str) -> None:

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -756,7 +756,7 @@ class TaskExporter(_ExporterBase, _TaskBackupBase):
         with zip_object.open(
             # without this, the file will have the default timestamp (1980-01-01)
             ZipInfo(target_annotations_file, date_time=timezone.now().timetuple()),
-            "w"
+            "w",
         ) as f:
             rapidjson.dump(annotations, f)
 

--- a/cvat/apps/engine/backup.py
+++ b/cvat/apps/engine/backup.py
@@ -286,6 +286,7 @@ class _TaskBackupBase(_BackupBase):
             "attributes",
             "shapes",
             "elements",
+            "score",
         }
 
         def _update_attribute(attribute, label):

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -1516,6 +1516,32 @@ class TestTaskBackups:
         backup_file = ASSETS_DIR / "backups" / "task_30_backup_pre_consensus_replica_removal.zip"
         self._test_can_restore_task_from_backup(original_task_id, backup_file=backup_file)
 
+    def test_can_import_backup_with_annotation_scores(self, tasks, jobs, labels, annotations):
+        task_id = next(
+            t
+            for t in tasks
+            if t.get("size", 0) > 0
+            if t.get("project_id", None) is None
+            if any(v for v in annotations["task"].get(str(t["id"]), {}).values())
+        )["id"]
+        label = next(l for l in labels if l.get("task_id") == task_id)
+        job = next(j for j in jobs if j["task_id"] == task_id if j["type"] == "annotation")
+
+        annotation = {
+            "shapes": [
+                {
+                    "type": "rectangle",
+                    "frame": job["start_frame"],
+                    "points": [0, 0, 1, 1],
+                    "score": 0.2,
+                    "label_id": label["id"],
+                }
+            ]
+        }
+        self.client.jobs.retrieve(job["id"]).set_annotations(annotation)
+
+        self._test_can_restore_task_from_backup(task_id)
+
     @pytest.mark.parametrize("mode", ["annotation", "interpolation"])
     def test_can_import_backup_for_task_in_nondefault_state(self, tasks, mode):
         # Reproduces the problem with empty 'mode' in a restored task,


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->

- Added the missing `score` annotation attribute in backups
- Fixed the date of `annotations.json` file in backups

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

Automatic tests for the `score` attribute.
There are not any requirements for the file dates in backups, so no tests for this. It was just looking inconsistent. Potentially, the date can be changed to the last annotation modification date to be more useful.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
