### PR TITLE
Fix #10402: CVAT Skeleton for annotation not working

### DIFF
--- a/cvat-ui/src/components/labels-editor/skeleton-configurator.tsx
+++ b/cvat-ui/src/components/labels-editor/skeleton-configurator.tsx
@@ -246,8 +246,8 @@ export default class SkeletonConfigurator extends React.PureComponent<Props, Sta
         const dataType = edge.getAttribute('data-type');
         const dataNodeFrom = edge.getAttribute('data-node-from');
         const dataNodeTo = edge.getAttribute('data-node-to');
-        const nodeFrom = svg.querySelector(`[data-node-id="${dataNodeFrom}"]`);
-        const nodeTo = svg.querySelector(`[data-node-id="${dataNodeTo}"]`);
+        const nodeFrom = svg.querySelector(`[data-node-id="${(dataNodeFrom || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`);
+        const nodeTo = svg.querySelector(`[data-node-id="${(dataNodeTo || '').replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"]`);
 
         if (dataType !== 'edge' || !nodeFrom || !nodeTo) {
             return false;


### PR DESCRIPTION
Closes #10402

<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Fixes #10402. When importing a project with skeleton labels whose node IDs contain special characters (e.g., double quotes), `setupEdge` in `skeleton-configurator.tsx` would construct an invalid CSS attribute selector, causing a `SyntaxError: Failed to execute 'querySelector' on 'Element'`.

The issue is in `setupEdge` (line ~246 of `cvat-ui/src/components/labels-editor/skeleton-configurator.tsx`), where `data-node-from` and `data-node-to` attribute values are interpolated directly into the `querySelector` call:

```ts
svg.querySelector(`[data-node-id="${dataNodeFrom}"]`)
```

If `dataNodeFrom` or `dataNodeTo` contains a double quote (e.g., the value `"11"`), the resulting selector `[data-node-id=""11""]` is invalid. The fix escapes backslashes and double quotes in both values before interpolation, and also guards against null attribute values with a fallback to an empty string.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
- Imported a project JSON file containing skeleton labels where node IDs include double-quote characters.
- Opened the label editor to trigger `componentDidMount` → `setupSkeleton` → `setupEdge`.
- Confirmed that the skeleton renders correctly and no `SyntaxError` is thrown in the browser console.
- Verified that skeletons with plain numeric node IDs (the common case) continue to work without regression.

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.

---
*This PR was created with AI assistance (Claude). The changes were reviewed by quality gates and a critic model before submission.*