### PR TITLE
Remove redundant "labels" parameters in tests

### DIFF
--- a/tests/python/cli/test_cli_misc.py
+++ b/tests/python/cli/test_cli_misc.py
@@ -2,7 +2,6 @@
 #
 # SPDX-License-Identifier: MIT
 
-import json
 import os
 from datetime import timedelta
 from io import BytesIO
@@ -65,7 +64,6 @@ class TestCliMisc(TestCliBase):
             "personal_task",
             ResourceType.LOCAL.name,
             *map(os.fspath, files),
-            "--labels=" + json.dumps([{"name": "person"}]),
             "--completion_verification_period=0.01",
             organization="",
         )
@@ -78,7 +76,6 @@ class TestCliMisc(TestCliBase):
             "org_task",
             ResourceType.LOCAL.name,
             *map(os.fspath, files),
-            "--labels=" + json.dumps([{"name": "person"}]),
             "--completion_verification_period=0.01",
             organization=org,
         )

--- a/tests/python/rest_api/test_jobs.py
+++ b/tests/python/rest_api/test_jobs.py
@@ -837,7 +837,6 @@ class TestGetGtJobData:
             admin_user,
             spec={
                 "name": "test complex frame setup",
-                "labels": [{"name": "cat"}],
             },
             data={
                 "image_quality": 75,

--- a/tests/python/rest_api/test_requests.py
+++ b/tests/python/rest_api/test_requests.py
@@ -70,7 +70,7 @@ class TestRequestsListFilters(CollectionSimpleFilterTestBase):
             task_ids = [
                 create_task(
                     self.user,
-                    spec={"name": f"Test task {idx + 1}", "labels": [{"name": "car"}]},
+                    spec={"name": f"Test task {idx + 1}"},
                     data={
                         "image_quality": 75,
                         "client_files": generate_image_files(2),
@@ -555,7 +555,7 @@ class TestGetRequests:
     def test_can_retrieve_task_creation_requests_using_legacy_ids(self, admin_user: str):
         task_id = create_task(
             admin_user,
-            spec={"name": "Test task", "labels": [{"name": "car"}]},
+            spec={"name": "Test task"},
             data={
                 "image_quality": 75,
                 "client_files": generate_image_files(2),

--- a/tests/python/rest_api/test_resource_import_export.py
+++ b/tests/python/rest_api/test_resource_import_export.py
@@ -150,11 +150,6 @@ class TestExportResourceToS3(_S3ResourceTest):
 
         task_spec = {
             "name": f"Task with files from foreign cloud storage {storage_id}",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
         data_spec = {
             "image_quality": 75,
@@ -311,11 +306,6 @@ class TestImportResourceFromS3(_S3ResourceTest):
 
         task_spec = {
             "name": f"Task with files from foreign cloud storage {storage_id}",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
         data_spec = {
             "image_quality": 75,

--- a/tests/python/rest_api/test_task_data.py
+++ b/tests/python/rest_api/test_task_data.py
@@ -70,21 +70,6 @@ class TestPostTaskData:
     def test_can_create_task_with_defined_start_and_stop_frames(self):
         task_spec = {
             "name": f"test {self._USERNAME} to create a task with defined start and stop frames",
-            "labels": [
-                {
-                    "name": "car",
-                    "color": "#ff00ff",
-                    "attributes": [
-                        {
-                            "name": "a",
-                            "mutable": True,
-                            "input_type": "number",
-                            "default_value": "5",
-                            "values": ["4", "5", "6"],
-                        }
-                    ],
-                }
-            ],
         }
 
         task_data = {
@@ -104,7 +89,6 @@ class TestPostTaskData:
     def test_default_overlap_for_small_segment_size(self):
         task_spec = {
             "name": f"test {self._USERNAME} with default overlap and small segment_size",
-            "labels": [{"name": "car"}],
             "segment_size": 5,
         }
 
@@ -142,7 +126,6 @@ class TestPostTaskData:
     def test_task_segmentation(self, size, expected_segments):
         task_spec = {
             "name": f"test {self._USERNAME} to check segmentation into jobs",
-            "labels": [{"name": "car"}],
             "segment_size": 3,
             "overlap": 1,
         }
@@ -166,11 +149,6 @@ class TestPostTaskData:
     def test_can_create_task_with_exif_rotated_images(self):
         task_spec = {
             "name": f"test {self._USERNAME} to create a task with exif rotated images",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         image_files = ["images/exif_rotated/left.jpg", "images/exif_rotated/right.jpg"]
@@ -210,11 +188,6 @@ class TestPostTaskData:
 
         task_spec = {
             "name": f"test {self._USERNAME} to create a task with big images",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         # We need a big file to reproduce the problem
@@ -251,11 +224,6 @@ class TestPostTaskData:
     def test_can_create_task_with_exif_rotated_tif_image(self):
         task_spec = {
             "name": f"test {self._USERNAME} to create a task with exif rotated tif image",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         image_files = ["images/exif_rotated/tif_left.tif"]
@@ -289,11 +257,6 @@ class TestPostTaskData:
     def test_can_create_task_with_sorting_method_natural(self):
         task_spec = {
             "name": f"test {self._USERNAME} to create a task with a custom sorting method",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         image_files = generate_image_files(15)
@@ -317,11 +280,6 @@ class TestPostTaskData:
     def test_can_create_task_with_video_without_keyframes(self):
         task_spec = {
             "name": f"test {self._USERNAME} to create a task with a video without keyframes",
-            "labels": [
-                {
-                    "name": "label1",
-                }
-            ],
         }
 
         task_data = {
@@ -339,11 +297,6 @@ class TestPostTaskData:
     def test_can_create_task_with_sorting_method_predefined(self, data_source):
         task_spec = {
             "name": f"test {self._USERNAME} to create a task with a custom sorting method",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         if data_source == "client_files":
@@ -801,11 +754,6 @@ class TestPostTaskData:
 
         task_spec = {
             "name": f"Task with files from foreign cloud storage {storage_id}",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         data_spec = {
@@ -919,11 +867,6 @@ class TestPostTaskData:
 
         task_spec = {
             "name": f"Task with files from cloud storage {cloud_storage_id}",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         data_spec = {
@@ -1072,7 +1015,6 @@ class TestPostTaskData:
     def test_can_specify_file_job_mapping(self):
         task_spec = {
             "name": f"test file-job mapping",
-            "labels": [{"name": "car"}],
         }
 
         files = generate_image_files(7)
@@ -1247,7 +1189,6 @@ class TestPostTaskData:
 
         task_params = {
             "name": fxt_test_name,
-            "labels": [{"name": "a"}],
             "segment_size": base_segment_size,
         }
 
@@ -1344,7 +1285,6 @@ class TestPostTaskData:
 
         task_params = {
             "name": fxt_test_name,
-            "labels": [{"name": "a"}],
             "segment_size": base_segment_size,
         }
 
@@ -1443,7 +1383,6 @@ class TestPostTaskData:
 
         task_params = {
             "name": request.node.name,
-            "labels": [{"name": "a"}],
             "segment_size": segment_size,
         }
 
@@ -1564,7 +1503,6 @@ class TestPostTaskData:
 
         task_params = {
             "name": request.node.name,
-            "labels": [{"name": "a"}],
             "segment_size": segment_size,
         }
 
@@ -1721,7 +1659,6 @@ class TestPostTaskData:
 
         task_params = {
             "name": request.node.name,
-            "labels": [{"name": "a"}],
             "segment_size": segment_size,
             "consensus_replicas": replication,
         }

--- a/tests/python/rest_api/test_tasks.py
+++ b/tests/python/rest_api/test_tasks.py
@@ -510,7 +510,6 @@ class TestPostTasks:
     def test_can_create_with_assignee(self, admin_user, users_by_name, assignee):
         task_spec = {
             "name": "test task creation with assignee",
-            "labels": [{"name": "car"}],
             "assignee_id": users_by_name[assignee]["id"] if assignee else None,
         }
 
@@ -1336,7 +1335,6 @@ class TestWorkWithTask:
 
         task_spec = {
             "name": f"Task with mythical file from cloud storage {cloud_storage_id}",
-            "labels": [{"name": "car"}],
         }
 
         data_spec = {
@@ -2817,11 +2815,6 @@ class TestPatchTask:
 
         task_spec = {
             "name": f"Task with files from foreign cloud storage {storage_id}",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
         data_spec = {
             "image_quality": 75,

--- a/tests/python/sdk/test_client.py
+++ b/tests/python/sdk/test_client.py
@@ -288,16 +288,12 @@ def test_organization_filtering(regular_lonely_user: str, fxt_image_file):
         # create a project and task in sandbox
         client.organization_slug = None
         client.projects.create(models.ProjectWriteRequest(name="personal_project"))
-        client.tasks.create_from_data(
-            spec={"name": "personal_task", "labels": [{"name": "a"}]}, resources=[fxt_image_file]
-        )
+        client.tasks.create_from_data(spec={"name": "personal_task"}, resources=[fxt_image_file])
 
         # create a project and task in the organization
         client.organization_slug = org.slug
         client.projects.create(models.ProjectWriteRequest(name="org_project"))
-        client.tasks.create_from_data(
-            spec={"name": "org_task", "labels": [{"name": "a"}]}, resources=[fxt_image_file]
-        )
+        client.tasks.create_from_data(spec={"name": "org_task"}, resources=[fxt_image_file])
 
         # return only non-org objects if org parameter is empty
         client.organization_slug = ""

--- a/tests/python/sdk/test_issues_comments.py
+++ b/tests/python/sdk/test_issues_comments.py
@@ -36,10 +36,7 @@ class TestIssuesUsecases:
     @pytest.fixture
     def fxt_new_task(self, fxt_image_file: Path):
         task = self.client.tasks.create_from_data(
-            spec={
-                "name": "test_task",
-                "labels": [{"name": "car"}, {"name": "person"}],
-            },
+            spec={"name": "test_task"},
             resource_type=ResourceType.LOCAL,
             resources=[fxt_image_file],
             data_params={"image_quality": 80},
@@ -157,10 +154,7 @@ class TestCommentsUsecases:
     @pytest.fixture
     def fxt_new_task(self, fxt_image_file: Path):
         task = self.client.tasks.create_from_data(
-            spec={
-                "name": "test_task",
-                "labels": [{"name": "car"}, {"name": "person"}],
-            },
+            spec={"name": "test_task"},
             resource_type=ResourceType.LOCAL,
             resources=[fxt_image_file],
             data_params={"image_quality": 80},

--- a/tests/python/sdk/test_tasks.py
+++ b/tests/python/sdk/test_tasks.py
@@ -58,12 +58,7 @@ class TestTaskUsecases(TestDatasetExport):
 
     @pytest.fixture
     def fxt_new_task_without_data(self):
-        task = self.client.tasks.create(
-            spec={
-                "name": "test_task",
-                "labels": [{"name": "car"}, {"name": "person"}],
-            },
-        )
+        task = self.client.tasks.create(spec={"name": "test_task"})
 
         return task
 
@@ -91,21 +86,6 @@ class TestTaskUsecases(TestDatasetExport):
 
         task_spec = {
             "name": f"test {self.user} to create a task with local data",
-            "labels": [
-                {
-                    "name": "car",
-                    "color": "#ff00ff",
-                    "attributes": [
-                        {
-                            "name": "a",
-                            "mutable": True,
-                            "input_type": "number",
-                            "default_value": "5",
-                            "values": ["4", "5", "6"],
-                        }
-                    ],
-                }
-            ],
         }
 
         data_params = {
@@ -152,10 +132,7 @@ class TestTaskUsecases(TestDatasetExport):
 
     def test_can_create_task_with_remote_data(self):
         task = self.client.tasks.create_from_data(
-            spec={
-                "name": "test_task",
-                "labels": [{"name": "car"}, {"name": "person"}],
-            },
+            spec={"name": "test_task"},
             resource_type=ResourceType.SHARE,
             resources=["images/image_1.jpg", "images/image_2.jpg"],
             # make sure string fields are transferred correctly;
@@ -173,11 +150,6 @@ class TestTaskUsecases(TestDatasetExport):
 
         task_spec = {
             "name": f"test {self.user} to create a task with no data",
-            "labels": [
-                {
-                    "name": "car",
-                }
-            ],
         }
 
         with pytest.raises(BackgroundRequestException) as capture:
@@ -198,7 +170,6 @@ class TestTaskUsecases(TestDatasetExport):
         task = self.client.tasks.create(
             {
                 "name": f"test task",
-                "labels": [{"name": "car"}],
             }
         )
 


### PR DESCRIPTION
<!-- Raise an issue to propose your change (https://github.com/cvat-ai/cvat/issues).
It helps to avoid duplication of efforts from multiple independent contributors.
Discuss your ideas with maintainers to be sure that changes will be approved and merged.
Read the [Contribution guide](https://docs.cvat.ai/docs/contributing/). -->

<!-- Provide a general summary of your changes in the Title above -->

### Motivation and context
<!-- Why is this change required? What problem does it solve? If it fixes an open
issue, please link to the issue here. Describe your changes in detail, add
screenshots. -->
Task labels used to be mandatory, but now (see #9822) they are not. This means that a lot of these parameters are no longer necessary and just create clutter.


### How has this been tested?
<!-- Please describe in detail how you tested your changes.
Include details of your testing environment, and the tests you ran to
see how your change affects other areas of the code, etc. -->

### Checklist
<!-- Go over all the following points, and put an `x` in all the boxes that apply.
If an item isn't applicable for some reason, then ~~explicitly strikethrough~~ the whole
line. If you don't do that, GitHub will show incorrect progress for the pull request.
If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I submit my changes into the `develop` branch
- ~~[ ] I have created a changelog fragment~~ <!-- see top comment in CHANGELOG.md -->
- ~~[ ] I have updated the documentation accordingly~~
- ~~[ ] I have added tests to cover my changes~~
- ~~[ ] I have linked related issues (see [GitHub docs](
  https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword))~~

### License

- [x] I submit _my code changes_ under the same [MIT License](
  https://github.com/cvat-ai/cvat/blob/develop/LICENSE) that covers the project.
  Feel free to contact the maintainers if that's a concern.
