### PR TITLE
Add `pytest --keep-data` to keep test data volumes across sessions

### DIFF
--- a/site/content/en/docs/contributing/running-tests.md
+++ b/site/content/en/docs/contributing/running-tests.md
@@ -78,6 +78,11 @@ If you need to rebuild your CVAT images add `--rebuild` option:
 pytest ./tests/python --rebuild
 ```
 
+If you need to persist data volumes across test sessions add `--keep-data` option
+```bash
+pytest ./tests/python --start-services --keep-data
+```
+
 If you want to get a code coverage report, use special option for it:
 ```bash
 COVERAGE_PROCESS_START=.coveragerc pytest ./tests/python --rebuild --cov --cov-report xml

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -429,15 +429,19 @@ def session_start(
 
     if session.config.getoption("--collect-only"):
         if any((stop, start, rebuild, cleanup, dumpdb)):
-            raise Exception("""--collect-only is not compatible with any of the other options:
-                --stop-services --start-services --rebuild --cleanup --dumpdb""")
+            raise Exception(
+                """--collect-only is not compatible with any of the other options:
+                --stop-services --start-services --rebuild --cleanup --dumpdb"""
+            )
         return  # don't need to start the services to collect tests
 
     platform = session.config.getoption("--platform")
 
     if platform == "kube" and any((stop, start, rebuild, cleanup, dumpdb)):
-        raise Exception("""--platform=kube is not compatible with any of the other options
-            --stop-services --start-services --rebuild --cleanup --dumpdb""")
+        raise Exception(
+            """--platform=kube is not compatible with any of the other options
+            --stop-services --start-services --rebuild --cleanup --dumpdb"""
+        )
 
     if platform == "local":
         local_start(
@@ -458,8 +462,16 @@ def session_start(
 
 
 def local_start(
-    start, stop, dumpdb, cleanup, rebuild, keep_data,
-    cvat_root_dir, cvat_db_dir, extra_dc_files, waiting_time
+    start,
+    stop,
+    dumpdb,
+    cleanup,
+    rebuild,
+    keep_data,
+    cvat_root_dir,
+    cvat_db_dir,
+    extra_dc_files,
+    waiting_time,
 ):
     if start and stop:
         raise Exception("--start-services and --stop-services are incompatible")

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -83,6 +83,11 @@ def pytest_addoption(parser):
         action="store_true",
         help="Update data.json without running tests. (default: %(default)s)",
     )
+    group._addoption(
+        "--keep-data",
+        action="store_true",
+        help="Do not reset volumes and database. (default: %(default)s)",
+    )
 
     group._addoption(
         "--platform",
@@ -418,6 +423,7 @@ def session_start(
     stop = session.config.getoption("--stop-services")
     start = session.config.getoption("--start-services")
     rebuild = session.config.getoption("--rebuild")
+    keep_data = session.config.getoption("--keep-data")
     cleanup = session.config.getoption("--cleanup")
     dumpdb = session.config.getoption("--dumpdb")
 
@@ -440,6 +446,7 @@ def session_start(
             dumpdb,
             cleanup,
             rebuild,
+            keep_data,
             cvat_root_dir,
             cvat_db_dir,
             extra_dc_files,
@@ -451,7 +458,8 @@ def session_start(
 
 
 def local_start(
-    start, stop, dumpdb, cleanup, rebuild, cvat_root_dir, cvat_db_dir, extra_dc_files, waiting_time
+    start, stop, dumpdb, cleanup, rebuild, keep_data,
+    cvat_root_dir, cvat_db_dir, extra_dc_files, waiting_time
 ):
     if start and stop:
         raise Exception("--start-services and --stop-services are incompatible")
@@ -480,18 +488,19 @@ def local_start(
 
     start_services(dc_files, rebuild, cvat_root_dir)
 
-    docker_restore_data_volumes()
-    docker_cp(cvat_db_dir / "restore.sql", f"{PREFIX}_cvat_db_1:/tmp/restore.sql")
-    docker_cp(cvat_db_dir / "data.json", f"{PREFIX}_cvat_server_1:/tmp/data.json")
+    if not keep_data:
+        docker_restore_data_volumes()
+        docker_cp(cvat_db_dir / "restore.sql", f"{PREFIX}_cvat_db_1:/tmp/restore.sql")
+        docker_cp(cvat_db_dir / "data.json", f"{PREFIX}_cvat_server_1:/tmp/data.json")
 
-    wait_for_services(waiting_time)
+        wait_for_services(waiting_time)
 
-    docker_exec_cvat(
-        ["sh", "-c", "./manage.py flush --no-input && ./manage.py loaddata /tmp/data.json"]
-    )
-    docker_exec(
-        Container.DB, "psql -U root -d postgres -v from=cvat -v to=test_db -f /tmp/restore.sql"
-    )
+        docker_exec_cvat(
+            ["sh", "-c", "./manage.py flush --no-input && ./manage.py loaddata /tmp/data.json"]
+        )
+        docker_exec(
+            Container.DB, "psql -U root -d postgres -v from=cvat -v to=test_db -f /tmp/restore.sql"
+        )
 
     if start:
         pytest.exit("All necessary containers have been created and started.", returncode=0)

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -454,7 +454,7 @@ def session_start(
         )
 
     elif platform == "kube":
-        kube_start(cvat_db_dir)
+        kube_start(cvat_db_dir, keep_data)
 
 
 def local_start(
@@ -514,7 +514,7 @@ def local_start(
         pytest.exit("All necessary containers have been created and started.", returncode=0)
 
 
-def kube_start(cvat_db_dir):
+def kube_start(cvat_db_dir, keep_data):
     kube_restore_data_volumes()
     server_pod_name = _kube_get_server_pod_name()
     db_pod_name = _kube_get_db_pod_name()
@@ -523,17 +523,18 @@ def kube_start(cvat_db_dir):
 
     wait_for_services()
 
-    kube_exec_cvat(
-        ["sh", "-c", "./manage.py flush --no-input && ./manage.py loaddata /tmp/data.json"]
-    )
+    if not keep_data:
+        kube_exec_cvat(
+            ["sh", "-c", "./manage.py flush --no-input && ./manage.py loaddata /tmp/data.json"]
+        )
 
-    kube_exec_cvat_db(
-        [
-            "/bin/sh",
-            "-c",
-            "PGPASSWORD=cvat_postgresql_postgres psql -U postgres -d postgres -v from=cvat -v to=test_db -f /tmp/restore.sql",
-        ]
-    )
+        kube_exec_cvat_db(
+            [
+                "/bin/sh",
+                "-c",
+                "PGPASSWORD=cvat_postgresql_postgres psql -U postgres -d postgres -v from=cvat -v to=test_db -f /tmp/restore.sql",
+            ]
+        )
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -429,19 +429,15 @@ def session_start(
 
     if session.config.getoption("--collect-only"):
         if any((stop, start, rebuild, cleanup, dumpdb)):
-            raise Exception(
-                """--collect-only is not compatible with any of the other options:
-                --stop-services --start-services --rebuild --cleanup --dumpdb"""
-            )
+            raise Exception("""--collect-only is not compatible with any of the other options:
+                --stop-services --start-services --rebuild --cleanup --dumpdb""")
         return  # don't need to start the services to collect tests
 
     platform = session.config.getoption("--platform")
 
     if platform == "kube" and any((stop, start, rebuild, cleanup, dumpdb)):
-        raise Exception(
-            """--platform=kube is not compatible with any of the other options
-            --stop-services --start-services --rebuild --cleanup --dumpdb"""
-        )
+        raise Exception("""--platform=kube is not compatible with any of the other options
+            --stop-services --start-services --rebuild --cleanup --dumpdb""")
 
     if platform == "local":
         local_start(

--- a/tests/python/shared/fixtures/init.py
+++ b/tests/python/shared/fixtures/init.py
@@ -515,6 +515,10 @@ def local_start(
 
 
 def kube_start(cvat_db_dir, keep_data):
+    if keep_data:
+        wait_for_services()
+        return
+
     kube_restore_data_volumes()
     server_pod_name = _kube_get_server_pod_name()
     db_pod_name = _kube_get_db_pod_name()
@@ -523,18 +527,17 @@ def kube_start(cvat_db_dir, keep_data):
 
     wait_for_services()
 
-    if not keep_data:
-        kube_exec_cvat(
-            ["sh", "-c", "./manage.py flush --no-input && ./manage.py loaddata /tmp/data.json"]
-        )
+    kube_exec_cvat(
+        ["sh", "-c", "./manage.py flush --no-input && ./manage.py loaddata /tmp/data.json"]
+    )
 
-        kube_exec_cvat_db(
-            [
-                "/bin/sh",
-                "-c",
-                "PGPASSWORD=cvat_postgresql_postgres psql -U postgres -d postgres -v from=cvat -v to=test_db -f /tmp/restore.sql",
-            ]
-        )
+    kube_exec_cvat_db(
+        [
+            "/bin/sh",
+            "-c",
+            "PGPASSWORD=cvat_postgresql_postgres psql -U postgres -d postgres -v from=cvat -v to=test_db -f /tmp/restore.sql",
+        ]
+    )
 
 
 def pytest_sessionstart(session: pytest.Session) -> None:


### PR DESCRIPTION
### Motivation and context

At times, it is useful to use rest api tests for troubleshooting, i.e. reproducing issues manually or automatically. For this activity, data persistence can be useful. This PR adds `pytest --keep-data` option to conditionally restore docker volumes and postgres data


### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I submit my changes into the `develop` branch
- [ ] I have created a changelog fragment <!-- see top comment in CHANGELOG.md -->
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))

### License

- [ ] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
