### PR TITLE
Fixed some empty-mask issues

### DIFF
--- a/cvat-canvas/src/typescript/masksHandler.ts
+++ b/cvat-canvas/src/typescript/masksHandler.ts
@@ -331,10 +331,10 @@ export class MasksHandlerImpl implements MasksHandler {
             this.canvas.add(this.brushMarker);
         }
         const rle = imageDataToRLE(imageData);
-        const emptyMask = rle.length < 2;
+        const isEmptyMask = rle.length < 2;
         this.tool.onBlockUpdated({
-            eraser: emptyMask,
-            'polygon-minus': emptyMask,
+            eraser: isEmptyMask,
+            'polygon-minus': isEmptyMask,
         });
     }
 

--- a/cvat-core/src/annotations-collection.ts
+++ b/cvat-core/src/annotations-collection.ts
@@ -1202,13 +1202,14 @@ export default class Collection {
         const additionalClientIDs = [];
         let globalEmptyMaskOccurred = false;
         for (const object of importedArray) {
-            if (object.shapeType === ShapeType.MASK && config.removeUnderlyingMaskPixels.enabled) {
+            if (object instanceof MaskShape && config.removeUnderlyingMaskPixels.enabled) {
                 const {
                     clientIDs,
                     emptyMaskOccurred,
                     undo: undoWithUnderlyingPixels,
                     redo: redoWithUnderlyingPixels,
-                } = (object as MaskShape).removeUnderlyingPixels(object.frame);
+                } = object.removeUnderlyingPixels(object.frame);
+
                 additionalUndo.push(undoWithUnderlyingPixels);
                 additionalRedo.push(redoWithUnderlyingPixels);
                 additionalClientIDs.push(clientIDs);

--- a/cvat-core/src/annotations-objects.ts
+++ b/cvat-core/src/annotations-objects.ts
@@ -36,6 +36,15 @@ function copyShape(state: TrackedShape, data: Partial<TrackedShape> = {}): Track
     };
 }
 
+function serverAttributesToDictionary(attributes: SerializedShape['attributes']): Record<number, string> {
+    const object = Object.create(null);
+    for (const attr of attributes) {
+        object[attr.spec_id] = attr.value;
+    }
+
+    return object;
+}
+
 function convertTrackedShape(shape: SerializedTrack['shapes'][0]): TrackedShape {
     return {
         serverID: shape.id,
@@ -44,10 +53,7 @@ function convertTrackedShape(shape: SerializedTrack['shapes'][0]): TrackedShape 
         points: shape.points,
         outside: shape.outside,
         rotation: shape.rotation || 0,
-        attributes: shape.attributes.reduce((attributeAccumulator, attr) => {
-            attributeAccumulator[attr.spec_id] = attr.value;
-            return attributeAccumulator;
-        }, {}),
+        attributes: serverAttributesToDictionary(shape.attributes),
     };
 }
 
@@ -139,10 +145,7 @@ class Annotation {
         this.votes = injection.replicasCount !== undefined ?
             Math.round(this.score * injection.replicasCount) : 0;
         this.updated = Date.now();
-        this.attributes = data.attributes.reduce((attributeAccumulator, attr) => {
-            attributeAccumulator[attr.spec_id] = attr.value;
-            return attributeAccumulator;
-        }, {});
+        this.attributes = serverAttributesToDictionary(data.attributes);
         this.groupObject = Object.defineProperties(
             {}, {
                 color: {
@@ -2248,7 +2251,7 @@ export class MaskShape extends Shape {
         super(data, clientID, color, injection);
         const [left, top, right, bottom] = this.points.slice(-4);
         const { width, height } = this.framesInfo[this.frame];
-        if (left >= width || top >= height || right >= width || bottom >= height) {
+        if (left < 0 || top < 0 || right >= width || bottom >= height) {
             this.points = cropMask(this.points, width, height);
         }
         [this.left, this.top, this.right, this.bottom] = this.points.splice(-4, 4);
@@ -2263,7 +2266,6 @@ export class MaskShape extends Shape {
             const { width, height } = this.framesInfo[frame];
             return cropMask(data.points, width, height);
         }
-
         return [];
     }
 

--- a/cvat-core/src/lambda-manager.ts
+++ b/cvat-core/src/lambda-manager.ts
@@ -96,9 +96,9 @@ class LambdaManager {
                 // wrap old interactor interfaces for backward compatibility
                 const maskHeight = result.mask.length;
                 const maskWidth = result.mask[0].length;
-                const rle = mask2Rle(result.mask.flat());
+                let rle = mask2Rle(result.mask.flat());
                 if (rle.length < 2) {
-                    rle.push(0, 0, 0, 0);
+                    rle = [0, 0, 0, 0, 0];
                 } else {
                     rle.push(0, 0, maskWidth - 1, maskHeight - 1);
                 }

--- a/cvat-core/src/lambda-manager.ts
+++ b/cvat-core/src/lambda-manager.ts
@@ -97,7 +97,7 @@ class LambdaManager {
                 const maskHeight = result.mask.length;
                 const maskWidth = result.mask[0].length;
                 const rle = mask2Rle(result.mask.flat());
-                if (!rle.length) {
+                if (rle.length < 2) {
                     rle.push(0, 0, 0, 0);
                 } else {
                     rle.push(0, 0, maskWidth - 1, maskHeight - 1);

--- a/cvat-core/src/object-utils.ts
+++ b/cvat-core/src/object-utils.ts
@@ -8,7 +8,7 @@ import { ShapeType, AttributeType, ObjectType } from './enums';
 import { SerializedShape } from './server-response-types';
 import ObjectState, { SerializedData } from './object-state';
 
-export function checkNumberOfPoints(shapeType: ShapeType, points: number[]): void {
+export function checkNumberOfPoints(shapeType: ShapeType, points: ArrayLike<number>): void {
     if (shapeType === ShapeType.RECTANGLE) {
         if (points.length / 2 !== 2) {
             throw new DataError(`Rectangle must have 2 points, but got ${points.length / 2}`);
@@ -38,7 +38,11 @@ export function checkNumberOfPoints(shapeType: ShapeType, points: number[]): voi
             throw new DataError('Mask must not be empty');
         }
 
-        const [left, top, right, bottom] = points.slice(-4);
+        const { length } = points;
+        const left = points[length - 4];
+        const top = points[length - 3];
+        const right = points[length - 2];
+        const bottom = points[length - 1];
         const [width, height] = [right - left, bottom - top];
         if (width < 0 || !Number.isInteger(width) || height < 0 || !Number.isInteger(height)) {
             throw new DataError(`Mask width, height must be positive integers, but got ${width}x${height}`);
@@ -66,7 +70,7 @@ export function findAngleDiff(rightAngle: number, leftAngle: number): number {
     return angleDiff;
 }
 
-export function checkShapeArea(shapeType: ShapeType, points: number[]): boolean {
+export function checkShapeArea(shapeType: ShapeType, points: ArrayLike<number>): boolean {
     const MIN_SHAPE_SIZE = 1;
 
     if (shapeType === ShapeType.POINTS) {
@@ -77,14 +81,18 @@ export function checkShapeArea(shapeType: ShapeType, points: number[]): boolean 
     let height = 0;
 
     if (shapeType === ShapeType.MASK) {
-        const [left, top, right, bottom] = points.slice(-4);
+        const { length } = points;
+        const left = points[length - 4];
+        const top = points[length - 3];
+        const right = points[length - 2];
+        const bottom = points[length - 1];
         [width, height] = [right - left + 1, bottom - top + 1];
     } else if (shapeType === ShapeType.RECTANGLE) {
-        const [xtl, ytl, xbr, ybr] = points;
-        [width, height] = [xbr - xtl, ybr - ytl];
+        width = points[2] - points[0];
+        height = points[3] - points[1];
     } else if (shapeType === ShapeType.ELLIPSE) {
-        const [cx, cy, rightX, topY] = points;
-        [width, height] = [(rightX - cx) * 2, (cy - topY) * 2];
+        width = (points[2] - points[0]) * 2;
+        height = (points[1] - points[3]) * 2;
     } else {
         // polygon, polyline, cuboid, skeleton
         let xmin = Number.MAX_SAFE_INTEGER;
@@ -119,7 +127,7 @@ export function rotatePoint(x: number, y: number, angle: number, cx = 0, cy = 0)
     return [rotX, rotY];
 }
 
-export function computeWrappingBox(points: number[], margin = 0): {
+export function computeWrappingBox(points: ArrayLike<number>, margin = 0): {
     xtl: number;
     ytl: number;
     xbr: number;
@@ -181,25 +189,26 @@ export function validateAttributeValue(value: string, attr: Attribute): boolean 
     return values.includes(value);
 }
 
-// Method computes correct mask wrapping bbox
-// Taking into account image size and removing leading/terminating zeros, minimizing the mask size
-function findMaskBorders(rle: number[], width: number, height: number): {
+/**
+ * Computes the minimal image-space bounding box of non-zero mask pixels.
+ * Pixels outside the image bounds are ignored.
+ * Returns null if the mask has no visible non-zero pixels inside the image.
+ */
+function findMaskBorders(rle: ArrayLike<number>, width: number, height: number): {
     top: number,
     left: number,
     right: number,
     bottom: number,
-} {
-    const [currentLeft, currentTop, currentRight, currentBottom] = rle.slice(-4);
-    const [currentWidth, currentHeight] = [currentRight - currentLeft + 1, currentBottom - currentTop + 1];
-    const empty = {
-        top: 0,
-        left: 0,
-        right: 0,
-        bottom: 0,
-    };
+} | null {
+    const currentLeft = rle[rle.length - 4];
+    const currentTop = rle[rle.length - 3];
+    const currentRight = rle[rle.length - 2];
+    const currentBottom = rle[rle.length - 1];
+    const currentWidth = currentRight - currentLeft + 1;
+    const currentHeight = currentBottom - currentTop + 1;
 
-    if (currentWidth < 0 || currentHeight < 0) {
-        return empty;
+    if (currentWidth <= 0 || currentHeight <= 0) {
+        return null;
     }
 
     let x = 0; // mask-relative
@@ -221,15 +230,13 @@ function findMaskBorders(rle: number[], width: number, height: number): {
             const absY = y + currentTop;
             const absX = x + currentLeft;
 
-            if (!(absX >= width || absY >= height || absX < 0 || absY < 0) && value) {
-                if (value) {
-                    // update coordinates to fit them around non-zero values
-                    atLeastOnePixel = true;
-                    left = Math.min(left, absX);
-                    top = Math.min(top, absY);
-                    right = Math.max(right, absX);
-                    bottom = Math.max(bottom, absY);
-                }
+            if (absX >= 0 && absX < width && absY >= 0 && absY < height && value) {
+                // update coordinates to fit them around non-zero values
+                atLeastOnePixel = true;
+                left = Math.min(left, absX);
+                top = Math.min(top, absY);
+                right = Math.max(right, absX);
+                bottom = Math.max(bottom, absY);
             }
 
             // shift coordinates and count
@@ -246,7 +253,7 @@ function findMaskBorders(rle: number[], width: number, height: number): {
     }
 
     if (!atLeastOnePixel) {
-        return empty;
+        return null;
     }
 
     return {
@@ -254,25 +261,29 @@ function findMaskBorders(rle: number[], width: number, height: number): {
     };
 }
 
-// Method performs cropping of a mask in RLE format
-// It cuts mask parts that are out of the image width/height
-// Also it cuts leading/terminating zeros and minimizes mask wrapping bounding box
-export function cropMask(rle: number[], width: number, height: number): number[] {
-    const [currentLeft, currentTop, currentRight] = rle.slice(-4, -1);
+/**
+ * Crops an RLE mask to the visible image area and minimizes its wrapping box.
+ * Parts of the mask outside image bounds are discarded.
+ * Returns an empty mask RLE if no visible area remains after cropping.
+ */
+export function cropMask(rle: ArrayLike<number>, width: number, height: number): number[] {
+    const currentLeft = rle[rle.length - 4];
+    const currentTop = rle[rle.length - 3];
+    const currentRight = rle[rle.length - 2];
+    const borders = findMaskBorders(rle, width, height);
+    if (!borders) {
+        return [0, 0, 0, 0, 0];
+    }
+
     const {
         top, left, right, bottom,
-    } = findMaskBorders(rle, width, height);
-
-    if (top === bottom || left === right) {
-        return [0, 0, 0, 0];
-    }
+    } = borders;
 
     const maskWidth = currentRight - currentLeft + 1;
     const croppedRLE = [];
 
     let x = 0; // mask-relative
     let y = 0; // mask-relative
-    let value = 0;
     let croppedCount = 0;
     for (let idx = 0; idx < rle.length - 4; idx++) {
         let count = rle[idx];
@@ -281,8 +292,8 @@ export function cropMask(rle: number[], width: number, height: number): number[]
             const absY = y + currentTop;
             const absX = x + currentLeft;
 
-            if (!(absX > right || absY > bottom || absX < left || absY < top)) {
-                // absolute coordinates stay within the image
+            if (absX >= left && absX <= right && absY >= top && absY <= bottom) {
+                // absolute coordinates stay within the cropped bounding box
                 croppedCount++;
             }
 
@@ -294,9 +305,6 @@ export function cropMask(rle: number[], width: number, height: number): number[]
             }
             count--;
         }
-
-        // switch current rle value
-        value = Math.abs(value - 1);
 
         // length - 5 === latest iteration
         // after this iteration we do not need to pop value
@@ -311,7 +319,7 @@ export function cropMask(rle: number[], width: number, height: number): number[]
 
     croppedRLE.push(left, top, right, bottom);
     if (!checkShapeArea(ShapeType.MASK, croppedRLE)) {
-        return [0, 0, 0, 0];
+        return [0, 0, 0, 0, 0];
     }
 
     return croppedRLE;

--- a/cvat-core/src/rle-utils.ts
+++ b/cvat-core/src/rle-utils.ts
@@ -2,25 +2,30 @@
 //
 // SPDX-License-Identifier: MIT
 
+/**
+ * Encodes a flattened binary mask into CVAT RLE.
+ * The encoded sequence always starts with the length of the initial zero run.
+ * Examples:
+ * [0, 0, 0, 1] -> [3, 1]
+ * [1, 1, 0, 0] -> [0, 2, 2]
+ */
 export function mask2Rle(mask: ArrayLike<number>): number[] {
-    const acc: number[] = [];
-    const n = mask.length;
-    if (n === 0) {
+    const { length } = mask;
+    const acc: number[] = [0];
+    if (length === 0) {
         return acc;
     }
 
     // idx = 0
     const first = mask[0];
     if (first > 0) {
-        // 0,0,0,1 => [3,1]
-        // 1,1,0,0 => [0,2,2]
-        acc.push(0, 1);
-    } else {
         acc.push(1);
+    } else {
+        acc[0] = 1;
     }
 
     // idx > 0
-    for (let idx = 1; idx < n; idx++) {
+    for (let idx = 1; idx < length; idx++) {
         const val = mask[idx];
         if (mask[idx - 1] === val) {
             acc[acc.length - 1] += 1;
@@ -32,6 +37,12 @@ export function mask2Rle(mask: ArrayLike<number>): number[] {
     return acc;
 }
 
+/**
+ * Decodes CVAT RLE back into a flattened binary mask of size width * height.
+ * RLE is expected to start with the length of the initial zero run, so:
+ * [3, 1] -> [0, 0, 0, 1]
+ * [0, 2, 2] -> [1, 1, 0, 0]
+ */
 export function rle2Mask(rle: ArrayLike<number>, width: number, height: number): number[] {
     const decoded = Array(width * height).fill(0);
     const { length } = rle;

--- a/cvat-ui/plugins/sam/src/ts/index.tsx
+++ b/cvat-ui/plugins/sam/src/ts/index.tsx
@@ -262,8 +262,12 @@ const samPlugin: SAMPlugin = {
                                         resolve({
                                             shapes: payload.map((item) => {
                                                 const { mask_input: maskInput, bounds } = item;
-                                                const rle = plugin.callbacks.mask2Rle!(item.points);
-                                                rle.push(...(rle.length < 2 ? [0, 0, 0, 0] : bounds));
+                                                let rle = plugin.callbacks.mask2Rle!(item.points);
+                                                if (rle.length < 2) {
+                                                    rle = [0, 0, 0, 0, 0];
+                                                } else {
+                                                    rle.push(...bounds);
+                                                }
 
                                                 plugin.data.lowResMasks.set(key, maskInput);
                                                 return {

--- a/cvat-ui/plugins/sam/src/ts/index.tsx
+++ b/cvat-ui/plugins/sam/src/ts/index.tsx
@@ -263,7 +263,7 @@ const samPlugin: SAMPlugin = {
                                             shapes: payload.map((item) => {
                                                 const { mask_input: maskInput, bounds } = item;
                                                 const rle = plugin.callbacks.mask2Rle!(item.points);
-                                                rle.push(...(rle.length ? bounds : [0, 0, 0, 0]));
+                                                rle.push(...(rle.length < 2 ? [0, 0, 0, 0] : bounds));
 
                                                 plugin.data.lowResMasks.set(key, maskInput);
                                                 return {


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
Before, an empty mask was represented as `[0, 0, 0, 0]`. That encoding is ambiguous and does not fully match the CVAT RLE contract, where the sequence must start with the length of the initial zero run.

For an empty mask, the minimal consistent representation is `[0, 0, 0, 0, 0]`:
- the first `0` is the empty initial zero run in RLE terms;
- the trailing `[0, 0, 0, 0]` is the bbox payload.

This also removes an important ambiguity: bounds `[0, 0, 0, 0]` are themselves valid and can describe a real `1x1` mask located at `(0, 0)`. Using `[0, 0, 0, 0]` as the empty-mask sentinel therefore conflates two different states: “empty mask” and “valid mask with a degenerate bbox at the origin.”

Additionally fixed a little issue, mask with left, top < 0 not cropped on import. 


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
