### PR TITLE
Fix snap to contour with rotation

### DIFF
--- a/changelog.d/20260408_095252_klakhov_fix_snap_to_contour_rotation.md
+++ b/changelog.d/20260408_095252_klakhov_fix_snap_to_contour_rotation.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- Snap to contour is not working with rotated bounding boxes
+  (<https://github.com/cvat-ai/cvat/pull/10457>)

--- a/cvat-canvas/src/typescript/autoborderHandler.ts
+++ b/cvat-canvas/src/typescript/autoborderHandler.ts
@@ -408,6 +408,29 @@ export class AutoborderHandlerImpl implements AutoborderHandler {
                     return null;
                 }
 
+                const svgElement = shape as unknown as SVGGraphicsElement;
+                const ctm = svgElement.getCTM();
+
+                const localCorners = [
+                    { x, y },
+                    { x: x + width, y },
+                    { x: x + width, y: y + height },
+                    { x, y: y + height },
+                ];
+
+                if (ctm && (ctm.a !== 1 || ctm.b !== 0 || ctm.c !== 0 || ctm.d !== 1)) {
+                    const transformedCorners = localCorners.map((corner) => {
+                        const transformedX = ctm.a * corner.x + ctm.c * corner.y + ctm.e;
+                        const transformedY = ctm.b * corner.x + ctm.d * corner.y + ctm.f;
+                        return [transformedX, transformedY];
+                    });
+
+                    return {
+                        color,
+                        points: transformedCorners,
+                    };
+                }
+
                 points = `${x},${y} ${x + width},${y} ${x + width},${y + height} ${x},${y + height}`;
             }
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Snap to contour is bugged when we work with rotated bounding boxes

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
