### PR TITLE
CLI: function create-native: support setting visibility

### DIFF
--- a/changelog.d/20260408_134536_roman_public_agents.md
+++ b/changelog.d/20260408_134536_roman_public_agents.md
@@ -1,0 +1,5 @@
+### Added
+
+- \[CLI\] The `function create-native` command now allows creating functions
+  with public visibility
+  (<https://github.com/cvat-ai/cvat/pull/10459>)

--- a/cvat-cli/src/cvat_cli/_internal/commands_functions.py
+++ b/cvat-cli/src/cvat_cli/_internal/commands_functions.py
@@ -34,6 +34,12 @@ class FunctionCreateNative:
             "name",
             help="a human-readable name for the function",
         )
+        parser.add_argument(
+            "--visibility",
+            choices=("private", "public"),
+            default="private",
+            help="visibility setting for the function",
+        )
 
         configure_function_implementation_arguments(parser)
 
@@ -65,6 +71,7 @@ class FunctionCreateNative:
         client: Client,
         *,
         name: str,
+        visibility: str,
         function_loader: FunctionLoader,
     ) -> None:
         function = function_loader.load()
@@ -72,6 +79,7 @@ class FunctionCreateNative:
         remote_function: dict[str, Any] = {
             "provider": FUNCTION_PROVIDER_NATIVE,
             "name": name,
+            "visibility": visibility,
         }
 
         spec = function.spec


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
This is the client-side implementation of the "public function" functionality that will be available in the Enterprise version.

### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->
Manual testing (will add private tests later).

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- [x] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
