### PR TITLE
e2e_testing flow: fail fast on setup fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,15 +370,17 @@ jobs:
           yarn --immutable
 
           if [[ ${{ matrix.specs }} == canvas3d_* ]]; then
-            npx cypress run \
-              --headed \
-              --browser chrome \
-              --config-file cypress_canvas3d.config.js \
-              --spec 'cypress/e2e/setup/setup_canvas3d.js,cypress/e2e/canvas3d_*/**/*.js,cypress/e2e/remove_users_tasks_projects_organizations.js'
+            npx cypress run --headless browser chrome --spec 'cypress/e2e/setup/setup_canvas3d.js' && \
+              npx cypress run
+                --headed \
+                --browser chrome \
+                --config-file cypress_canvas3d.config.js \
+                --spec 'cypress/e2e/canvas3d_*/**/*.js,cypress/e2e/remove_users_tasks_projects_organizations.js'
           else
+            npx cypress run --headless browser chrome --spec 'cypress/e2e/setup/setup.js,cypress/e2e/setup/setup_project.js' && \
             npx cypress run \
               --browser chrome \
-              --spec 'cypress/e2e/setup/setup.js,cypress/e2e/setup/setup_project.js,cypress/e2e/${{ matrix.specs }}/**/*.js,cypress/e2e/remove_users_tasks_projects_organizations.js'
+              --spec 'cypress/e2e/${{ matrix.specs }}/**/*.js,cypress/e2e/remove_users_tasks_projects_organizations.js'
           fi
           mv coverage/coverage-final.json coverage/${{ matrix.specs }}_coverage.json
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -370,14 +370,14 @@ jobs:
           yarn --immutable
 
           if [[ ${{ matrix.specs }} == canvas3d_* ]]; then
-            npx cypress run --headless browser chrome --spec 'cypress/e2e/setup/setup_canvas3d.js' && \
+            npx cypress run --browser --headless chrome --spec 'cypress/e2e/setup/setup_canvas3d.js' && \
               npx cypress run
                 --headed \
                 --browser chrome \
                 --config-file cypress_canvas3d.config.js \
                 --spec 'cypress/e2e/canvas3d_*/**/*.js,cypress/e2e/remove_users_tasks_projects_organizations.js'
           else
-            npx cypress run --headless browser chrome --spec 'cypress/e2e/setup/setup.js,cypress/e2e/setup/setup_project.js' && \
+            npx cypress run --browser --headless chrome --spec 'cypress/e2e/setup/setup.js,cypress/e2e/setup/setup_project.js' && \
             npx cypress run \
               --browser chrome \
               --spec 'cypress/e2e/${{ matrix.specs }}/**/*.js,cypress/e2e/remove_users_tasks_projects_organizations.js'

--- a/tests/cypress/e2e/setup/setup.js
+++ b/tests/cypress/e2e/setup/setup.js
@@ -4,7 +4,6 @@
 
 /// <reference types="cypress" />
 
-import { Exception } from 'sass';
 import {
     taskName, labelName, attrName,
     textDefaultValue,
@@ -15,7 +14,7 @@ import { defaultTaskSpec } from '../../support/default-specs';
 it('Prepare for testing', () => {
     cy.log('Seeding shared data');
     cy.visit('/auth/login');
-    throw Exception('Something very bad happened during setup');
+    throw Error('Something very bad happened during setup');
     const attributes = [
         { name: attrName, values: textDefaultValue, type: 'text' },
         { ...multiAttrParams },

--- a/tests/cypress/e2e/setup/setup.js
+++ b/tests/cypress/e2e/setup/setup.js
@@ -4,6 +4,7 @@
 
 /// <reference types="cypress" />
 
+import { Exception } from 'sass';
 import {
     taskName, labelName, attrName,
     textDefaultValue,
@@ -14,6 +15,7 @@ import { defaultTaskSpec } from '../../support/default-specs';
 it('Prepare for testing', () => {
     cy.log('Seeding shared data');
     cy.visit('/auth/login');
+    throw Exception('Something very bad happened during setup');
     const attributes = [
         { name: attrName, values: textDefaultValue, type: 'text' },
         { ...multiAttrParams },
@@ -29,7 +31,7 @@ it('Prepare for testing', () => {
         frameFilter: `step=${advancedConfigurationParams.frameStep}`,
     });
     cy.headlessLogin();
-    cy.intercept('POST', '/api/tasks**').as('createTaskRequest');
+    cy.intercept('POST', '/api  /tasks**').as('createTaskRequest');
     cy.headlessCreateTask(taskSpec, dataSpec, extras);
     cy.wait('@createTaskRequest');
 });


### PR DESCRIPTION
### Motivation and context

In this run https://github.com/cvat-ai/cvat/actions/runs/24348121876/job/71095603320?pr=10455
some networking issue happened, whereby UI wasn't fully built before the tests, so the setup specs have failed. This still went on to run e2e tests. Setup files set up shared data that is crucial for testruns
The PR fixes this

### How has this been tested?

Tests pass

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
